### PR TITLE
stagedstorage: add shared sync scheduler

### DIFF
--- a/common/metrics/service_metrics.go
+++ b/common/metrics/service_metrics.go
@@ -223,6 +223,31 @@ var (
 		Name:      "file_stored_count",
 		Help:      "Current number of local segment files",
 	}, []string{"node_id", "namespace", "log_id"})
+
+	WpSyncSchedulerScheduled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "sync_scheduler_scheduled",
+		Help:      "Number of delayed staged-writer sync checks scheduled",
+	}, []string{"node_id"})
+	WpSyncSchedulerRunning = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "sync_scheduler_running",
+		Help:      "Number of running staged-writer sync scheduler workers",
+	}, []string{"node_id"})
+	WpSyncSchedulerWaiting = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "sync_scheduler_waiting",
+		Help:      "Number of staged-writer sync scheduler jobs waiting",
+	}, []string{"node_id"})
+	WpSyncSchedulerCapacity = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "sync_scheduler_capacity",
+		Help:      "Worker capacity of the staged-writer sync scheduler",
+	}, []string{"node_id"})
 )
 
 // RegisterServerMetricsWithRegisterer registers all server-side metrics and system metrics.
@@ -260,5 +285,9 @@ func RegisterServerMetricsWithRegisterer(registerer prometheus.Registerer) {
 		registerer.MustRegister(WpObjectStorageStoredObjects)
 		registerer.MustRegister(WpFileStoredBytes)
 		registerer.MustRegister(WpFileStoredCount)
+		registerer.MustRegister(WpSyncSchedulerScheduled)
+		registerer.MustRegister(WpSyncSchedulerRunning)
+		registerer.MustRegister(WpSyncSchedulerWaiting)
+		registerer.MustRegister(WpSyncSchedulerCapacity)
 	})
 }

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -39,6 +40,7 @@ import (
 	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/proto"
 	"github.com/zilliztech/woodpecker/server/processor"
+	"github.com/zilliztech/woodpecker/server/storage/stagedstorage"
 )
 
 const (
@@ -73,6 +75,7 @@ type logStore struct {
 	cancel        context.CancelFunc
 	storageClient storageclient.ObjectStorage
 	address       string
+	syncScheduler *stagedstorage.SyncScheduler
 
 	spMu              sync.RWMutex
 	segmentProcessors map[string]map[int64]processor.SegmentProcessor // bucketName/rootPath/logId,segmentId -> segmentProcessor
@@ -91,6 +94,7 @@ func NewLogStore(ctx context.Context, cfg *config.Configuration, storageClient s
 		ctx:               ctx,
 		cancel:            cancel,
 		storageClient:     storageClient,
+		syncScheduler:     stagedstorage.NewSyncScheduler(runtime.NumCPU() * 2),
 		segmentProcessors: make(map[string]map[int64]processor.SegmentProcessor),
 		address:           net.GetIP(""),
 		cleanupDone:       make(chan struct{}),
@@ -146,6 +150,10 @@ func (l *logStore) Stop() error {
 			totalProcessors += 1
 			l.closeSegmentProcessor(shutdownCtx, logKey, segmentId, processor)
 		}
+	}
+
+	if l.syncScheduler != nil {
+		l.syncScheduler.Close()
 	}
 
 	// Clear the maps
@@ -246,7 +254,7 @@ func (l *logStore) getOrCreateSegmentProcessor(ctx context.Context, bucketName s
 		zap.Int64("segmentId", segmentId),
 		zap.Int("totalProcessors", l.getTotalProcessorCountUnsafe()))
 
-	s := processor.NewSegmentProcessor(ctx, l.cfg, bucketName, rootPath, logId, segmentId, l.storageClient)
+	s := processor.NewSegmentProcessor(ctx, l.cfg, bucketName, rootPath, logId, segmentId, l.storageClient, l.syncScheduler)
 
 	// Initialize log map if not exists
 	if _, exists := l.segmentProcessors[logKey]; !exists {
@@ -796,5 +804,12 @@ func (l *logStore) performBackgroundCleanup(maxIdleTime time.Duration) {
 		logger.Ctx(l.ctx).Info("cleaned up idle segment processor",
 			zap.String("logKey", item.logKey),
 			zap.Int64("segmentId", item.segmentId))
+	}
+
+	if l.syncScheduler != nil {
+		metrics.WpSyncSchedulerScheduled.WithLabelValues(metrics.NodeID).Set(float64(l.syncScheduler.Scheduled()))
+		metrics.WpSyncSchedulerRunning.WithLabelValues(metrics.NodeID).Set(float64(l.syncScheduler.Running()))
+		metrics.WpSyncSchedulerWaiting.WithLabelValues(metrics.NodeID).Set(float64(l.syncScheduler.Waiting()))
+		metrics.WpSyncSchedulerCapacity.WithLabelValues(metrics.NodeID).Set(float64(l.syncScheduler.Capacity()))
 	}
 }

--- a/server/processor/segment_processor.go
+++ b/server/processor/segment_processor.go
@@ -67,9 +67,13 @@ type SegmentProcessor interface {
 	GetWriterSnapshotDetailed() *storage.WriterSnapshotDetailed
 }
 
-func NewSegmentProcessor(ctx context.Context, cfg *config.Configuration, userBucketName string, userRootPath string, logId int64, segId int64, storageClient storageclient.ObjectStorage) SegmentProcessor {
+func NewSegmentProcessor(ctx context.Context, cfg *config.Configuration, userBucketName string, userRootPath string, logId int64, segId int64, storageClient storageclient.ObjectStorage, syncSchedulers ...*stagedstorage.SyncScheduler) SegmentProcessor {
 	ctime := time.Now().UnixMilli()
 	logger.Ctx(ctx).Info("new segment processor created", zap.Int64("ctime", ctime), zap.Int64("logId", logId), zap.Int64("segId", segId))
+	var syncScheduler *stagedstorage.SyncScheduler
+	if len(syncSchedulers) > 0 {
+		syncScheduler = syncSchedulers[0]
+	}
 	s := &segmentProcessor{
 		cfg:           cfg,
 		bucketName:    userBucketName,
@@ -77,6 +81,7 @@ func NewSegmentProcessor(ctx context.Context, cfg *config.Configuration, userBuc
 		logId:         logId,
 		segId:         segId,
 		storageClient: storageClient,
+		syncScheduler: syncScheduler,
 		createTime:    ctime,
 	}
 	s.lastAccessTime.Store(ctime)
@@ -93,6 +98,7 @@ type segmentProcessor struct {
 	logId         int64
 	segId         int64
 	storageClient storageclient.ObjectStorage
+	syncScheduler *stagedstorage.SyncScheduler
 
 	createTime     int64
 	lastAccessTime atomic.Int64
@@ -440,7 +446,8 @@ func (s *segmentProcessor) getOrCreateSegmentWriter(ctx context.Context, recover
 			s.segId,
 			s.storageClient,
 			s.cfg,
-			recoverMode)
+			recoverMode,
+			s.syncScheduler)
 		if getWriterErr != nil {
 			return nil, getWriterErr
 		}

--- a/server/storage/snapshot.go
+++ b/server/storage/snapshot.go
@@ -24,6 +24,10 @@ type WriterSnapshotDetailed struct {
 	BufferEntries                int64 `json:"buffer_entries"`
 	FlushQueueDepth              int   `json:"flush_queue_depth"`
 	FlushQueueCapacity           int   `json:"flush_queue_capacity"`
+	SyncSchedulerScheduled       int   `json:"sync_scheduler_scheduled,omitempty"`
+	SyncSchedulerRunning         int   `json:"sync_scheduler_running,omitempty"`
+	SyncSchedulerWaiting         int   `json:"sync_scheduler_waiting,omitempty"`
+	SyncSchedulerCapacity        int   `json:"sync_scheduler_capacity,omitempty"`
 	WrittenBytes                 int64 `json:"written_bytes"`
 	LastSubmittedFlushingEntryID int64 `json:"last_submitted_flushing_entry_id"`
 	LastSubmittedFlushingBlockID int64 `json:"last_submitted_flushing_block_id"`

--- a/server/storage/stagedstorage/snapshot.go
+++ b/server/storage/stagedstorage/snapshot.go
@@ -41,12 +41,24 @@ func (w *StagedFileWriter) SnapshotDetailed() storage.WriterSnapshotDetailed {
 	writtenBytes := w.writtenBytes
 	w.mu.Unlock()
 
+	var syncScheduled, syncRunning, syncWaiting, syncCapacity int
+	if w.syncScheduler != nil {
+		syncScheduled = w.syncScheduler.Scheduled()
+		syncRunning = w.syncScheduler.Running()
+		syncWaiting = w.syncScheduler.Waiting()
+		syncCapacity = w.syncScheduler.Capacity()
+	}
+
 	return storage.WriterSnapshotDetailed{
 		WriterSnapshot:               snap,
 		BufferBytes:                  bufBytes,
 		BufferEntries:                bufEntries,
 		FlushQueueDepth:              len(w.flushTaskChan),
 		FlushQueueCapacity:           cap(w.flushTaskChan),
+		SyncSchedulerScheduled:       syncScheduled,
+		SyncSchedulerRunning:         syncRunning,
+		SyncSchedulerWaiting:         syncWaiting,
+		SyncSchedulerCapacity:        syncCapacity,
 		WrittenBytes:                 writtenBytes,
 		LastSubmittedFlushingEntryID: w.lastSubmittedFlushingEntryID.Load(),
 		LastSubmittedFlushingBlockID: w.lastSubmittedFlushingBlockID.Load(),

--- a/server/storage/stagedstorage/sync_scheduler.go
+++ b/server/storage/stagedstorage/sync_scheduler.go
@@ -1,0 +1,256 @@
+package stagedstorage
+
+import (
+	"container/heap"
+	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type syncJob func(context.Context)
+
+type syncSchedulerTarget interface {
+	resetSyncScheduled()
+	enqueueScheduledSyncJob()
+}
+
+type syncScheduleRequest struct {
+	target syncSchedulerTarget
+	delay  time.Duration
+}
+
+type scheduledSync struct {
+	target syncSchedulerTarget
+	due    time.Time
+}
+
+type syncScheduleHeap []*scheduledSync
+
+func (h syncScheduleHeap) Len() int {
+	return len(h)
+}
+
+func (h syncScheduleHeap) Less(i, j int) bool {
+	return h[i].due.Before(h[j].due)
+}
+
+func (h syncScheduleHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+func (h *syncScheduleHeap) Push(x any) {
+	*h = append(*h, x.(*scheduledSync))
+}
+
+func (h *syncScheduleHeap) Pop() any {
+	old := *h
+	n := len(old)
+	item := old[n-1]
+	old[n-1] = nil
+	*h = old[:n-1]
+	return item
+}
+
+// SyncScheduler owns the shared staged-writer timer and bounded worker pool.
+// It replaces per-writer run goroutines without changing each writer's flush
+// queue processing semantics.
+type SyncScheduler struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	scheduleCh chan syncScheduleRequest
+	jobCh      chan syncJob
+
+	workerCount int
+	wg          sync.WaitGroup
+	closeOnce   sync.Once
+
+	running atomic.Int64
+	delayed atomic.Int64
+	closed  atomic.Bool
+}
+
+var (
+	defaultSyncSchedulerOnce sync.Once
+	defaultSyncScheduler     *SyncScheduler
+)
+
+func DefaultSyncScheduler() *SyncScheduler {
+	defaultSyncSchedulerOnce.Do(func() {
+		defaultSyncScheduler = NewSyncScheduler(runtime.NumCPU() * 2)
+	})
+	return defaultSyncScheduler
+}
+
+func NewSyncScheduler(workerCount int) *SyncScheduler {
+	if workerCount <= 0 {
+		workerCount = runtime.NumCPU() * 2
+	}
+	if workerCount <= 0 {
+		workerCount = 1
+	}
+	queueSize := workerCount * 4096
+	if queueSize < 1024 {
+		queueSize = 1024
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &SyncScheduler{
+		ctx:         ctx,
+		cancel:      cancel,
+		scheduleCh:  make(chan syncScheduleRequest, queueSize),
+		jobCh:       make(chan syncJob, queueSize),
+		workerCount: workerCount,
+	}
+	s.wg.Add(1)
+	go s.runDelayLoop()
+	for i := 0; i < workerCount; i++ {
+		s.wg.Add(1)
+		go s.runWorkerLoop()
+	}
+	return s
+}
+
+func (s *SyncScheduler) Close() {
+	if s == nil {
+		return
+	}
+	s.closeOnce.Do(func() {
+		s.closed.Store(true)
+		s.cancel()
+		s.wg.Wait()
+	})
+}
+
+func (s *SyncScheduler) ScheduleSyncCheckAfter(writer *StagedFileWriter, delay time.Duration) bool {
+	if s == nil || writer == nil {
+		return false
+	}
+	return s.scheduleSyncCheckAfter(writer, delay)
+}
+
+func (s *SyncScheduler) scheduleSyncCheckAfter(target syncSchedulerTarget, delay time.Duration) bool {
+	if s == nil || target == nil || s.closed.Load() {
+		return false
+	}
+	if delay <= 0 {
+		delay = time.Millisecond
+	}
+	select {
+	case s.scheduleCh <- syncScheduleRequest{target: target, delay: delay}:
+		return true
+	case <-s.ctx.Done():
+		return false
+	}
+}
+
+func (s *SyncScheduler) tryEnqueueJob(job syncJob) bool {
+	if s == nil || job == nil || s.closed.Load() {
+		return false
+	}
+	select {
+	case s.jobCh <- job:
+		return true
+	case <-s.ctx.Done():
+		return false
+	}
+}
+
+func (s *SyncScheduler) Running() int {
+	if s == nil {
+		return 0
+	}
+	return int(s.running.Load())
+}
+
+func (s *SyncScheduler) Waiting() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.jobCh)
+}
+
+func (s *SyncScheduler) Scheduled() int {
+	if s == nil {
+		return 0
+	}
+	return int(s.delayed.Load())
+}
+
+func (s *SyncScheduler) Capacity() int {
+	if s == nil {
+		return 0
+	}
+	return s.workerCount
+}
+
+func (s *SyncScheduler) runDelayLoop() {
+	defer s.wg.Done()
+	h := &syncScheduleHeap{}
+	heap.Init(h)
+	for {
+		if h.Len() == 0 {
+			select {
+			case <-s.ctx.Done():
+				return
+			case req := <-s.scheduleCh:
+				heap.Push(h, &scheduledSync{
+					target: req.target,
+					due:    time.Now().Add(req.delay),
+				})
+				s.delayed.Add(1)
+			}
+			continue
+		}
+
+		next := (*h)[0]
+		delay := time.Until(next.due)
+		if delay <= 0 {
+			item := heap.Pop(h).(*scheduledSync)
+			s.delayed.Add(-1)
+			item.target.resetSyncScheduled()
+			item.target.enqueueScheduledSyncJob()
+			continue
+		}
+
+		timer := time.NewTimer(delay)
+		select {
+		case <-s.ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		case req := <-s.scheduleCh:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			heap.Push(h, &scheduledSync{
+				target: req.target,
+				due:    time.Now().Add(req.delay),
+			})
+			s.delayed.Add(1)
+		}
+	}
+}
+
+func (s *SyncScheduler) runWorkerLoop() {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-s.ctx.Done():
+			return
+		case job := <-s.jobCh:
+			if job == nil {
+				continue
+			}
+			s.running.Add(1)
+			func() {
+				defer s.running.Add(-1)
+				job(s.ctx)
+			}()
+		}
+	}
+}

--- a/server/storage/stagedstorage/sync_scheduler_test.go
+++ b/server/storage/stagedstorage/sync_scheduler_test.go
@@ -1,0 +1,210 @@
+package stagedstorage
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testSyncSchedulerTarget struct {
+	resetCount   atomic.Int64
+	enqueueCount atomic.Int64
+	fired        chan time.Time
+}
+
+func (t *testSyncSchedulerTarget) resetSyncScheduled() {
+	t.resetCount.Add(1)
+}
+
+func (t *testSyncSchedulerTarget) enqueueScheduledSyncJob() {
+	t.enqueueCount.Add(1)
+	if t.fired != nil {
+		select {
+		case t.fired <- time.Now():
+		default:
+		}
+	}
+}
+
+func TestSyncScheduleHeapOrdersByDueTime(t *testing.T) {
+	now := time.Now()
+	first := &testSyncSchedulerTarget{}
+	second := &testSyncSchedulerTarget{}
+	third := &testSyncSchedulerTarget{}
+
+	h := &syncScheduleHeap{}
+	heap.Init(h)
+	heap.Push(h, &scheduledSync{target: third, due: now.Add(30 * time.Millisecond)})
+	heap.Push(h, &scheduledSync{target: first, due: now.Add(10 * time.Millisecond)})
+	heap.Push(h, &scheduledSync{target: second, due: now.Add(20 * time.Millisecond)})
+
+	require.Same(t, first, heap.Pop(h).(*scheduledSync).target)
+	require.Same(t, second, heap.Pop(h).(*scheduledSync).target)
+	require.Same(t, third, heap.Pop(h).(*scheduledSync).target)
+}
+
+func TestSyncSchedulerTryEnqueueJobExecutesJobs(t *testing.T) {
+	scheduler := NewSyncScheduler(2)
+	defer scheduler.Close()
+
+	const totalJobs = 32
+	var wg sync.WaitGroup
+	wg.Add(totalJobs)
+	for i := 0; i < totalJobs; i++ {
+		require.True(t, scheduler.tryEnqueueJob(func(context.Context) {
+			wg.Done()
+		}))
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for scheduler jobs")
+	}
+	require.Eventually(t, func() bool {
+		return scheduler.Running() == 0 && scheduler.Waiting() == 0
+	}, time.Second, time.Millisecond)
+}
+
+func TestSyncSchedulerScheduleSyncCheckAfterFiresAfterDelay(t *testing.T) {
+	scheduler := NewSyncScheduler(1)
+	defer scheduler.Close()
+
+	target := &testSyncSchedulerTarget{fired: make(chan time.Time, 1)}
+	delay := 20 * time.Millisecond
+	start := time.Now()
+	require.True(t, scheduler.scheduleSyncCheckAfter(target, delay))
+
+	select {
+	case firedAt := <-target.fired:
+		t.Fatalf("sync check fired too early after %s", firedAt.Sub(start))
+	case <-time.After(delay / 2):
+	}
+
+	select {
+	case firedAt := <-target.fired:
+		require.GreaterOrEqual(t, firedAt.Sub(start), delay/2)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for delayed sync check")
+	}
+	require.Equal(t, int64(1), target.resetCount.Load())
+	require.Equal(t, int64(1), target.enqueueCount.Load())
+}
+
+func TestSyncSchedulerCloseRejectsNewWork(t *testing.T) {
+	scheduler := NewSyncScheduler(1)
+	scheduler.Close()
+
+	target := &testSyncSchedulerTarget{}
+	require.False(t, scheduler.scheduleSyncCheckAfter(target, time.Millisecond))
+	require.False(t, scheduler.tryEnqueueJob(func(context.Context) {}))
+}
+
+type benchmarkSyncSchedulerTarget struct {
+	dueUnixNano int64
+	fired       chan time.Duration
+}
+
+func (t *benchmarkSyncSchedulerTarget) resetSyncScheduled() {}
+
+func (t *benchmarkSyncSchedulerTarget) enqueueScheduledSyncJob() {
+	t.fired <- time.Since(time.Unix(0, t.dueUnixNano))
+}
+
+func BenchmarkSyncSchedulerJobDispatchLatency(b *testing.B) {
+	for _, jobs := range []int{1_000, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("jobs_%d", jobs), func(b *testing.B) {
+			b.ReportAllocs()
+			scheduler := NewSyncScheduler(runtime.NumCPU())
+			defer scheduler.Close()
+
+			latencies := make(chan time.Duration, jobs)
+			var totalJobs int64
+			var totalLatencyNs int64
+			var maxLatencyNs int64
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var wg sync.WaitGroup
+				wg.Add(jobs)
+				for j := 0; j < jobs; j++ {
+					enqueuedAt := time.Now()
+					if !scheduler.tryEnqueueJob(func(context.Context) {
+						latencies <- time.Since(enqueuedAt)
+						wg.Done()
+					}) {
+						b.Fatal("failed to enqueue scheduler job")
+					}
+				}
+				wg.Wait()
+
+				for j := 0; j < jobs; j++ {
+					latencyNs := (<-latencies).Nanoseconds()
+					totalLatencyNs += latencyNs
+					if latencyNs > maxLatencyNs {
+						maxLatencyNs = latencyNs
+					}
+				}
+				totalJobs += int64(jobs)
+			}
+			b.StopTimer()
+
+			b.ReportMetric(float64(totalLatencyNs)/float64(totalJobs)/1e3, "avg_us/job")
+			b.ReportMetric(float64(maxLatencyNs)/1e3, "max_us/job")
+		})
+	}
+}
+
+func BenchmarkSyncSchedulerDelayedCheckLatency(b *testing.B) {
+	for _, checks := range []int{1_000, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("checks_%d", checks), func(b *testing.B) {
+			b.ReportAllocs()
+			scheduler := NewSyncScheduler(runtime.NumCPU())
+			defer scheduler.Close()
+
+			delay := 10 * time.Millisecond
+			targets := make([]benchmarkSyncSchedulerTarget, checks)
+			latencies := make(chan time.Duration, checks)
+			var totalChecks int64
+			var totalLateNs int64
+			var maxLateNs int64
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				for j := 0; j < checks; j++ {
+					due := time.Now().Add(delay)
+					targets[j].dueUnixNano = due.UnixNano()
+					targets[j].fired = latencies
+					if !scheduler.scheduleSyncCheckAfter(&targets[j], delay) {
+						b.Fatal("failed to schedule sync check")
+					}
+				}
+				for j := 0; j < checks; j++ {
+					lateNs := (<-latencies).Nanoseconds()
+					totalLateNs += lateNs
+					if lateNs > maxLateNs {
+						maxLateNs = lateNs
+					}
+				}
+				totalChecks += int64(checks)
+			}
+			b.StopTimer()
+
+			b.ReportMetric(float64(totalLateNs)/float64(totalChecks)/1e3, "avg_late_us/check")
+			b.ReportMetric(float64(maxLateNs)/1e3, "max_late_us/check")
+		})
+	}
+}

--- a/server/storage/stagedstorage/writer_impl.go
+++ b/server/storage/stagedstorage/writer_impl.go
@@ -107,12 +107,16 @@ type StagedFileWriter struct {
 	recovered      atomic.Bool
 
 	// Async flush management
-	flushTaskChan                chan *blockFlushTask
+	flushTaskChan                chan *blockFlushTask // flushTasksQueue
+	syncScheduler                *SyncScheduler
+	syncScheduled                atomic.Bool // Prevents repeated delayed sync checks for this writer in the shared delay heap.
+	syncTaskSubmitted            atomic.Bool // Prevents repeated scheduled Sync jobs for this writer in the shared worker queue.
 	storageWritable              atomic.Bool // Indicates whether the segment is writable
 	lastSubmittedFlushingEntryID atomic.Int64
 	lastSubmittedFlushingBlockID atomic.Int64
 	allUploadingTaskDone         atomic.Bool
-	flushMu                      sync.Mutex // the mutex ensures sequential writing for each flush batch
+	flushTasksQueueProcessing    atomic.Bool // Ensures only one shared worker is consuming this writer's flushTasksQueue.
+	flushMu                      sync.Mutex  // the mutex ensures sequential writing for each flush batch
 
 	// Close management
 	fileClose  chan struct{} // Close signal
@@ -123,12 +127,12 @@ type StagedFileWriter struct {
 }
 
 // NewStagedFileWriter creates a new staged file writer
-func NewStagedFileWriter(ctx context.Context, bucket string, rootPath string, localBaseDir string, logId int64, segmentId int64, storageCli objectstorage.ObjectStorage, cfg *config.Configuration) (*StagedFileWriter, error) {
-	return NewStagedFileWriterWithMode(ctx, bucket, rootPath, localBaseDir, logId, segmentId, storageCli, cfg, false)
+func NewStagedFileWriter(ctx context.Context, bucket string, rootPath string, localBaseDir string, logId int64, segmentId int64, storageCli objectstorage.ObjectStorage, cfg *config.Configuration, schedulers ...*SyncScheduler) (*StagedFileWriter, error) {
+	return NewStagedFileWriterWithMode(ctx, bucket, rootPath, localBaseDir, logId, segmentId, storageCli, cfg, false, schedulers...)
 }
 
 // NewStagedFileWriterWithMode creates a new staged file writer with recovery mode option
-func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath string, localBaseDir string, logId int64, segmentId int64, storageCli objectstorage.ObjectStorage, cfg *config.Configuration, recoveryMode bool) (*StagedFileWriter, error) {
+func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath string, localBaseDir string, logId int64, segmentId int64, storageCli objectstorage.ObjectStorage, cfg *config.Configuration, recoveryMode bool, schedulers ...*SyncScheduler) (*StagedFileWriter, error) {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, WriterScope, "NewStagedFileWriterWithMode")
 	defer sp.End()
 	blockSize := cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxFlushSize.Int64()
@@ -136,6 +140,10 @@ func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath st
 	maxBytes := cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxBytes.Int64()
 	flushQueueSize := max(int(maxBytes/blockSize), 300)
 	maxInterval := cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage.Milliseconds()
+	syncScheduler := DefaultSyncScheduler()
+	if len(schedulers) > 0 && schedulers[0] != nil {
+		syncScheduler = schedulers[0]
+	}
 	logger.Ctx(ctx).Debug("creating new staged file writer",
 		zap.String("localBaseDir", localBaseDir),
 		zap.Int64("logId", logId),
@@ -182,6 +190,7 @@ func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath st
 		maxBufferEntries:    int64(maxBufferEntries),                    // Default max entries per buffer
 		maxIntervalMs:       maxInterval,                                // 10ms default sync interval for more responsive syncing
 		flushTaskChan:       make(chan *blockFlushTask, flushQueueSize), // Increased buffer size to reduce blocking
+		syncScheduler:       syncScheduler,
 		runCtx:              runCtx,
 		runCancel:           runCancel,
 	}
@@ -200,6 +209,9 @@ func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath st
 	writer.lastSubmittedFlushingEntryID.Store(-1)
 	writer.lastSubmittedFlushingBlockID.Store(-1)
 	writer.allUploadingTaskDone.Store(false)
+	writer.syncScheduled.Store(false)
+	writer.syncTaskSubmitted.Store(false)
+	writer.flushTasksQueueProcessing.Store(false)
 	writer.lastSyncTimestamp.Store(0) // Set to 0 so first write will trigger sync after interval
 
 	// Set default block size if not specified
@@ -282,8 +294,7 @@ func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath st
 		zap.Int64("maxBufferEntries", writer.maxBufferEntries),
 		zap.String("bufferInstance", fmt.Sprintf("%p", initialBuffer)))
 
-	// Start async flush goroutine
-	go writer.run()
+	metrics.WpFileWriters.WithLabelValues(metrics.NodeID, writer.nsStr, writer.logIdStr).Inc()
 
 	logger.Ctx(ctx).Info("staged file writer created successfully",
 		zap.String("filePath", filePath),
@@ -298,76 +309,31 @@ func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath st
 	return writer, nil
 }
 
-// run is the main async goroutine that handles buffer flushing
-func (w *StagedFileWriter) run() {
-	ticker := time.NewTicker(time.Duration(w.maxIntervalMs) * time.Millisecond)
-	defer ticker.Stop()
-
-	metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Inc()
-
-	logger.Ctx(w.runCtx).Debug("StagedFileWriter run goroutine started",
-		zap.Int64("logId", w.logId),
-		zap.Int64("segmentId", w.segmentId))
-
-	for {
-		select {
-		case <-w.runCtx.Done():
-			// Context cancelled, exit
-			logger.Ctx(w.runCtx).Debug("StagedFileWriter run goroutine stopping due to context cancellation")
-			metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Dec()
-			return
-		case flushTask, ok := <-w.flushTaskChan:
-			// Process flush tasks with higher priority
-			if !ok {
-				// Channel closed, exit
-				logger.Ctx(w.runCtx).Debug("StagedFileWriter run goroutine stopping due to channel close")
-				metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Dec()
-				return
-			}
-			if flushTask.entries == nil {
-				logger.Ctx(context.TODO()).Debug("received termination signal, marking all upload tasks as done",
-					zap.String("segmentFilePath", w.segmentFilePath))
-				w.allUploadingTaskDone.Store(true)
-				metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Dec()
-				return
-			}
-			// Process flush task synchronously
-			logger.Ctx(w.runCtx).Debug("Processing flush task from channel",
-				zap.Int64("logId", w.logId),
-				zap.Int64("segId", w.segmentId),
-				zap.Int32("blockNumber", flushTask.blockNumber),
-				zap.Int64("firstEntryId", flushTask.firstEntryId),
-				zap.Int64("lastEntryId", flushTask.lastEntryId),
-				zap.Int("entriesCount", len(flushTask.entries)))
-			w.processFlushTask(w.runCtx, flushTask)
-			logger.Ctx(w.runCtx).Debug("Flush task processing completed")
-		case <-ticker.C:
-			// Periodic sync check
-			autoSyncErr := w.Sync(w.runCtx)
-			if autoSyncErr != nil {
-				logger.Ctx(w.runCtx).Warn("auto sync error", zap.Int64("logId", w.logId), zap.Int64("segId", w.segmentId), zap.Error(autoSyncErr))
-			}
-			// Reset ticker after sync to ensure consistent intervals
-			ticker.Reset(time.Duration(w.maxIntervalMs) * time.Millisecond)
-		}
-	}
-}
-
 // Sync forces immediate sync of all buffered data
 func (w *StagedFileWriter) Sync(ctx context.Context) error {
+	return w.sync(ctx, false)
+}
+
+func (w *StagedFileWriter) sync(ctx context.Context, allowClosed bool) error {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, WriterScope, "Sync")
 	defer sp.End()
 	startTime := time.Now()
-	// Use syncMu to ensure only one sync can proceed at a time
+	// Roll the buffer under the writer lock; flush execution is serialized by flushTasksQueueProcessing/flushMu.
 	w.mu.Lock()
-	defer w.mu.Unlock()
+
+	if w.closed.Load() && !allowClosed {
+		w.mu.Unlock()
+		return werr.ErrFileWriterAlreadyClosed
+	}
 
 	if !w.storageWritable.Load() {
+		w.mu.Unlock()
 		return nil
 	}
 
 	currentBuffer := w.buffer.Load()
 	if currentBuffer == nil {
+		w.mu.Unlock()
 		return nil
 	}
 
@@ -379,10 +345,16 @@ func (w *StagedFileWriter) Sync(ctx context.Context) error {
 	// Sync if there's any data to sync
 	needSync := bufferSize > 0 || hasEntries
 
+	submitted := false
 	if needSync {
 		logger.Ctx(ctx).Debug("Sync: triggering rollBufferAndFlush", zap.Int64("logId", w.logId), zap.Int64("segmentId", w.segmentId), zap.Int64("entryCount", entryCount), zap.Int64("bufferSize", bufferSize), zap.String("bufInst", fmt.Sprintf("%p", currentBuffer)))
 		// Add global writer lock to prevent race conditions with WriteDataAsync
-		w.rollBufferAndSubmitFlushTaskUnsafe(ctx)
+		submitted = w.rollBufferAndEnqueueFlushTaskUnsafe(ctx)
+	}
+	w.mu.Unlock()
+
+	if submitted {
+		w.startFlushTasksQueueProcessing(ctx)
 	}
 
 	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "sync", "success").Inc()
@@ -391,29 +363,31 @@ func (w *StagedFileWriter) Sync(ctx context.Context) error {
 	return nil
 }
 
-// rollBufferAndSubmitFlushTaskUnsafe rolls the current buffer and flushes it to disk (must be called with mu held)
-func (w *StagedFileWriter) rollBufferAndSubmitFlushTaskUnsafe(ctx context.Context) {
+// rollBufferAndEnqueueFlushTaskUnsafe rolls the current buffer and submits a
+// flush task (must be called with mu held). It returns true when a task was
+// accepted into the writer's flush queue.
+func (w *StagedFileWriter) rollBufferAndEnqueueFlushTaskUnsafe(ctx context.Context) bool {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, WriterScope, "rollBufferAndFlushUnsafe")
 	defer sp.End()
 	startTime := time.Now()
 	currentBuffer := w.buffer.Load()
 	if currentBuffer == nil {
-		return
+		return false
 	}
 
 	expectedNextEntryId := currentBuffer.ExpectedNextEntryId.Load()
 	if expectedNextEntryId-currentBuffer.FirstEntryId == 0 {
-		return
+		return false
 	}
 
 	// Get entries from old buffer
 	toFlushEntries, err := currentBuffer.ReadEntriesRange(currentBuffer.GetFirstEntryId(), currentBuffer.GetExpectedNextEntryId())
 	if err != nil {
-		logger.Ctx(ctx).Warn("rollBufferAndSubmitFlushTaskUnsafe: error reading entries from buffer", zap.Int64("logId", w.logId), zap.Int64("segmentId", w.segmentId), zap.Error(err))
-		return
+		logger.Ctx(ctx).Warn("rollBufferAndEnqueueFlushTaskUnsafe: error reading entries from buffer", zap.Int64("logId", w.logId), zap.Int64("segmentId", w.segmentId), zap.Error(err))
+		return false
 	}
 	if len(toFlushEntries) == 0 {
-		return
+		return false
 	}
 
 	// Create flush task
@@ -427,7 +401,7 @@ func (w *StagedFileWriter) rollBufferAndSubmitFlushTaskUnsafe(ctx context.Contex
 
 	restData, err := currentBuffer.ReadEntriesToLast(expectedNextEntryId)
 	if err != nil {
-		return
+		return false
 	}
 	restDataFirstEntryId := expectedNextEntryId
 	newBuffer := cache.NewSequentialBufferWithData(w.logId, w.segmentId, restDataFirstEntryId, w.maxBufferEntries, restData, w.nsStr)
@@ -459,14 +433,137 @@ func (w *StagedFileWriter) rollBufferAndSubmitFlushTaskUnsafe(ctx context.Contex
 		logger.Ctx(ctx).Warn("Context cancelled while submitting flush task", zap.Int32("blockNumber", flushTask.blockNumber))
 		// Notify entries of cancellation
 		w.notifyFlushError(flushTask.entries, ctx.Err())
+		return false
 	case <-w.runCtx.Done():
 		logger.Ctx(ctx).Warn("Writer context cancelled while submitting flush task", zap.Int32("blockNumber", flushTask.blockNumber))
 		// Notify entries of cancellation
 		w.notifyFlushError(flushTask.entries, werr.ErrFileWriterAlreadyClosed)
+		return false
 	}
 
 	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "rollBuffer", "success").Inc()
 	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "rollBuffer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	return true
+}
+
+func (w *StagedFileWriter) startFlushTasksQueueProcessing(ctx context.Context) {
+	if !w.flushTasksQueueProcessing.CompareAndSwap(false, true) {
+		return
+	}
+	job := func(context.Context) {
+		w.processFlushTasksQueue()
+	}
+	if w.syncScheduler != nil && w.syncScheduler.tryEnqueueJob(job) {
+		return
+	}
+	// Scheduler shutdown should not leave accepted flush tasks stranded.
+	job(ctx)
+}
+
+func (w *StagedFileWriter) processFlushTasksQueue() {
+	defer func() {
+		w.flushTasksQueueProcessing.Store(false)
+		if w.runCtx.Err() == nil && len(w.flushTaskChan) > 0 {
+			w.startFlushTasksQueueProcessing(context.Background())
+		}
+	}()
+
+	for {
+		select {
+		case <-w.runCtx.Done():
+			return
+		case flushTask, ok := <-w.flushTaskChan:
+			if !ok {
+				return
+			}
+			if flushTask.entries == nil {
+				logger.Ctx(context.TODO()).Debug("received termination signal, marking all upload tasks as done",
+					zap.String("segmentFilePath", w.segmentFilePath))
+				w.allUploadingTaskDone.Store(true)
+				return
+			}
+			logger.Ctx(w.runCtx).Debug("Processing flush task from shared scheduler",
+				zap.Int64("logId", w.logId),
+				zap.Int64("segId", w.segmentId),
+				zap.Int32("blockNumber", flushTask.blockNumber),
+				zap.Int64("firstEntryId", flushTask.firstEntryId),
+				zap.Int64("lastEntryId", flushTask.lastEntryId),
+				zap.Int("entriesCount", len(flushTask.entries)))
+			w.processFlushTask(w.runCtx, flushTask)
+			logger.Ctx(w.runCtx).Debug("Flush task processing completed")
+		default:
+			return
+		}
+	}
+}
+
+func (w *StagedFileWriter) resetSyncScheduled() {
+	w.syncScheduled.Store(false)
+}
+
+func (w *StagedFileWriter) scheduleDelayedSyncCheck(delay time.Duration) {
+	if w.syncScheduler == nil || !w.hasSyncableEntries() {
+		return
+	}
+	if !w.syncScheduled.CompareAndSwap(false, true) {
+		return
+	}
+	if !w.syncScheduler.ScheduleSyncCheckAfter(w, delay) {
+		w.syncScheduled.Store(false)
+	}
+}
+
+func (w *StagedFileWriter) enqueueScheduledSyncJob() {
+	if !w.hasSyncableEntries() {
+		return
+	}
+	if !w.syncTaskSubmitted.CompareAndSwap(false, true) {
+		w.scheduleDelayedSyncCheck(w.getSyncCheckInterval())
+		return
+	}
+	job := func(context.Context) {
+		defer w.syncTaskSubmitted.Store(false)
+		if !w.hasSyncableEntries() {
+			return
+		}
+		if err := w.Sync(w.runCtx); err != nil {
+			logger.Ctx(w.runCtx).Warn("scheduled sync failed",
+				zap.String("segmentFilePath", w.segmentFilePath),
+				zap.Int64("logId", w.logId),
+				zap.Int64("segmentId", w.segmentId),
+				zap.Error(err))
+		}
+		if w.hasSyncableEntries() {
+			w.scheduleDelayedSyncCheck(w.getSyncCheckInterval())
+		}
+	}
+	if w.syncScheduler != nil && w.syncScheduler.tryEnqueueJob(job) {
+		return
+	}
+	job(context.Background())
+}
+
+func (w *StagedFileWriter) getSyncCheckInterval() time.Duration {
+	delay := time.Duration(w.maxIntervalMs) * time.Millisecond
+	if delay <= 0 {
+		return time.Millisecond
+	}
+	return delay
+}
+
+func (w *StagedFileWriter) hasSyncableEntries() bool {
+	if w.closed.Load() || w.finalized.Load() || w.finalizing.Load() || !w.storageWritable.Load() {
+		return false
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	currentBuffer := w.buffer.Load()
+	if currentBuffer == nil {
+		return false
+	}
+	return currentBuffer.ExpectedNextEntryId.Load()-currentBuffer.FirstEntryId > 0
 }
 
 // processFlushTask processes a flush task by writing data to disk
@@ -655,11 +752,12 @@ func (f *StagedFileWriter) awaitAllFlushTasks(ctx context.Context) error {
 		return nil
 	}
 
-	// Now wait for the ack goroutine to process all completed tasks
+	// Now wait for a shared flush worker to process all completed tasks
 	// This ensures that blockIndexes are properly populated
-	logger.Ctx(ctx).Info("waiting for ack goroutine to process completed tasks", zap.String("segmentFilePath", f.segmentFilePath))
+	logger.Ctx(ctx).Info("waiting for shared flush worker to process completed tasks", zap.String("segmentFilePath", f.segmentFilePath))
 
-	// Send termination signal to ack goroutine
+	// Send termination signal to the writer's flush queue.
+	f.startFlushTasksQueueProcessing(ctx)
 	select {
 	case f.flushTaskChan <- &blockFlushTask{
 		entries:      nil,
@@ -668,23 +766,26 @@ func (f *StagedFileWriter) awaitAllFlushTasks(ctx context.Context) error {
 		blockNumber:  -1,
 	}:
 		logger.Ctx(ctx).Info("termination signal sent to ack goroutine", zap.String("segmentFilePath", f.segmentFilePath))
+		f.startFlushTasksQueueProcessing(ctx)
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-f.runCtx.Done():
+		return werr.ErrFileWriterAlreadyClosed
 	}
 
-	// Wait for ack goroutine to set the done flag
+	// Wait for the flush worker to set the done flag
 	ackWaitTime := 15 * time.Second // TODO configurable
 	ackStartTime := time.Now()
 
 	for {
 		if f.allUploadingTaskDone.Load() {
-			logger.Ctx(ctx).Info("ack goroutine completed processing all tasks", zap.String("segmentFilePath", f.segmentFilePath))
+			logger.Ctx(ctx).Info("shared flush worker completed processing all tasks", zap.String("segmentFilePath", f.segmentFilePath))
 			return nil
 		}
 
 		// Check timeout
 		if time.Since(ackStartTime) > ackWaitTime {
-			logger.Ctx(ctx).Warn("timeout waiting for ack goroutine to complete",
+			logger.Ctx(ctx).Warn("timeout waiting for shared flush worker to complete",
 				zap.String("segmentFilePath", f.segmentFilePath),
 				zap.Bool("allUploadingTaskDone", f.allUploadingTaskDone.Load()),
 				zap.Duration("elapsed", time.Since(ackStartTime)))
@@ -695,6 +796,8 @@ func (f *StagedFileWriter) awaitAllFlushTasks(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-f.runCtx.Done():
+			return werr.ErrFileWriterAlreadyClosed
 		case <-time.After(25 * time.Millisecond):
 			continue
 		}
@@ -747,7 +850,9 @@ func (w *StagedFileWriter) WriteDataAsync(ctx context.Context, entryId int64, da
 	}
 	if entryId <= w.lastEntryID.Load() {
 		// If entryId is less than or equal to lastEntryID, it indicates that the entry has already been written to storage. Return immediately.
-		cache.NotifyPendingEntryDirectly(ctx, w.logId, w.segmentId, entryId, resultCh, entryId, nil, "", time.Time{})
+		if resultCh != nil {
+			cache.NotifyPendingEntryDirectly(ctx, w.logId, w.segmentId, entryId, resultCh, entryId, nil, "", time.Time{})
+		}
 		w.mu.Unlock()
 		return entryId, nil
 	}
@@ -809,6 +914,7 @@ func (w *StagedFileWriter) WriteDataAsync(ctx context.Context, entryId int64, da
 			)
 		}
 	}
+	w.scheduleDelayedSyncCheck(w.getSyncCheckInterval())
 	return entryId, nil
 }
 
@@ -1017,10 +1123,11 @@ func (w *StagedFileWriter) Close(ctx context.Context) error {
 			w.file = nil
 		}
 		close(w.flushTaskChan)
+		metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Dec()
 	}()
 
 	logger.Ctx(ctx).Info("Close: trigger sync before close", zap.Int64("logId", w.logId), zap.Int64("segmentId", w.segmentId))
-	err := w.Sync(ctx) // manual sync all pending append operation
+	err := w.sync(ctx, true) // manual sync all pending append operation
 	if err != nil {
 		logger.Ctx(ctx).Warn("sync error before close",
 			zap.String("segmentFilePath", w.segmentFilePath),

--- a/server/storage/stagedstorage/writer_impl_test.go
+++ b/server/storage/stagedstorage/writer_impl_test.go
@@ -353,6 +353,122 @@ func TestStagedFileWriter_Sync(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestStagedFileWriter_ScheduledSyncFlushesBufferedEntry(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage = config.NewDurationMillisecondsFromInt(10)
+	scheduler := NewSyncScheduler(1)
+	defer scheduler.Close()
+
+	writer, err := NewStagedFileWriter(context.Background(), "test-bucket", "test-root", dir, 1, 0, nil, cfg, scheduler)
+	require.NoError(t, err)
+	defer writer.Close(context.Background())
+
+	resultCh := channel.NewLocalResultChannel("scheduled-sync")
+	_, err = writer.WriteDataAsync(context.Background(), 0, []byte("test"), resultCh)
+	require.NoError(t, err)
+
+	readCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := resultCh.ReadResult(readCtx)
+	require.NoError(t, err)
+	require.NoError(t, result.Err)
+	assert.Equal(t, int64(0), result.SyncedId)
+	assert.Equal(t, int64(0), writer.GetLastEntryId(context.Background()))
+}
+
+func TestStagedFileWriter_ScheduledSyncWaitsForMissingFirstEntry(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage = config.NewDurationMillisecondsFromInt(10)
+	scheduler := NewSyncScheduler(1)
+	defer scheduler.Close()
+
+	writer, err := NewStagedFileWriter(context.Background(), "test-bucket", "test-root", dir, 1, 0, nil, cfg, scheduler)
+	require.NoError(t, err)
+	defer writer.Close(context.Background())
+
+	resultChans := make([]*channel.LocalResultChannel, 5)
+	for i := range resultChans {
+		resultChans[i] = channel.NewLocalResultChannel(fmt.Sprintf("missing-first-%d", i))
+	}
+
+	for i := int64(1); i < 5; i++ {
+		_, err = writer.WriteDataAsync(context.Background(), i, []byte(fmt.Sprintf("data-%d", i)), resultChans[i])
+		require.NoError(t, err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, int64(-1), writer.GetLastEntryId(context.Background()))
+	assert.Equal(t, 0, scheduler.Scheduled())
+	assert.Equal(t, 0, scheduler.Waiting())
+
+	noResultCtx, noResultCancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	_, err = resultChans[1].ReadResult(noResultCtx)
+	noResultCancel()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	_, err = writer.WriteDataAsync(context.Background(), 0, []byte("data-0"), resultChans[0])
+	require.NoError(t, err)
+
+	for i, resultCh := range resultChans {
+		readCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		result, readErr := resultCh.ReadResult(readCtx)
+		cancel()
+		require.NoError(t, readErr)
+		require.NoError(t, result.Err)
+		assert.Equal(t, int64(i), result.SyncedId)
+	}
+	assert.Equal(t, int64(4), writer.GetLastEntryId(context.Background()))
+}
+
+func TestStagedFileWriter_ScheduledSyncReschedulesWhenJobAlreadySubmitted(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage = config.NewDurationMillisecondsFromInt(10)
+	scheduler := NewSyncScheduler(1)
+	defer scheduler.Close()
+
+	writer, err := NewStagedFileWriter(context.Background(), "test-bucket", "test-root", dir, 1, 0, nil, cfg, scheduler)
+	require.NoError(t, err)
+	defer func() {
+		writer.syncTaskSubmitted.Store(false)
+		require.NoError(t, writer.Close(context.Background()))
+	}()
+
+	resultChans := make([]*channel.LocalResultChannel, 5)
+	for i := range resultChans {
+		resultChans[i] = channel.NewLocalResultChannel(fmt.Sprintf("submitted-sync-%d", i))
+	}
+
+	for i := int64(1); i < 5; i++ {
+		_, err = writer.WriteDataAsync(context.Background(), i, []byte(fmt.Sprintf("data-%d", i)), resultChans[i])
+		require.NoError(t, err)
+	}
+
+	writer.syncTaskSubmitted.Store(true)
+	_, err = writer.WriteDataAsync(context.Background(), 0, []byte("data-0"), resultChans[0])
+	require.NoError(t, err)
+
+	noResultCtx, noResultCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	_, err = resultChans[0].ReadResult(noResultCtx)
+	noResultCancel()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Equal(t, int64(-1), writer.GetLastEntryId(context.Background()))
+
+	writer.syncTaskSubmitted.Store(false)
+
+	for i, resultCh := range resultChans {
+		readCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		result, readErr := resultCh.ReadResult(readCtx)
+		cancel()
+		require.NoError(t, readErr)
+		require.NoError(t, result.Err)
+		assert.Equal(t, int64(i), result.SyncedId)
+	}
+	assert.Equal(t, int64(4), writer.GetLastEntryId(context.Background()))
+}
+
 func TestStagedFileWriter_Sync_StorageNotWritable(t *testing.T) {
 	dir := t.TempDir()
 	cfg := newTestConfig(t)


### PR DESCRIPTION
issue: https://github.com/zilliztech/woodpecker/issues/103

  Replace per-writer sync goroutines with a shared scheduler and bounded worker
  pool. Writers now schedule delayed sync checks only when they have contiguous
  syncable entries, and shared workers process each writer's flush task queue
  while preserving per-writer flush ordering.

  Also add scheduler tests, scheduled-sync regression tests for out-of-order
  writes and rescheduling, plus benchmarks for worker dispatch latency and
  delayed-check lateness