### PR TITLE
fix: update Prometheus image to soldevelo/prometheus:latest in docker-compose.monitor.yaml

### DIFF
--- a/tests/docker/monitor/docker-compose.monitor.yaml
+++ b/tests/docker/monitor/docker-compose.monitor.yaml
@@ -19,7 +19,7 @@ services:
     restart: "no"
 
   prometheus:
-    image: bitnami/prometheus:latest
+    image: soldevelo/prometheus:latest
     container_name: prometheus
     ports:
       - "9090:9090"


### PR DESCRIPTION
This change replaces the bitnami/prometheus image with the soldevelo/prometheus image to ensure the test and monitoring stack remains fully functional and accessible without external dependency constraints.

The Bitnami Prometheus image is increasingly problematic in some environments due to distribution and availability limitations, which can lead to broken CI pipelines or inconsistent local setups. By switching to the SolDevelo-maintained image, we ensure that:

* the monitoring stack remains fully runnable out-of-the-box
* CI/CD pipelines do not depend on externally restricted or unstable images
* the project uses a drop-in compatible replacement with the same configuration model
* we reduce risk of future breakages caused by upstream availability or policy changes

This change aligns with previous updates in the repository where Bitnami images were replaced with SolDevelo equivalents to maintain consistency and reliability across the test environment.