### PR TITLE
fix: prevent preempted writer from skipping segment ids

### DIFF
--- a/common/werr/errors.go
+++ b/common/werr/errors.go
@@ -164,6 +164,7 @@ var (
 	ErrMetadataRevisionInvalid        = newWoodpeckerError("metadata revision is invalid or outdated", 3011, false)
 	ErrMetadataKeyNotExists           = newWoodpeckerError("metadata key not exists", 3012, false)
 	ErrMetadataCreateLogAlreadyExists = newWoodpeckerError("log already exists in metadata", 3013, false)
+	ErrMetadataSegmentAlreadyExists   = newWoodpeckerError("segment already exists in metadata", 3014, false)
 
 	// ---------------------------------------------
 	// Service Layer Errors

--- a/meta/metadata_etcd.go
+++ b/meta/metadata_etcd.go
@@ -705,7 +705,7 @@ func (e *metadataProviderEtcd) StoreSegmentMetadata(ctx context.Context, logName
 		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_segment_metadata", "error").Inc()
 		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("segment metadata already exists", zap.String("logName", logName), zap.Int64("segmentId", segmentMeta.Metadata.GetSegNo()))
-		return werr.ErrMetadataCreateSegment.WithCauseErrMsg(
+		return werr.ErrMetadataSegmentAlreadyExists.WithCauseErrMsg(
 			fmt.Sprintf("segment metadata already exists for logName:%s segmentId:%d", logName, segmentMeta.Metadata.GetSegNo()))
 	}
 	// update revision

--- a/meta/metadata_etcd_test.go
+++ b/meta/metadata_etcd_test.go
@@ -1676,6 +1676,7 @@ func testStoreSegmentMetaAlreadyExists(t *testing.T) {
 	seg2 := &SegmentMeta{Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Active}}
 	err = provider.StoreSegmentMetadata(context.Background(), logName, int64(1), seg2)
 	assert.Error(t, err)
+	assert.True(t, werr.ErrMetadataSegmentAlreadyExists.Is(err), "expected ErrMetadataSegmentAlreadyExists, got: %v", err)
 	assert.Contains(t, err.Error(), "segment metadata already exists")
 }
 

--- a/woodpecker/log/log_handle.go
+++ b/woodpecker/log/log_handle.go
@@ -565,7 +565,7 @@ func (l *logHandleImpl) createAndCacheWritableSegmentHandleWithID(ctx context.Co
 		return nil, err
 	}
 	if err := l.advanceLastSegmentId(newSegMeta.Metadata.SegNo); err != nil {
-		return nil, err
+		return nil, l.invalidateWriterAndReturnLockLost(ctx, writerInvalidationNotifier, "last segment id changed concurrently", err)
 	}
 	newSegHandle := segment.NewSegmentHandle(ctx, l.Id, l.Name, newSegMeta, l.Metadata, l.ClientPool, l.cfg, true)
 	newSegHandle.SetWriterInvalidationNotifier(ctx, writerInvalidationNotifier)
@@ -633,6 +633,7 @@ func (l *logHandleImpl) advanceLastSegmentIdFromSegments(segments map[int64]*met
 	return l.advanceLastSegmentId(maxSegmentID)
 }
 
+// advanceLastSegmentId advances the cached last segment id monotonically.
 func (l *logHandleImpl) advanceLastSegmentId(segmentID int64) error {
 	current := l.LastSegmentId.Load()
 	if segmentID <= current {

--- a/woodpecker/log/log_handle.go
+++ b/woodpecker/log/log_handle.go
@@ -279,6 +279,13 @@ func (l *logHandleImpl) fenceAllActiveSegments(ctx context.Context) error {
 			zap.Error(err))
 		return err
 	}
+	if err := l.advanceLastSegmentIdFromSegments(segments); err != nil {
+		logger.Ctx(ctx).Warn("failed to advance last segment id from metadata",
+			zap.String("logName", l.Name),
+			zap.Int64("logId", l.Id),
+			zap.Error(err))
+		return err
+	}
 
 	// Find all active segments
 	var activeSegmentIds []int64
@@ -420,6 +427,14 @@ func (l *logHandleImpl) GetOrCreateWritableSegmentHandle(ctx context.Context, wr
 	if !writableExists {
 		handle, err := l.createAndCacheWritableSegmentHandle(ctx, writerInvalidationNotifier)
 		if err != nil {
+			if werr.ErrMetadataSegmentAlreadyExists.Is(err) {
+				logger.Ctx(ctx).Warn("aborting segment creation: log has been taken over by another writer",
+					zap.String("logName", l.Name),
+					zap.Int64("logId", l.Id),
+					zap.Int64("expectedSegmentId", l.LastSegmentId.Load()+1),
+					zap.Error(err))
+				return nil, l.invalidateWriterAndReturnLockLost(ctx, writerInvalidationNotifier, "segment creation conflict", err)
+			}
 			logger.Ctx(ctx).Warn("get or create writable segment handle failed", zap.String("logName", l.Name), zap.Int64("logId", l.Id), zap.Error(err))
 			return nil, err
 		}
@@ -448,13 +463,23 @@ func (l *logHandleImpl) GetOrCreateWritableSegmentHandle(ctx context.Context, wr
 				zap.Int64("logId", l.GetId()),
 				zap.Int64("segmentId", writeableSegmentHandle.GetId(ctx)),
 				zap.Error(rollErr))
-			return nil, werr.ErrLogWriterLockLost.WithCauseErr(rollErr)
+			return nil, l.invalidateWriterAndReturnLockLost(ctx, writerInvalidationNotifier, "segment completion metadata revision invalid", rollErr)
 		}
 
 		// 2. create new segMeta(active)
-		logger.Ctx(ctx).Debug("create new segment handle", zap.String("logName", l.Name))
-		newSegmentHandle, err := l.createAndCacheWritableSegmentHandle(ctx, writerInvalidationNotifier)
+		nextSegmentId := writeableSegmentHandle.GetId(ctx) + 1
+		logger.Ctx(ctx).Debug("create new segment handle", zap.String("logName", l.Name), zap.Int64("segmentId", nextSegmentId))
+		newSegmentHandle, err := l.createAndCacheWritableSegmentHandleWithID(ctx, nextSegmentId, writerInvalidationNotifier)
 		if err != nil {
+			if werr.ErrMetadataSegmentAlreadyExists.Is(err) {
+				logger.Ctx(ctx).Warn("aborting segment rolling: next segment has been claimed by another writer",
+					zap.String("logName", l.Name),
+					zap.Int64("logId", l.GetId()),
+					zap.Int64("oldSegmentId", writeableSegmentHandle.GetId(ctx)),
+					zap.Int64("expectedSegmentId", nextSegmentId),
+					zap.Error(err))
+				return nil, l.invalidateWriterAndReturnLockLost(ctx, writerInvalidationNotifier, "next segment creation conflict", err)
+			}
 			return nil, err
 		}
 
@@ -531,8 +556,15 @@ func (l *logHandleImpl) GetExistsReadonlySegmentHandle(ctx context.Context, segm
 }
 
 func (l *logHandleImpl) createAndCacheWritableSegmentHandle(ctx context.Context, writerInvalidationNotifier func(ctx context.Context, reason string)) (segment.SegmentHandle, error) {
-	newSegMeta, err := l.createNewSegmentMeta(ctx)
+	return l.createAndCacheWritableSegmentHandleWithID(ctx, l.LastSegmentId.Load()+1, writerInvalidationNotifier)
+}
+
+func (l *logHandleImpl) createAndCacheWritableSegmentHandleWithID(ctx context.Context, segmentID int64, writerInvalidationNotifier func(ctx context.Context, reason string)) (segment.SegmentHandle, error) {
+	newSegMeta, err := l.createNewSegmentMetaWithID(ctx, segmentID)
 	if err != nil {
+		return nil, err
+	}
+	if err := l.advanceLastSegmentId(newSegMeta.Metadata.SegNo); err != nil {
 		return nil, err
 	}
 	newSegHandle := segment.NewSegmentHandle(ctx, l.Id, l.Name, newSegMeta, l.Metadata, l.ClientPool, l.cfg, true)
@@ -557,17 +589,16 @@ func (l *logHandleImpl) shouldRollingCloseAndCreateWritableSegmentHandle(ctx con
 	return l.rollingPolicy.ShouldRollover(ctx, size, blocksCount, last)
 }
 
-func (l *logHandleImpl) createNewSegmentMeta(ctx context.Context) (*meta.SegmentMeta, error) {
+func (l *logHandleImpl) createNewSegmentMetaWithID(ctx context.Context, segmentNo int64) (*meta.SegmentMeta, error) {
 	quorumInfo, selectQuorumErr := l.selectQuorumFunc(ctx)
 	if selectQuorumErr != nil {
 		return nil, selectQuorumErr
 	}
+	return l.storeNewSegmentMeta(ctx, segmentNo, quorumInfo)
+}
 
+func (l *logHandleImpl) storeNewSegmentMeta(ctx context.Context, segmentNo int64, quorumInfo *proto.QuorumInfo) (*meta.SegmentMeta, error) {
 	// construct new segment metadata
-	segmentNo, err := l.GetNextSegmentId(ctx)
-	if err != nil {
-		return nil, err
-	}
 	newSegmentMetadata := &proto.SegmentMetadata{
 		SegNo:       segmentNo,
 		CreateTime:  time.Now().UnixMilli(),
@@ -581,12 +612,45 @@ func (l *logHandleImpl) createNewSegmentMeta(ctx context.Context) (*meta.Segment
 		Revision: 0,
 	}
 	// create segment metadata
-	err = l.Metadata.StoreSegmentMetadata(ctx, l.Name, l.Id, segMeta)
+	err := l.Metadata.StoreSegmentMetadata(ctx, l.Name, l.Id, segMeta)
 	if err != nil {
 		return nil, err
 	}
 
 	return segMeta, nil
+}
+
+func (l *logHandleImpl) advanceLastSegmentIdFromSegments(segments map[int64]*meta.SegmentMeta) error {
+	maxSegmentID := int64(-1)
+	for _, segmentMeta := range segments {
+		if segmentMeta == nil || segmentMeta.Metadata == nil {
+			continue
+		}
+		if maxSegmentID < segmentMeta.Metadata.SegNo {
+			maxSegmentID = segmentMeta.Metadata.SegNo
+		}
+	}
+	return l.advanceLastSegmentId(maxSegmentID)
+}
+
+func (l *logHandleImpl) advanceLastSegmentId(segmentID int64) error {
+	current := l.LastSegmentId.Load()
+	if segmentID <= current {
+		return nil
+	}
+	if !l.LastSegmentId.CompareAndSwap(current, segmentID) {
+		return werr.ErrInternalError.WithCauseErrMsg(
+			fmt.Sprintf("last segment id changed concurrently for logName:%s logId:%d expected:%d target:%d actual:%d",
+				l.Name, l.Id, current, segmentID, l.LastSegmentId.Load()))
+	}
+	return nil
+}
+
+func (l *logHandleImpl) invalidateWriterAndReturnLockLost(ctx context.Context, writerInvalidationNotifier func(ctx context.Context, reason string), reason string, cause error) error {
+	if writerInvalidationNotifier != nil {
+		writerInvalidationNotifier(ctx, reason)
+	}
+	return werr.ErrLogWriterLockLost.WithCauseErr(cause)
 }
 
 // TODO To be optimized, reduce meta access, maybe use a param to indicate whether to refresh lastSegmentId, most of the time, the lastSegmentId is not changed

--- a/woodpecker/log/log_handle_test.go
+++ b/woodpecker/log/log_handle_test.go
@@ -206,9 +206,6 @@ func TestCreateAndCacheNewSegmentHandle_SetsAccessTime(t *testing.T) {
 	logHandle, mockMeta := createMockLogHandle(t)
 	ctx := context.Background()
 
-	// Mock GetNextSegmentId
-	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(map[int64]*meta.SegmentMeta{}, nil)
-
 	// Mock StoreSegmentMetadata
 	mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.Anything).Return(nil)
 
@@ -235,7 +232,6 @@ func TestGetOrCreateWritableSegmentHandle_ErrorHandling(t *testing.T) {
 	logHandle.WritableSegmentId = -1 // No writable segment exists
 
 	// Mock metadata operations for createNewSegmentMeta that will fail
-	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(map[int64]*meta.SegmentMeta{}, nil)
 	mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.Anything).Return(errors.New("storage error"))
 
 	// Call GetOrCreateWritableSegmentHandle and expect error
@@ -262,6 +258,7 @@ func TestFenceAllActiveSegments_NoActiveSegments(t *testing.T) {
 
 	err := logHandle.fenceAllActiveSegments(ctx)
 	assert.NoError(t, err)
+	assert.Equal(t, int64(2), logHandle.LastSegmentId.Load())
 
 	mockMeta.AssertExpectations(t)
 }
@@ -295,6 +292,7 @@ func TestFenceAllActiveSegments_SuccessfulFencing(t *testing.T) {
 
 	err := logHandle.fenceAllActiveSegments(ctx)
 	assert.NoError(t, err)
+	assert.Equal(t, int64(3), logHandle.LastSegmentId.Load())
 
 	// Verify all expectations
 	mockSegment1.AssertExpectations(t)
@@ -375,9 +373,6 @@ func TestLogHandle_GetOrCreateWritableSegmentHandle_SizeTriggeredRolling(t *test
 	mockOldSegment.EXPECT().SetRollingReady(mock.Anything).Return(nil).Once()
 
 	// Mock metadata operations for creating new segment
-	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(map[int64]*meta.SegmentMeta{
-		1: {Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Active}, Revision: 1},
-	}, nil)
 	mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.MatchedBy(func(meta *meta.SegmentMeta) bool {
 		return meta.Metadata.SegNo == 2 && meta.Metadata.State == proto.SegmentState_Active
 	})).Return(nil)
@@ -418,9 +413,6 @@ func TestLogHandle_GetOrCreateWritableSegmentHandle_TimeTriggeredRolling(t *test
 	mockOldSegment.EXPECT().SetRollingReady(mock.Anything).Return(nil).Once()
 
 	// Mock metadata operations for creating new segment
-	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(map[int64]*meta.SegmentMeta{
-		1: {Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Active}, Revision: 1},
-	}, nil)
 	mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.MatchedBy(func(meta *meta.SegmentMeta) bool {
 		return meta.Metadata.SegNo == 2 && meta.Metadata.State == proto.SegmentState_Active
 	})).Return(nil)
@@ -459,9 +451,6 @@ func TestLogHandle_GetOrCreateWritableSegmentHandle_ForceRolling(t *testing.T) {
 	mockOldSegment.EXPECT().SetRollingReady(mock.Anything).Return(nil).Once()
 
 	// Mock metadata operations for creating new segment
-	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(map[int64]*meta.SegmentMeta{
-		1: {Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Active}, Revision: 1},
-	}, nil)
 	mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.MatchedBy(func(meta *meta.SegmentMeta) bool {
 		return meta.Metadata.SegNo == 2 && meta.Metadata.State == proto.SegmentState_Active
 	})).Return(nil)
@@ -520,7 +509,6 @@ func TestLogHandle_GetOrCreateWritableSegmentHandle_CreateFirstSegment(t *testin
 	assert.Equal(t, int64(-1), logHandle.WritableSegmentId)
 
 	// Mock metadata operations for creating first segment
-	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(map[int64]*meta.SegmentMeta{}, nil)
 	mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.MatchedBy(func(meta *meta.SegmentMeta) bool {
 		return meta.Metadata.SegNo == 0 && meta.Metadata.State == proto.SegmentState_Active
 	})).Return(nil)
@@ -535,6 +523,39 @@ func TestLogHandle_GetOrCreateWritableSegmentHandle_CreateFirstSegment(t *testin
 	assert.Contains(t, logHandle.SegmentHandles, int64(0)) // First segment should be cached
 
 	// Verify all expectations
+	mockMeta.AssertExpectations(t)
+}
+
+func TestLogHandle_GetOrCreateWritableSegmentHandle_FirstSegmentAlreadyExists_LockLost(t *testing.T) {
+	logHandle, mockMeta := createMockLogHandle(t)
+	ctx := context.Background()
+
+	logHandle.LastSegmentId.Store(0)
+
+	mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.MatchedBy(func(meta *meta.SegmentMeta) bool {
+		return meta.Metadata.SegNo == 1 && meta.Metadata.State == proto.SegmentState_Active
+	})).Return(werr.ErrMetadataSegmentAlreadyExists).Once()
+
+	notified := false
+	notifier := func(ctx context.Context, reason string) {
+		notified = true
+		assert.Contains(t, reason, "creation conflict")
+	}
+
+	handle, err := logHandle.GetOrCreateWritableSegmentHandle(ctx, notifier)
+
+	require.Error(t, err)
+	assert.Nil(t, handle)
+	assert.True(t, werr.ErrLogWriterLockLost.Is(err), "expected ErrLogWriterLockLost, got: %v", err)
+	assert.True(t, notified, "writer invalidation notifier must be called on first segment conflict")
+
+	assert.Equal(t, int64(-1), logHandle.WritableSegmentId)
+	assert.Equal(t, int64(0), logHandle.LastSegmentId.Load())
+	_, createdExpected := logHandle.SegmentHandles[1]
+	assert.False(t, createdExpected, "claimed segment must not be cached")
+	_, skipped := logHandle.SegmentHandles[2]
+	assert.False(t, skipped, "writer must not skip to a later segment")
+
 	mockMeta.AssertExpectations(t)
 }
 
@@ -2177,7 +2198,7 @@ func TestLogHandle_CreateNewSegmentMeta_QuorumError(t *testing.T) {
 	defer logHandle.stopBackgroundCleanup()
 
 	ctx := context.Background()
-	_, err := logHandle.createNewSegmentMeta(ctx)
+	_, err := logHandle.createNewSegmentMetaWithID(ctx, 0)
 	assert.Error(t, err)
 }
 
@@ -2255,10 +2276,9 @@ func TestLogHandle_CreateNewSegmentMeta_StoreError(t *testing.T) {
 	logHandle, mockMeta := createMockLogHandle(t)
 	ctx := context.Background()
 
-	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(map[int64]*meta.SegmentMeta{}, nil)
 	mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.Anything).Return(werr.ErrInternalError)
 
-	_, err := logHandle.createNewSegmentMeta(ctx)
+	_, err := logHandle.createNewSegmentMetaWithID(ctx, 0)
 	assert.Error(t, err)
 }
 
@@ -2289,17 +2309,69 @@ func TestLogHandle_GetOrCreateWritableSegmentHandle_RollingMetaRevisionInvalid_A
 
 	// Critical: StoreSegmentMetadata for a new segment must NOT be called.
 	// (no mockMeta.EXPECT().StoreSegmentMetadata ... here)
+	notified := false
+	notifier := func(ctx context.Context, reason string) {
+		notified = true
+		assert.Contains(t, reason, "revision invalid")
+	}
 
-	newHandle, err := logHandle.GetOrCreateWritableSegmentHandle(ctx, nil)
+	newHandle, err := logHandle.GetOrCreateWritableSegmentHandle(ctx, notifier)
 
 	require.Error(t, err)
 	assert.Nil(t, newHandle)
 	assert.True(t, werr.ErrLogWriterLockLost.Is(err), "expected ErrLogWriterLockLost, got: %v", err)
+	assert.True(t, notified, "writer invalidation notifier must be called on lock lost")
 
 	// Writable segment id must NOT advance; no new handle was cached.
 	assert.Equal(t, int64(1), logHandle.WritableSegmentId)
 	_, created := logHandle.SegmentHandles[2]
 	assert.False(t, created, "no new segment should be created when the log has been taken over")
+
+	mockOldSegment.AssertExpectations(t)
+	mockMeta.AssertExpectations(t)
+}
+
+// TestLogHandle_GetOrCreateWritableSegmentHandle_RollingNextSegmentAlreadyExists_LockLost
+// verifies that a preempted writer does not skip over a segment claimed by the
+// new writer. It must try current+1 only; if that exact segment exists, the old
+// writer has lost ownership.
+func TestLogHandle_GetOrCreateWritableSegmentHandle_RollingNextSegmentAlreadyExists_LockLost(t *testing.T) {
+	logHandle, mockMeta := createMockLogHandle(t)
+	ctx := context.Background()
+
+	mockOldSegment := mocks_segment_handle.NewSegmentHandle(t)
+
+	logHandle.SegmentHandles[1] = mockOldSegment
+	logHandle.WritableSegmentId = 1
+	logHandle.LastSegmentId.Store(1)
+
+	mockOldSegment.EXPECT().IsForceRollingReady(mock.Anything).Return(true)
+	mockOldSegment.EXPECT().GetId(mock.Anything).Return(int64(1)).Maybe()
+	mockOldSegment.EXPECT().SetRollingReady(mock.Anything).Return(nil).Once()
+
+	mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.MatchedBy(func(meta *meta.SegmentMeta) bool {
+		return meta.Metadata.SegNo == 2 && meta.Metadata.State == proto.SegmentState_Active
+	})).Return(werr.ErrMetadataSegmentAlreadyExists).Once()
+
+	notified := false
+	notifier := func(ctx context.Context, reason string) {
+		notified = true
+		assert.Contains(t, reason, "creation conflict")
+	}
+
+	newHandle, err := logHandle.GetOrCreateWritableSegmentHandle(ctx, notifier)
+
+	require.Error(t, err)
+	assert.Nil(t, newHandle)
+	assert.True(t, werr.ErrLogWriterLockLost.Is(err), "expected ErrLogWriterLockLost, got: %v", err)
+	assert.True(t, notified, "writer invalidation notifier must be called on next segment conflict")
+
+	assert.Equal(t, int64(1), logHandle.WritableSegmentId)
+	assert.Equal(t, int64(1), logHandle.LastSegmentId.Load())
+	_, createdNext := logHandle.SegmentHandles[2]
+	assert.False(t, createdNext, "claimed segment must not be cached by the old writer")
+	_, skipped := logHandle.SegmentHandles[3]
+	assert.False(t, skipped, "old writer must not skip to a later segment")
 
 	mockOldSegment.AssertExpectations(t)
 	mockMeta.AssertExpectations(t)


### PR DESCRIPTION
issue: #155