### PR TITLE
feat: add /admin/log-health per-log read/write health probe (#131)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/zilliztech/woodpecker/common/logger"
 	"github.com/zilliztech/woodpecker/common/membership"
 	"github.com/zilliztech/woodpecker/common/metrics"
+	"github.com/zilliztech/woodpecker/common/runtime/loghealth"
 	"github.com/zilliztech/woodpecker/common/runtime/opregistry"
 	"github.com/zilliztech/woodpecker/common/topology"
 	"github.com/zilliztech/woodpecker/common/tracer"
@@ -206,6 +207,9 @@ func main() {
 	opregistry.WirePrometheusCallbacks(opReg)
 	srv.SetGRPCExtraInterceptors(opregistry.UnaryInterceptor())
 
+	logHealth := loghealth.New(loghealth.DefaultStallAfter)
+	metrics.RegisterOpObserver(logHealth)
+
 	// Start HTTP server for metrics, health check, and pprof
 	if err := commonhttp.Start(cfg, commonhttp.AdminCallbacks{
 		GetMemberlistStatus: srv.GetServerNodeMemberlistStatus,
@@ -224,6 +228,9 @@ func main() {
 		},
 		GetConfig: func() any {
 			return cfg
+		},
+		GetLogHealth: func(_ context.Context, bucketName, rootPath string) (any, int) {
+			return logHealth.Report(bucketName, rootPath)
 		},
 		Logstore: commonhttp.LogstoreCallbacks{
 			ListSegments: func(logID *int64, writable *bool) []any {

--- a/common/http/README.md
+++ b/common/http/README.md
@@ -94,6 +94,7 @@ curl "http://localhost:9091/admin/log-health?bucket_name=a-bucket&root_path=file
   and all tenants are returned.
 - Write health is the logstore "accept" outcome (`logstore.add_entry`); read health is
   `logstore.get_batch_entries`. Each log is classified Healthy / Stalled / Failed / Idle.
+  Reaching the end of a log (EOF / entry-not-found) is a healthy read, not a failure.
 - Independent of `/healthz`: `/healthz` is process liveness, while `/admin/log-health` is
   data-path health — a stalled or failed log never affects the `/healthz` result.
 - Cold start, idle, or no observed log activity returns `Healthy` (a quiet node is not

--- a/common/http/README.md
+++ b/common/http/README.md
@@ -92,8 +92,13 @@ curl "http://localhost:9091/admin/log-health?bucket_name=a-bucket&root_path=file
 
 - Both `bucket_name` and `root_path` must be supplied to filter; a partial filter is ignored
   and all tenants are returned.
-- Cold start or no observed log activity returns `Healthy`.
-- **HTTP Status:** `200` when healthy, `503` when one or more logs are stalled.
+- Write health is the logstore "accept" outcome (`logstore.add_entry`); read health is
+  `logstore.get_batch_entries`. Each log is classified Healthy / Stalled / Failed / Idle.
+- Independent of `/healthz`: `/healthz` is process liveness, while `/admin/log-health` is
+  data-path health — a stalled or failed log never affects the `/healthz` result.
+- Cold start, idle, or no observed log activity returns `Healthy` (a quiet node is not
+  pulled out of rotation).
+- **HTTP Status:** `503` only when every tracked log is Stalled or Failed; `200` otherwise.
 
 ---
 

--- a/common/http/README.md
+++ b/common/http/README.md
@@ -11,6 +11,7 @@ Woodpecker exposes an HTTP admin server on each node (default port `9091`, confi
 | GET | `/log/level` | Ops | Query/update log level at runtime |
 | GET | `/admin/memberlist` | Cluster | Gossip memberlist status |
 | GET | `/admin/node/status` | Lifecycle | Node status and membership info |
+| GET | `/admin/log-health` | Health | Node-wide per-log read/write health (optionally filtered by bucket/rootPath) |
 | POST | `/admin/node/decommission` | Lifecycle | Start graceful node decommission |
 | GET | `/admin/node/decommission/progress` | Lifecycle | Decommission progress and safe-to-terminate check |
 | GET | `/debug/pprof/` | Debug | Pprof index page (enabled by default, disable via `PPROF_ENABLE=false`) |
@@ -73,6 +74,26 @@ curl -H "Content-Type: application/json" http://localhost:9091/healthz
 **HTTP Status:** `200` if all healthy, `500` if any component is unhealthy.
 
 **Component health codes:** `Initializing` | `Healthy` | `Abnormal` | `StandBy` | `Stopping`
+
+---
+
+## Log Health
+
+`/admin/log-health` reports the local node's observed per-log read/write health, derived
+from real operation results (no synthetic heartbeat logs are created).
+
+```bash
+# All logs observed on this node
+curl "http://localhost:9091/admin/log-health"
+
+# Filter to a single Woodpecker instance (both params required, otherwise ignored)
+curl "http://localhost:9091/admin/log-health?bucket_name=a-bucket&root_path=files"
+```
+
+- Both `bucket_name` and `root_path` must be supplied to filter; a partial filter is ignored
+  and all tenants are returned.
+- Cold start or no observed log activity returns `Healthy`.
+- **HTTP Status:** `200` when healthy, `503` when one or more logs are stalled.
 
 ---
 

--- a/common/http/management/log_health_handler.go
+++ b/common/http/management/log_health_handler.go
@@ -1,0 +1,53 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// LogHealthCallback returns the node's log health, optionally filtered to one
+// (bucketName, rootPath) instance. Empty strings mean "all tenants".
+type LogHealthCallback func(ctx context.Context, bucketName, rootPath string) (any, int)
+
+// NewLogHealthHandler serves the node-wide log health endpoint.
+// Optional query params: ?bucket_name=<bucket>&root_path=<root>.
+// A partial filter (only one of the two) is ignored — all tenants are returned.
+func NewLogHealthHandler(get LogHealthCallback) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		bucketName := firstNonEmpty(
+			r.URL.Query().Get("bucket_name"),
+			r.URL.Query().Get("bucketName"),
+			r.URL.Query().Get("bucketname"),
+		)
+		rootPath := firstNonEmpty(
+			r.URL.Query().Get("root_path"),
+			r.URL.Query().Get("rootPath"),
+			r.URL.Query().Get("rootpath"),
+		)
+		if bucketName == "" || rootPath == "" {
+			bucketName, rootPath = "", "" // partial filter -> no filter
+		}
+
+		result, statusCode := get(r.Context(), bucketName, rootPath)
+		if statusCode == 0 {
+			statusCode = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_ = json.NewEncoder(w).Encode(result)
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/common/http/management/log_health_handler_test.go
+++ b/common/http/management/log_health_handler_test.go
@@ -1,0 +1,68 @@
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogHealthHandler_NoFilterReturnsAll(t *testing.T) {
+	var gotBucket, gotRoot string
+	h := NewLogHealthHandler(func(_ context.Context, b, r string) (any, int) {
+		gotBucket, gotRoot = b, r
+		return map[string]string{"state": "Healthy"}, http.StatusOK
+	})
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/admin/log-health", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Empty(t, gotBucket)
+	require.Empty(t, gotRoot)
+}
+
+func TestLogHealthHandler_PartialFilterIgnored(t *testing.T) {
+	var gotBucket, gotRoot string
+	h := NewLogHealthHandler(func(_ context.Context, b, r string) (any, int) {
+		gotBucket, gotRoot = b, r
+		return map[string]string{}, http.StatusOK
+	})
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/admin/log-health?bucket_name=b", nil))
+	require.Empty(t, gotBucket)
+	require.Empty(t, gotRoot)
+}
+
+func TestLogHealthHandler_FilterPassedThrough(t *testing.T) {
+	var gotBucket, gotRoot string
+	h := NewLogHealthHandler(func(_ context.Context, b, r string) (any, int) {
+		gotBucket, gotRoot = b, r
+		return map[string]string{}, http.StatusServiceUnavailable
+	})
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/admin/log-health?bucket_name=b&root_path=r", nil))
+	require.Equal(t, "b", gotBucket)
+	require.Equal(t, "r", gotRoot)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestLogHealthHandler_RejectsNonGet(t *testing.T) {
+	h := NewLogHealthHandler(func(context.Context, string, string) (any, int) { return nil, http.StatusOK })
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodPost, "/admin/log-health", nil))
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestLogHealthHandler_EncodesJSON(t *testing.T) {
+	h := NewLogHealthHandler(func(context.Context, string, string) (any, int) {
+		return map[string]any{"state": "Healthy", "tracked_logs": 0}, http.StatusOK
+	})
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/admin/log-health", nil))
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "Healthy", body["state"])
+}

--- a/common/http/router.go
+++ b/common/http/router.go
@@ -46,6 +46,9 @@ const AdminConfigPath = "/admin/config"
 // AdminEnvPath is path for GET /admin/env.
 const AdminEnvPath = "/admin/env"
 
+// AdminLogHealthPath is the path for node-wide per-log read/write health.
+const AdminLogHealthPath = "/admin/log-health"
+
 // C family — logstore runtime
 const (
 	AdminLogstoreSegmentsPath = "/admin/logstore/segments"

--- a/common/http/server.go
+++ b/common/http/server.go
@@ -59,6 +59,7 @@ type AdminCallbacks struct {
 	GetDecommissionProgress func() any
 	CancelDecommission      func() error
 	GetConfig               func() any
+	GetLogHealth            management.LogHealthCallback
 
 	// Phase 2 callbacks
 	Logstore LogstoreCallbacks
@@ -188,6 +189,12 @@ func Start(cfg *config.Configuration, callbacks AdminCallbacks) error {
 		Register(&Handler{
 			Path:        AdminConfigPath,
 			HandlerFunc: management.NewConfigHandler(callbacks.GetConfig),
+		})
+	}
+	if callbacks.GetLogHealth != nil {
+		Register(&Handler{
+			Path:        AdminLogHealthPath,
+			HandlerFunc: management.NewLogHealthHandler(callbacks.GetLogHealth),
 		})
 	}
 

--- a/common/metrics/op.go
+++ b/common/metrics/op.go
@@ -9,12 +9,14 @@ import (
 
 // Op represents an in-flight operation being tracked.
 type Op struct {
-	OpType    string
-	Labels    prometheus.Labels
-	LogID     int64
-	SegmentID int64
-	TraceID   string
-	SpanID    string
+	OpType     string
+	Labels     prometheus.Labels
+	BucketName string
+	RootPath   string
+	LogID      int64
+	SegmentID  int64
+	TraceID    string
+	SpanID     string
 
 	histo   prometheus.Observer // may be nil
 	start   time.Time
@@ -30,6 +32,14 @@ func WithLogSegment(logID, segmentID int64) OpOption {
 	return func(op *Op) {
 		op.LogID = logID
 		op.SegmentID = segmentID
+	}
+}
+
+// WithInstance sets the multi-tenant identity (bucket + root path) for the op.
+func WithInstance(bucketName, rootPath string) OpOption {
+	return func(op *Op) {
+		op.BucketName = bucketName
+		op.RootPath = rootPath
 	}
 }
 

--- a/common/metrics/op_test.go
+++ b/common/metrics/op_test.go
@@ -109,6 +109,18 @@ func TestOp_StartedAt(t *testing.T) {
 	assert.False(t, op.StartedAt().After(after))
 }
 
+func TestWithInstance_SetsBucketAndRoot(t *testing.T) {
+	ResetObservers()
+	defer ResetObservers()
+	op := StartOp("test.op", nil, nil, WithInstance("bucket-a", "root-a"), WithLogSegment(7, 3))
+	if op.BucketName != "bucket-a" || op.RootPath != "root-a" {
+		t.Fatalf("got bucket=%q root=%q", op.BucketName, op.RootPath)
+	}
+	if op.LogID != 7 || op.SegmentID != 3 {
+		t.Fatalf("WithLogSegment regressed: log=%d seg=%d", op.LogID, op.SegmentID)
+	}
+}
+
 func TestOp_NoObservers(t *testing.T) {
 	ResetObservers()
 	defer ResetObservers()

--- a/common/runtime/loghealth/tracker.go
+++ b/common/runtime/loghealth/tracker.go
@@ -48,7 +48,9 @@ type logHealth struct {
 	writeFailureMS atomic.Int64
 	readSuccessMS  atomic.Int64
 	readFailureMS  atomic.Int64
-	failureReason  atomic.Pointer[string]
+
+	writeFailureReason atomic.Pointer[string]
+	readFailureReason  atomic.Pointer[string]
 }
 
 // Tracker observes the metrics.Op stream and derives per-log read/write health.
@@ -179,7 +181,7 @@ func (t *Tracker) recordWriteFailure(b, r string, logID int64, now time.Time, re
 	}
 	lh := t.get(b, r, logID)
 	lh.writeFailureMS.Store(now.UnixMilli())
-	lh.failureReason.Store(&reason)
+	lh.writeFailureReason.Store(&reason)
 }
 
 func (t *Tracker) recordReadSuccess(b, r string, logID int64, now time.Time) {
@@ -195,7 +197,7 @@ func (t *Tracker) recordReadFailure(b, r string, logID int64, now time.Time, rea
 	}
 	lh := t.get(b, r, logID)
 	lh.readFailureMS.Store(now.UnixMilli())
-	lh.failureReason.Store(&reason)
+	lh.readFailureReason.Store(&reason)
 }
 
 // --- snapshot / classification ---
@@ -274,7 +276,13 @@ func (t *Tracker) snapshotLog(key logInstanceKey, logID int64, lh *logHealth, no
 		LastReadSuccessMS:  lh.readSuccessMS.Load(),
 		LastReadFailureMS:  lh.readFailureMS.Load(),
 	}
-	if rp := lh.failureReason.Load(); rp != nil {
+	// Surface the reason of whichever direction failed most recently. When both
+	// are zero (no failures), this loads the write pointer, which is nil -> "".
+	if snap.LastWriteFailureMS >= snap.LastReadFailureMS {
+		if rp := lh.writeFailureReason.Load(); rp != nil {
+			snap.LastFailureReason = *rp
+		}
+	} else if rp := lh.readFailureReason.Load(); rp != nil {
 		snap.LastFailureReason = *rp
 	}
 	writeAttempt := lh.writeAttemptMS.Load()

--- a/common/runtime/loghealth/tracker.go
+++ b/common/runtime/loghealth/tracker.go
@@ -40,13 +40,19 @@ const (
 // Compile-time assertion that Tracker is an OpObserver.
 var _ metrics.OpObserver = (*Tracker)(nil)
 
-// logKey is the full per-log identity. It is a comparable struct used directly
-// as a native map key, so lookups hash it in place without boxing or allocation
-// (unlike an interface-keyed sync.Map).
-type logKey struct {
+// namespace is woodpecker's per-tenant scope — a (bucketName, rootPath) pair,
+// the same identity metrics.BuildMetricsNamespace renders as "bucket/rootPath".
+type namespace struct {
 	bucketName string
 	rootPath   string
-	logID      int64
+}
+
+// logKey is the full per-log identity: a namespace plus the log ID. It is a
+// comparable struct used directly as a native map key, so lookups hash it in
+// place without boxing or allocation (unlike an interface-keyed sync.Map).
+type logKey struct {
+	ns    namespace
+	logID int64
 }
 
 // logHealth is the lock-free per-log state. Once its *logHealth is published in
@@ -155,7 +161,7 @@ func (t *Tracker) OnOpEnd(op *metrics.Op, _ uint64, elapsed time.Duration, statu
 // --- internal record methods (unit-testable without metrics.Op) ---
 
 func (t *Tracker) get(bucketName, rootPath string, logID int64) *logHealth {
-	key := logKey{bucketName: bucketName, rootPath: rootPath, logID: logID}
+	key := logKey{ns: namespace{bucketName: bucketName, rootPath: rootPath}, logID: logID}
 	// Fast path: lock-free, allocation-free read of the current snapshot.
 	if lh := (*t.logs.Load())[key]; lh != nil {
 		return lh
@@ -234,7 +240,7 @@ func (t *Tracker) Snapshot(bucketFilter, rootPathFilter, nodeID string, now time
 	// Load the immutable snapshot once; iterating it needs no lock, and each
 	// log's per-direction fields are read atomically inside snapshotLog.
 	for key, lh := range *t.logs.Load() {
-		if filtered && (key.bucketName != bucketFilter || key.rootPath != rootPathFilter) {
+		if filtered && (key.ns.bucketName != bucketFilter || key.ns.rootPath != rootPathFilter) {
 			continue
 		}
 		resp.Logs = append(resp.Logs, t.snapshotLog(key, lh, now))
@@ -281,8 +287,8 @@ func (t *Tracker) Snapshot(bucketFilter, rootPathFilter, nodeID string, now time
 
 func (t *Tracker) snapshotLog(key logKey, lh *logHealth, now time.Time) LogSnapshot {
 	snap := LogSnapshot{
-		BucketName:         key.bucketName,
-		RootPath:           key.rootPath,
+		BucketName:         key.ns.bucketName,
+		RootPath:           key.ns.rootPath,
 		LogID:              key.logID,
 		LastWriteSuccessMS: lh.writeSuccessMS.Load(),
 		LastWriteFailureMS: lh.writeFailureMS.Load(),

--- a/common/runtime/loghealth/tracker.go
+++ b/common/runtime/loghealth/tracker.go
@@ -31,6 +31,9 @@ const (
 	opGetBatchEntries = "logstore.get_batch_entries"
 	// statusSuccess is the literal status server/logstore.go sets on success.
 	statusSuccess = "success"
+	// statusEndOfFile marks a read that reached the end of the log — a healthy read
+	// outcome, not a failure (server/logstore.go sets it for EOF / entry-not-found).
+	statusEndOfFile = "end_of_file"
 )
 
 // Compile-time assertion that Tracker is an OpObserver.
@@ -129,7 +132,7 @@ func (t *Tracker) OnOpEnd(op *metrics.Op, _ uint64, elapsed time.Duration, statu
 			t.recordWriteFailure(op.BucketName, op.RootPath, op.LogID, now, status)
 		}
 	case opGetBatchEntries:
-		if ok {
+		if ok || status == statusEndOfFile {
 			t.recordReadSuccess(op.BucketName, op.RootPath, op.LogID, now)
 		} else {
 			t.recordReadFailure(op.BucketName, op.RootPath, op.LogID, now, status)

--- a/common/runtime/loghealth/tracker.go
+++ b/common/runtime/loghealth/tracker.go
@@ -1,0 +1,334 @@
+package loghealth
+
+import (
+	"net/http"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/zilliztech/woodpecker/common/metrics"
+)
+
+const (
+	// Node rollup states.
+	StateHealthy   = "Healthy"
+	StateUnhealthy = "Unhealthy"
+
+	// Per-log / per-direction states.
+	logStateHealthy = "Healthy"
+	logStateFailed  = "Failed"
+	logStateStalled = "Stalled"
+	logStateIdle    = "Idle"
+
+	// DefaultStallAfter is the no-success window after which an active-but-not-
+	// completing log is considered Stalled.
+	DefaultStallAfter = 10 * time.Minute
+
+	// Observed op types — MUST match the opType strings passed to metrics.StartOp
+	// in server/logstore.go.
+	opAddEntry        = "logstore.add_entry"
+	opGetBatchEntries = "logstore.get_batch_entries"
+	// statusSuccess is the literal status server/logstore.go sets on success.
+	statusSuccess = "success"
+)
+
+// Compile-time assertion that Tracker is an OpObserver.
+var _ metrics.OpObserver = (*Tracker)(nil)
+
+type logInstanceKey struct {
+	bucketName string
+	rootPath   string
+}
+
+// logHealth is the lock-free per-log state, written via atomic stores under RLock.
+type logHealth struct {
+	writeAttemptMS atomic.Int64
+	writeSuccessMS atomic.Int64
+	writeFailureMS atomic.Int64
+	readSuccessMS  atomic.Int64
+	readFailureMS  atomic.Int64
+	failureReason  atomic.Pointer[string]
+}
+
+// Tracker observes the metrics.Op stream and derives per-log read/write health.
+type Tracker struct {
+	mu         sync.RWMutex // guards map STRUCTURE only
+	stallAfter time.Duration
+	logs       map[logInstanceKey]map[int64]*logHealth
+}
+
+// LogSnapshot is the per-log view; (BucketName, RootPath, LogID) is the unique key.
+type LogSnapshot struct {
+	BucketName         string `json:"bucket_name"`
+	RootPath           string `json:"root_path"`
+	LogID              int64  `json:"log_id"`
+	State              string `json:"state"`
+	WriteState         string `json:"write_state"`
+	ReadState          string `json:"read_state"`
+	LastWriteSuccessMS int64  `json:"last_write_success_ms,omitempty"`
+	LastWriteFailureMS int64  `json:"last_write_failure_ms,omitempty"`
+	LastReadSuccessMS  int64  `json:"last_read_success_ms,omitempty"`
+	LastReadFailureMS  int64  `json:"last_read_failure_ms,omitempty"`
+	LastFailureReason  string `json:"last_failure_reason,omitempty"`
+}
+
+// Response is the node-wide payload, optionally filtered to one tenant.
+type Response struct {
+	State            string        `json:"state"`
+	Reason           string        `json:"reason"`
+	NodeID           string        `json:"node_id,omitempty"`
+	FilterBucketName string        `json:"filter_bucket_name,omitempty"`
+	FilterRootPath   string        `json:"filter_root_path,omitempty"`
+	TimestampMS      int64         `json:"timestamp_ms"`
+	StallAfterMS     int64         `json:"stall_after_ms"`
+	TrackedLogs      int           `json:"tracked_logs"`
+	HealthyLogs      int           `json:"healthy_logs"`
+	FailedLogs       int           `json:"failed_logs"`
+	StalledLogs      int           `json:"stalled_logs"`
+	IdleLogs         int           `json:"idle_logs"`
+	Logs             []LogSnapshot `json:"logs"`
+}
+
+// New creates a Tracker. stallAfter <= 0 uses DefaultStallAfter.
+func New(stallAfter time.Duration) *Tracker {
+	if stallAfter <= 0 {
+		stallAfter = DefaultStallAfter
+	}
+	return &Tracker{
+		stallAfter: stallAfter,
+		logs:       make(map[logInstanceKey]map[int64]*logHealth),
+	}
+}
+
+// --- metrics.OpObserver ---
+
+func (t *Tracker) OnOpStart(op *metrics.Op) uint64 {
+	if t == nil || op == nil {
+		return 0
+	}
+	if op.OpType == opAddEntry {
+		t.recordWriteAttempt(op.BucketName, op.RootPath, op.LogID, op.StartedAt())
+	}
+	return 0 // the tracker keeps no per-op handle
+}
+
+func (t *Tracker) OnOpEnd(op *metrics.Op, _ uint64, elapsed time.Duration, status string) {
+	if t == nil || op == nil {
+		return
+	}
+	now := op.StartedAt().Add(elapsed)
+	ok := status == statusSuccess
+	switch op.OpType {
+	case opAddEntry:
+		if ok {
+			t.recordWriteSuccess(op.BucketName, op.RootPath, op.LogID, now)
+		} else {
+			t.recordWriteFailure(op.BucketName, op.RootPath, op.LogID, now, status)
+		}
+	case opGetBatchEntries:
+		if ok {
+			t.recordReadSuccess(op.BucketName, op.RootPath, op.LogID, now)
+		} else {
+			t.recordReadFailure(op.BucketName, op.RootPath, op.LogID, now, status)
+		}
+	}
+}
+
+// --- internal record methods (unit-testable without metrics.Op) ---
+
+func (t *Tracker) get(bucketName, rootPath string, logID int64) *logHealth {
+	key := logInstanceKey{bucketName: bucketName, rootPath: rootPath}
+	t.mu.RLock()
+	lh := t.logs[key][logID] // indexing a nil inner map is safe -> nil
+	t.mu.RUnlock()
+	if lh != nil {
+		return lh
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	instanceLogs := t.logs[key]
+	if instanceLogs == nil {
+		instanceLogs = make(map[int64]*logHealth)
+		t.logs[key] = instanceLogs
+	}
+	if lh = instanceLogs[logID]; lh == nil {
+		lh = &logHealth{}
+		instanceLogs[logID] = lh
+	}
+	return lh
+}
+
+func (t *Tracker) recordWriteAttempt(b, r string, logID int64, now time.Time) {
+	if t == nil {
+		return
+	}
+	t.get(b, r, logID).writeAttemptMS.Store(now.UnixMilli())
+}
+
+func (t *Tracker) recordWriteSuccess(b, r string, logID int64, now time.Time) {
+	if t == nil {
+		return
+	}
+	t.get(b, r, logID).writeSuccessMS.Store(now.UnixMilli())
+}
+
+func (t *Tracker) recordWriteFailure(b, r string, logID int64, now time.Time, reason string) {
+	if t == nil {
+		return
+	}
+	lh := t.get(b, r, logID)
+	lh.writeFailureMS.Store(now.UnixMilli())
+	lh.failureReason.Store(&reason)
+}
+
+func (t *Tracker) recordReadSuccess(b, r string, logID int64, now time.Time) {
+	if t == nil {
+		return
+	}
+	t.get(b, r, logID).readSuccessMS.Store(now.UnixMilli())
+}
+
+func (t *Tracker) recordReadFailure(b, r string, logID int64, now time.Time, reason string) {
+	if t == nil {
+		return
+	}
+	lh := t.get(b, r, logID)
+	lh.readFailureMS.Store(now.UnixMilli())
+	lh.failureReason.Store(&reason)
+}
+
+// --- snapshot / classification ---
+
+// Snapshot is pure and deterministic (nodeID + now injected). Empty filters = all.
+func (t *Tracker) Snapshot(bucketFilter, rootPathFilter, nodeID string, now time.Time) Response {
+	resp := Response{
+		State:            StateHealthy,
+		Reason:           "no_observed_activity",
+		NodeID:           nodeID,
+		FilterBucketName: bucketFilter,
+		FilterRootPath:   rootPathFilter,
+		TimestampMS:      now.UnixMilli(),
+		StallAfterMS:     int64(t.stallAfter / time.Millisecond),
+		Logs:             []LogSnapshot{},
+	}
+	filtered := bucketFilter != "" && rootPathFilter != ""
+
+	t.mu.RLock()
+	for key, instanceLogs := range t.logs {
+		if filtered && (key.bucketName != bucketFilter || key.rootPath != rootPathFilter) {
+			continue
+		}
+		for logID, lh := range instanceLogs {
+			resp.Logs = append(resp.Logs, t.snapshotLog(key, logID, lh, now))
+		}
+	}
+	t.mu.RUnlock()
+
+	sort.Slice(resp.Logs, func(i, j int) bool {
+		a, b := resp.Logs[i], resp.Logs[j]
+		if a.BucketName != b.BucketName {
+			return a.BucketName < b.BucketName
+		}
+		if a.RootPath != b.RootPath {
+			return a.RootPath < b.RootPath
+		}
+		return a.LogID < b.LogID
+	})
+
+	resp.TrackedLogs = len(resp.Logs)
+	for _, s := range resp.Logs {
+		switch s.State {
+		case logStateHealthy:
+			resp.HealthyLogs++
+		case logStateFailed:
+			resp.FailedLogs++
+		case logStateStalled:
+			resp.StalledLogs++
+		case logStateIdle:
+			resp.IdleLogs++
+		}
+	}
+
+	switch {
+	case resp.TrackedLogs == 0:
+		// Healthy / no_observed_activity
+	case resp.HealthyLogs > 0:
+		resp.Reason = "observed_read_write_success"
+	case resp.IdleLogs == 0: // all Stalled or Failed
+		resp.State = StateUnhealthy
+		resp.Reason = "all_logs_failed_or_stalled"
+	default: // no healthy, but some idle -> quiet, not actively broken
+		resp.Reason = "idle_logs_present"
+	}
+	return resp
+}
+
+func (t *Tracker) snapshotLog(key logInstanceKey, logID int64, lh *logHealth, now time.Time) LogSnapshot {
+	snap := LogSnapshot{
+		BucketName:         key.bucketName,
+		RootPath:           key.rootPath,
+		LogID:              logID,
+		LastWriteSuccessMS: lh.writeSuccessMS.Load(),
+		LastWriteFailureMS: lh.writeFailureMS.Load(),
+		LastReadSuccessMS:  lh.readSuccessMS.Load(),
+		LastReadFailureMS:  lh.readFailureMS.Load(),
+	}
+	if rp := lh.failureReason.Load(); rp != nil {
+		snap.LastFailureReason = *rp
+	}
+	writeAttempt := lh.writeAttemptMS.Load()
+	snap.WriteState = t.classify(snap.LastWriteSuccessMS, snap.LastWriteFailureMS, writeAttempt, now, true)
+	snap.ReadState = t.classify(snap.LastReadSuccessMS, snap.LastReadFailureMS, 0, now, false)
+	snap.State = overallLogState(snap.WriteState, snap.ReadState)
+	return snap
+}
+
+// classify derives one direction's state. Stalled requires allowStall (writes) AND a
+// prior success (lastSuccess > 0): a never-succeeded log is Failed or Idle, not Stalled.
+func (t *Tracker) classify(lastSuccess, lastFailure, lastAttempt int64, now time.Time, allowStall bool) string {
+	if lastSuccess == 0 && lastFailure == 0 && lastAttempt == 0 {
+		return logStateIdle
+	}
+	nowMS := now.UnixMilli()
+	stallMS := int64(t.stallAfter / time.Millisecond)
+
+	if lastSuccess > 0 && nowMS-lastSuccess <= stallMS {
+		return logStateHealthy
+	}
+	if allowStall && lastSuccess > 0 && nowMS-lastSuccess > stallMS &&
+		lastAttempt > lastSuccess && lastAttempt > lastFailure {
+		return logStateStalled
+	}
+	if lastFailure > lastSuccess && nowMS-lastFailure <= stallMS {
+		return logStateFailed
+	}
+	return logStateIdle
+}
+
+// overallLogState combines the two directions, worst-wins: Stalled > Failed > Healthy > Idle.
+func overallLogState(writeState, readState string) string {
+	switch {
+	case writeState == logStateStalled || readState == logStateStalled:
+		return logStateStalled
+	case writeState == logStateFailed || readState == logStateFailed:
+		return logStateFailed
+	case writeState == logStateHealthy || readState == logStateHealthy:
+		return logStateHealthy
+	default:
+		return logStateIdle
+	}
+}
+
+// Report is the production entry point for the admin callback: nodeID from
+// metrics.NodeID, now from time.Now(), and state -> HTTP status.
+func (t *Tracker) Report(bucketFilter, rootPathFilter string) (Response, int) {
+	if t == nil {
+		return Response{State: StateHealthy, Reason: "no_observed_activity", Logs: []LogSnapshot{}}, http.StatusOK
+	}
+	resp := t.Snapshot(bucketFilter, rootPathFilter, metrics.NodeID, time.Now())
+	if resp.State == StateUnhealthy {
+		return resp, http.StatusServiceUnavailable
+	}
+	return resp, http.StatusOK
+}

--- a/common/runtime/loghealth/tracker.go
+++ b/common/runtime/loghealth/tracker.go
@@ -1,6 +1,7 @@
 package loghealth
 
 import (
+	"maps"
 	"net/http"
 	"sort"
 	"sync"
@@ -39,12 +40,17 @@ const (
 // Compile-time assertion that Tracker is an OpObserver.
 var _ metrics.OpObserver = (*Tracker)(nil)
 
-type logInstanceKey struct {
+// logKey is the full per-log identity. It is a comparable struct used directly
+// as a native map key, so lookups hash it in place without boxing or allocation
+// (unlike an interface-keyed sync.Map).
+type logKey struct {
 	bucketName string
 	rootPath   string
+	logID      int64
 }
 
-// logHealth is the lock-free per-log state, written via atomic stores under RLock.
+// logHealth is the lock-free per-log state. Once its *logHealth is published in
+// the map, every update is a plain atomic store — no lock is taken to record.
 type logHealth struct {
 	writeAttemptMS atomic.Int64
 	writeSuccessMS atomic.Int64
@@ -57,10 +63,16 @@ type logHealth struct {
 }
 
 // Tracker observes the metrics.Op stream and derives per-log read/write health.
+//
+// The hot path (recording an op on an already-seen log) is lock-free and
+// allocation-free: it atomically loads an immutable map snapshot and indexes it.
+// Only the first time a given log is observed does a writer take writerMu, clone
+// the map, insert the entry, and atomically swap the snapshot in (copy-on-write).
+// Thereafter the log's *logHealth never moves and updates are plain atomic stores.
 type Tracker struct {
-	mu         sync.RWMutex // guards map STRUCTURE only
 	stallAfter time.Duration
-	logs       map[logInstanceKey]map[int64]*logHealth
+	logs       atomic.Pointer[map[logKey]*logHealth]
+	writerMu   sync.Mutex // serializes copy-on-write inserts only; readers never take it
 }
 
 // LogSnapshot is the per-log view; (BucketName, RootPath, LogID) is the unique key.
@@ -100,10 +112,10 @@ func New(stallAfter time.Duration) *Tracker {
 	if stallAfter <= 0 {
 		stallAfter = DefaultStallAfter
 	}
-	return &Tracker{
-		stallAfter: stallAfter,
-		logs:       make(map[logInstanceKey]map[int64]*logHealth),
-	}
+	t := &Tracker{stallAfter: stallAfter}
+	empty := make(map[logKey]*logHealth)
+	t.logs.Store(&empty)
+	return t
 }
 
 // --- metrics.OpObserver ---
@@ -143,24 +155,24 @@ func (t *Tracker) OnOpEnd(op *metrics.Op, _ uint64, elapsed time.Duration, statu
 // --- internal record methods (unit-testable without metrics.Op) ---
 
 func (t *Tracker) get(bucketName, rootPath string, logID int64) *logHealth {
-	key := logInstanceKey{bucketName: bucketName, rootPath: rootPath}
-	t.mu.RLock()
-	lh := t.logs[key][logID] // indexing a nil inner map is safe -> nil
-	t.mu.RUnlock()
-	if lh != nil {
+	key := logKey{bucketName: bucketName, rootPath: rootPath, logID: logID}
+	// Fast path: lock-free, allocation-free read of the current snapshot.
+	if lh := (*t.logs.Load())[key]; lh != nil {
 		return lh
 	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	instanceLogs := t.logs[key]
-	if instanceLogs == nil {
-		instanceLogs = make(map[int64]*logHealth)
-		t.logs[key] = instanceLogs
+	// Slow path — first touch of this log. Clone-on-write under writerMu so the
+	// published map stays immutable for lock-free readers.
+	t.writerMu.Lock()
+	defer t.writerMu.Unlock()
+	cur := *t.logs.Load()
+	if lh := cur[key]; lh != nil {
+		return lh // another writer inserted it between our load and the lock
 	}
-	if lh = instanceLogs[logID]; lh == nil {
-		lh = &logHealth{}
-		instanceLogs[logID] = lh
-	}
+	next := make(map[logKey]*logHealth, len(cur)+1)
+	maps.Copy(next, cur)
+	lh := &logHealth{}
+	next[key] = lh
+	t.logs.Store(&next)
 	return lh
 }
 
@@ -219,16 +231,14 @@ func (t *Tracker) Snapshot(bucketFilter, rootPathFilter, nodeID string, now time
 	}
 	filtered := bucketFilter != "" && rootPathFilter != ""
 
-	t.mu.RLock()
-	for key, instanceLogs := range t.logs {
+	// Load the immutable snapshot once; iterating it needs no lock, and each
+	// log's per-direction fields are read atomically inside snapshotLog.
+	for key, lh := range *t.logs.Load() {
 		if filtered && (key.bucketName != bucketFilter || key.rootPath != rootPathFilter) {
 			continue
 		}
-		for logID, lh := range instanceLogs {
-			resp.Logs = append(resp.Logs, t.snapshotLog(key, logID, lh, now))
-		}
+		resp.Logs = append(resp.Logs, t.snapshotLog(key, lh, now))
 	}
-	t.mu.RUnlock()
 
 	sort.Slice(resp.Logs, func(i, j int) bool {
 		a, b := resp.Logs[i], resp.Logs[j]
@@ -269,11 +279,11 @@ func (t *Tracker) Snapshot(bucketFilter, rootPathFilter, nodeID string, now time
 	return resp
 }
 
-func (t *Tracker) snapshotLog(key logInstanceKey, logID int64, lh *logHealth, now time.Time) LogSnapshot {
+func (t *Tracker) snapshotLog(key logKey, lh *logHealth, now time.Time) LogSnapshot {
 	snap := LogSnapshot{
 		BucketName:         key.bucketName,
 		RootPath:           key.rootPath,
-		LogID:              logID,
+		LogID:              key.logID,
 		LastWriteSuccessMS: lh.writeSuccessMS.Load(),
 		LastWriteFailureMS: lh.writeFailureMS.Load(),
 		LastReadSuccessMS:  lh.readSuccessMS.Load(),

--- a/common/runtime/loghealth/tracker_test.go
+++ b/common/runtime/loghealth/tracker_test.go
@@ -217,3 +217,50 @@ func TestTracker_ReadEndOfFileIsHealthy(t *testing.T) {
 	require.Equal(t, 0, snap.FailedLogs)
 	require.Equal(t, StateHealthy, snap.State)
 }
+
+// TestTracker_RecordHotPathZeroAlloc pins the core performance contract: once a
+// log is known, recording an op outcome on it must not allocate. This is what
+// makes the observer "as light as metrics" on the hot path. It also guards the
+// implementation choice — e.g. a sync.Map keyed by a struct would box the key
+// into an interface and allocate on every call, which this test would catch.
+func TestTracker_RecordHotPathZeroAlloc(t *testing.T) {
+	tr := New(testStall)
+	now := time.UnixMilli(1_000_000)
+	// Warm up: first touch is the only path allowed to allocate (it creates the
+	// per-log state). Everything after must be allocation-free.
+	tr.recordWriteSuccess("b", "r", 1, now)
+
+	allocs := testing.AllocsPerRun(1000, func() {
+		tr.recordWriteAttempt("b", "r", 1, now)
+		tr.recordWriteSuccess("b", "r", 1, now)
+		tr.recordReadSuccess("b", "r", 1, now)
+	})
+	require.Zero(t, allocs, "recording on a known log must be zero-allocation on the hot path")
+}
+
+// TestTracker_ConcurrentInsertRaceFree stresses the new-log insert path: every
+// (goroutine, i) pair is a distinct log, so all goroutines race to create new
+// entries while others snapshot concurrently. It must be race-free (run with
+// -race) and lose no inserts — a copy-on-write writer that stores without a
+// re-check under its lock would drop entries and fail the final count.
+func TestTracker_ConcurrentInsertRaceFree(t *testing.T) {
+	tr := New(testStall)
+	now := time.UnixMilli(1_000_000)
+	const goroutines = 16
+	const perG = 200
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < perG; i++ {
+				id := int64(g*perG + i) // unique across all goroutines
+				tr.recordWriteAttempt("b", "r", id, now)
+				tr.recordWriteSuccess("b", "r", id, now)
+				_ = tr.Snapshot("", "", "n", now)
+			}
+		}(g)
+	}
+	wg.Wait()
+	require.Equal(t, goroutines*perG, tr.Snapshot("", "", "n", now).TrackedLogs)
+}

--- a/common/runtime/loghealth/tracker_test.go
+++ b/common/runtime/loghealth/tracker_test.go
@@ -184,3 +184,18 @@ func TestTracker_ObserverMapsOps(t *testing.T) {
 	require.Equal(t, logStateHealthy, byLog[1].WriteState)
 	require.Equal(t, logStateFailed, byLog[2].ReadState)
 }
+
+func TestTracker_FailureReasonPerDirection(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	// Write fails; later read succeeds. The write reason must survive.
+	tr.recordWriteFailure("b", "r", 1, now, "write boom")
+	tr.recordReadSuccess("b", "r", 1, now.Add(time.Second))
+	snap := tr.Snapshot("", "", "n", now.Add(2*time.Second))
+	require.Equal(t, "write boom", snap.Logs[0].LastFailureReason)
+
+	// A newer read failure should win over the older write failure.
+	tr.recordReadFailure("b", "r", 1, now.Add(3*time.Second), "read boom")
+	snap = tr.Snapshot("", "", "n", now.Add(4*time.Second))
+	require.Equal(t, "read boom", snap.Logs[0].LastFailureReason)
+}

--- a/common/runtime/loghealth/tracker_test.go
+++ b/common/runtime/loghealth/tracker_test.go
@@ -1,0 +1,186 @@
+package loghealth
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/woodpecker/common/metrics"
+)
+
+const testStall = 10 * time.Minute
+
+func TestTracker_NilSafe(t *testing.T) {
+	var tr *Tracker
+	tr.OnOpStart(&metrics.Op{OpType: opAddEntry})
+	tr.OnOpEnd(&metrics.Op{OpType: opAddEntry}, 0, time.Second, "success")
+	resp, code := tr.Report("", "")
+	require.Equal(t, StateHealthy, resp.State)
+	require.Equal(t, 200, code)
+}
+
+func TestTracker_NoActivityHealthy(t *testing.T) {
+	tr := New(testStall)
+	snap := tr.Snapshot("", "", "node-1", time.UnixMilli(1000))
+	require.Equal(t, StateHealthy, snap.State)
+	require.Equal(t, "no_observed_activity", snap.Reason)
+	require.Equal(t, 0, snap.TrackedLogs)
+	require.Equal(t, "node-1", snap.NodeID)
+}
+
+func TestTracker_RecentWriteSuccessHealthy(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	tr.recordWriteAttempt("b", "r", 1, now)
+	tr.recordWriteSuccess("b", "r", 1, now.Add(time.Second))
+	snap := tr.Snapshot("", "", "n", now.Add(2*time.Second))
+	require.Equal(t, 1, snap.HealthyLogs)
+	require.Equal(t, logStateHealthy, snap.Logs[0].WriteState)
+	require.Equal(t, "b", snap.Logs[0].BucketName)
+	require.Equal(t, "r", snap.Logs[0].RootPath)
+	require.Equal(t, int64(1), snap.Logs[0].LogID)
+}
+
+func TestTracker_OverallWorstOfReadWrite(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	tr.recordWriteSuccess("b", "r", 1, now)
+	tr.recordReadFailure("b", "r", 1, now.Add(time.Second), "read boom")
+	snap := tr.Snapshot("", "", "n", now.Add(2*time.Second))
+	require.Equal(t, logStateHealthy, snap.Logs[0].WriteState)
+	require.Equal(t, logStateFailed, snap.Logs[0].ReadState)
+	require.Equal(t, logStateFailed, snap.Logs[0].State)
+	require.Equal(t, "read boom", snap.Logs[0].LastFailureReason)
+}
+
+func TestTracker_HungWriteStalledUnderLoad(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	tr.recordWriteSuccess("b", "r", 1, now)
+	tr.recordWriteAttempt("b", "r", 1, now.Add(12*time.Minute))
+	snap := tr.Snapshot("", "", "n", now.Add(12*time.Minute+time.Second))
+	require.Equal(t, logStateStalled, snap.Logs[0].WriteState)
+	require.Equal(t, 1, snap.StalledLogs)
+	require.Equal(t, StateUnhealthy, snap.State)
+	require.Equal(t, "all_logs_failed_or_stalled", snap.Reason)
+}
+
+func TestTracker_NeverSucceededNotStalled(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	tr.recordWriteAttempt("b", "r", 1, now)
+	snap := tr.Snapshot("", "", "n", now.Add(30*time.Minute))
+	require.Equal(t, logStateIdle, snap.Logs[0].WriteState)
+}
+
+func TestTracker_ReadNeverStalls(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	tr.recordReadSuccess("b", "r", 1, now)
+	snap := tr.Snapshot("", "", "n", now.Add(20*time.Minute))
+	require.Equal(t, logStateIdle, snap.Logs[0].ReadState)
+	require.Equal(t, logStateIdle, snap.Logs[0].State)
+	require.Equal(t, StateHealthy, snap.State)
+}
+
+func TestTracker_IdleNodeStaysHealthy(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	tr.recordWriteSuccess("b", "r", 1, now)
+	tr.recordWriteFailure("b", "r", 2, now, "old fail")
+	snap := tr.Snapshot("", "", "n", now.Add(30*time.Minute))
+	require.Equal(t, 2, snap.IdleLogs)
+	require.Equal(t, 0, snap.HealthyLogs)
+	require.Equal(t, 0, snap.FailedLogs)
+	require.Equal(t, StateHealthy, snap.State)
+}
+
+func TestTracker_UnhealthyOnlyWhenAllActiveFailures(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	tr.recordWriteFailure("b", "r", 1, now, "f1")
+	tr.recordWriteFailure("b", "r", 2, now, "f2")
+	snap := tr.Snapshot("", "", "n", now.Add(time.Second))
+	require.Equal(t, 2, snap.FailedLogs)
+	require.Equal(t, StateUnhealthy, snap.State)
+	require.Equal(t, "all_logs_failed_or_stalled", snap.Reason)
+}
+
+func TestTracker_HealthyIfAnyHealthy(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	tr.recordWriteSuccess("b", "r", 1, now)
+	tr.recordWriteFailure("b", "r", 2, now, "f2")
+	snap := tr.Snapshot("", "", "n", now.Add(time.Second))
+	require.Equal(t, 1, snap.HealthyLogs)
+	require.Equal(t, 1, snap.FailedLogs)
+	require.Equal(t, StateHealthy, snap.State)
+	require.Equal(t, "observed_read_write_success", snap.Reason)
+}
+
+func TestTracker_MultiTenantAndFilter(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	tr.recordWriteSuccess("bucket-a", "root-a", 1, now)
+	tr.recordWriteSuccess("bucket-b", "root-b", 7, now)
+	all := tr.Snapshot("", "", "n", now.Add(time.Second))
+	require.Equal(t, 2, all.TrackedLogs)
+	require.Equal(t, "bucket-a", all.Logs[0].BucketName)
+	require.Equal(t, "bucket-b", all.Logs[1].BucketName)
+	filtered := tr.Snapshot("bucket-b", "root-b", "n", now.Add(time.Second))
+	require.Equal(t, 1, filtered.TrackedLogs)
+	require.Equal(t, int64(7), filtered.Logs[0].LogID)
+	require.Equal(t, "bucket-b", filtered.FilterBucketName)
+}
+
+func TestTracker_ReportStatusCode(t *testing.T) {
+	now := time.Now()
+	tr := New(testStall)
+	tr.recordWriteFailure("b", "r", 1, now, "boom")
+	resp, code := tr.Report("", "")
+	require.Equal(t, StateUnhealthy, resp.State)
+	require.Equal(t, 503, code)
+}
+
+func TestTracker_ConcurrentRaceFree(t *testing.T) {
+	tr := New(testStall)
+	now := time.UnixMilli(1_000_000)
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				id := int64(i % 4)
+				tr.recordWriteAttempt("b", "r", id, now)
+				tr.recordWriteSuccess("b", "r", id, now)
+				_ = tr.Snapshot("", "", "n", now)
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, 4, tr.Snapshot("", "", "n", now).TrackedLogs)
+}
+
+func TestTracker_ObserverMapsOps(t *testing.T) {
+	metrics.ResetObservers()
+	defer metrics.ResetObservers()
+	tr := New(testStall)
+	metrics.RegisterOpObserver(tr)
+
+	w := metrics.StartOp(opAddEntry, nil, nil, metrics.WithInstance("b", "r"), metrics.WithLogSegment(1, 0))
+	w.End("success")
+	r := metrics.StartOp(opGetBatchEntries, nil, nil, metrics.WithInstance("b", "r"), metrics.WithLogSegment(2, 0))
+	r.End("error")
+
+	snap := tr.Snapshot("", "", "n", time.Now())
+	require.Equal(t, 2, snap.TrackedLogs)
+	byLog := map[int64]LogSnapshot{}
+	for _, l := range snap.Logs {
+		byLog[l.LogID] = l
+	}
+	require.Equal(t, logStateHealthy, byLog[1].WriteState)
+	require.Equal(t, logStateFailed, byLog[2].ReadState)
+}

--- a/common/runtime/loghealth/tracker_test.go
+++ b/common/runtime/loghealth/tracker_test.go
@@ -199,3 +199,21 @@ func TestTracker_FailureReasonPerDirection(t *testing.T) {
 	snap = tr.Snapshot("", "", "n", now.Add(4*time.Second))
 	require.Equal(t, "read boom", snap.Logs[0].LastFailureReason)
 }
+
+func TestTracker_ReadEndOfFileIsHealthy(t *testing.T) {
+	metrics.ResetObservers()
+	defer metrics.ResetObservers()
+	tr := New(testStall)
+	metrics.RegisterOpObserver(tr)
+
+	// A caught-up tail read ends with the end_of_file status — must count as a
+	// healthy read, not a failure.
+	r := metrics.StartOp(opGetBatchEntries, nil, nil, metrics.WithInstance("b", "r"), metrics.WithLogSegment(5, 0))
+	r.End("end_of_file")
+
+	snap := tr.Snapshot("", "", "n", time.Now())
+	require.Equal(t, 1, snap.TrackedLogs)
+	require.Equal(t, logStateHealthy, snap.Logs[0].ReadState)
+	require.Equal(t, 0, snap.FailedLogs)
+	require.Equal(t, StateHealthy, snap.State)
+}

--- a/docs/superpowers/plans/2026-06-01-log-health.md
+++ b/docs/superpowers/plans/2026-06-01-log-health.md
@@ -1,0 +1,970 @@
+# Log Health Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the in-progress `rw_health` draft with a lightweight, node-wide, multi-tenant per-log read/write health probe (`log_health`) derived from real traffic, exposed at `GET /admin/log-health`.
+
+**Architecture:** A `LogHealthTracker` keeps a few `atomic.Int64` timestamps per `(bucket, rootPath, logID)`. The write path (`AddEntry`) and read path (`GetBatchEntriesAdv`) record attempt/success/failure timestamps with a shared `RLock` + atomic store (no per-write allocation, no exclusive lock). At snapshot time each log is classified Healthy/Stalled/Failed/Idle from those timestamps. One HTTP endpoint returns all tracked logs (optionally filtered to one tenant) plus a node rollup. The earlier cluster fan-out / quorum / pending-map code is deleted.
+
+**Tech Stack:** Go, `sync/atomic`, `net/http`, `testify`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-log-health-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `server/log_health.go` | Create (replaces `server/rw_health.go`) | `LogHealthTracker`, record methods, classification, `Snapshot`, `Server.GetLogHealth` |
+| `server/rw_health.go` | Delete | superseded |
+| `server/log_health_test.go` | Create (replaces `server/rw_health_test.go`) | tracker unit tests |
+| `server/rw_health_test.go` | Delete | superseded |
+| `server/service.go` | Modify | rename field; simplify write instrumentation; add read instrumentation |
+| `server/service_test.go` | Modify | rename symbols in helpers + assertions |
+| `common/http/management/log_health_handler.go` | Create (replaces `rw_health_handler.go`) | HTTP handler + optional filter parsing |
+| `common/http/management/rw_health_handler.go` | Delete | superseded |
+| `common/http/management/log_health_handler_test.go` | Create (replaces `rw_health_handler_test.go`) | handler tests |
+| `common/http/management/rw_health_handler_test.go` | Delete | superseded |
+| `common/http/router.go` | Modify | one route const `AdminLogHealthPath`, drop the two RW consts |
+| `common/http/server.go` | Modify | one callback field + one registration block |
+| `cmd/main.go` | Modify | one callback wiring |
+| `common/http/README.md` | Modify | document `/admin/log-health`, drop the two RW rows |
+
+**Compilation note (Go packages compile as a unit):** `cmd` imports `server` and `common/http`, which imports `common/http/management`. Renaming symbols therefore breaks the full module build until every task is done. So:
+- **Task 1** keeps package `server` self-consistent → verify with `go test ./server/...` (NOT a full `go build ./...`, which stays red until Task 2).
+- **Task 2** completes `management` + `common/http` + `cmd` → `go build ./...` goes green.
+- **Task 3** is docs + final full verification.
+
+---
+
+## Task 1: Rewrite the tracker and instrument the data path (package `server`)
+
+**Files:**
+- Create: `server/log_health.go`
+- Delete: `server/rw_health.go`
+- Create: `server/log_health_test.go`
+- Delete: `server/rw_health_test.go`
+- Modify: `server/service.go` (field at `:54`, constructor at `:129`, `AddEntry` `:365-441`, `GetBatchEntriesAdv` `:452-460`)
+- Modify: `server/service_test.go` (`:55`, `:509`, `:974-977`, `:1001-1004`)
+
+- [ ] **Step 1: Write the new tracker test file**
+
+Delete the old test and write the new one:
+
+```bash
+git rm server/rw_health_test.go
+```
+
+Create `server/log_health_test.go`:
+
+```go
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/woodpecker/common/membership"
+)
+
+const testStall = 10 * time.Minute
+
+func TestLogHealth_NilTrackerSafe(t *testing.T) {
+	var tr *LogHealthTracker
+	// none of these should panic
+	tr.RecordWriteAttempt("b", "r", 1, time.UnixMilli(1000))
+	tr.RecordWriteSuccess("b", "r", 1, time.UnixMilli(1000))
+	tr.RecordWriteFailure("b", "r", 1, time.UnixMilli(1000), "x")
+	tr.RecordReadSuccess("b", "r", 1, time.UnixMilli(1000))
+	tr.RecordReadFailure("b", "r", 1, time.UnixMilli(1000), "x")
+}
+
+func TestLogHealth_NoActivityHealthy(t *testing.T) {
+	tr := NewLogHealthTracker(testStall)
+	snap := tr.Snapshot("", "", "node-1", time.UnixMilli(1000))
+	require.Equal(t, LogHealthStateHealthy, snap.State)
+	require.Equal(t, "no_observed_activity", snap.Reason)
+	require.Equal(t, 0, snap.TrackedLogs)
+	require.Equal(t, "node-1", snap.NodeID)
+}
+
+func TestLogHealth_RecentWriteSuccessIsHealthy(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := NewLogHealthTracker(testStall)
+	tr.RecordWriteAttempt("b", "r", 1, now)
+	tr.RecordWriteSuccess("b", "r", 1, now.Add(time.Second))
+
+	snap := tr.Snapshot("", "", "node-1", now.Add(2*time.Second))
+	require.Equal(t, 1, snap.TrackedLogs)
+	require.Equal(t, 1, snap.HealthyLogs)
+	require.Equal(t, LogHealthStateHealthy, snap.State)
+	require.Equal(t, logStateHealthy, snap.Logs[0].WriteState)
+	require.Equal(t, "b", snap.Logs[0].BucketName)
+	require.Equal(t, "r", snap.Logs[0].RootPath)
+	require.Equal(t, int64(1), snap.Logs[0].LogID)
+}
+
+func TestLogHealth_RecentReadFailureIsFailed(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := NewLogHealthTracker(testStall)
+	tr.RecordWriteSuccess("b", "r", 1, now)            // write healthy
+	tr.RecordReadFailure("b", "r", 1, now.Add(time.Second), "read boom")
+
+	snap := tr.Snapshot("", "", "node-1", now.Add(2*time.Second))
+	// overall = worst(Healthy write, Failed read) = Failed
+	require.Equal(t, logStateHealthy, snap.Logs[0].WriteState)
+	require.Equal(t, logStateFailed, snap.Logs[0].ReadState)
+	require.Equal(t, logStateFailed, snap.Logs[0].State)
+	require.Equal(t, "read boom", snap.Logs[0].LastFailureReason)
+}
+
+func TestLogHealth_HungWriteBecomesStalledUnderLoad(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := NewLogHealthTracker(testStall)
+	// One real success long ago, then attempts keep coming but never complete.
+	tr.RecordWriteSuccess("b", "r", 1, now)
+	tr.RecordWriteAttempt("b", "r", 1, now.Add(12*time.Minute)) // recent attempt, no success/failure after
+
+	snap := tr.Snapshot("", "", "node-1", now.Add(12*time.Minute+time.Second))
+	require.Equal(t, logStateStalled, snap.Logs[0].WriteState)
+	require.Equal(t, 1, snap.StalledLogs)
+	require.Equal(t, LogHealthStateUnhealthy, snap.State)
+	require.Equal(t, "all_logs_failed_or_stalled", snap.Reason)
+}
+
+func TestLogHealth_ReadNeverStalls(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := NewLogHealthTracker(testStall)
+	tr.RecordReadSuccess("b", "r", 1, now) // success then 20 min of silence on reads
+
+	snap := tr.Snapshot("", "", "node-1", now.Add(20*time.Minute))
+	// reads have no attempt timestamp; stale success -> Idle, never Stalled
+	require.Equal(t, logStateIdle, snap.Logs[0].ReadState)
+	require.Equal(t, logStateIdle, snap.Logs[0].State)
+	require.Equal(t, 1, snap.IdleLogs)
+	require.Equal(t, LogHealthStateHealthy, snap.State) // idle never forces Unhealthy
+}
+
+func TestLogHealth_IdleNodeStaysHealthy(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := NewLogHealthTracker(testStall)
+	tr.RecordWriteSuccess("b", "r", 1, now) // healthy log, goes quiet
+	tr.RecordWriteFailure("b", "r", 2, now, "old fail") // a stale failure
+
+	snap := tr.Snapshot("", "", "node-1", now.Add(30*time.Minute))
+	require.Equal(t, 2, snap.TrackedLogs)
+	require.Equal(t, 2, snap.IdleLogs) // both went idle (stale)
+	require.Equal(t, 0, snap.HealthyLogs)
+	require.Equal(t, 0, snap.FailedLogs)
+	require.Equal(t, LogHealthStateHealthy, snap.State) // quiet node not pulled out
+}
+
+func TestLogHealth_UnhealthyOnlyWhenAllActiveFailures(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := NewLogHealthTracker(testStall)
+	tr.RecordWriteFailure("b", "r", 1, now, "f1")
+	tr.RecordWriteFailure("b", "r", 2, now, "f2")
+
+	snap := tr.Snapshot("", "", "node-1", now.Add(time.Second))
+	require.Equal(t, 2, snap.FailedLogs)
+	require.Equal(t, LogHealthStateUnhealthy, snap.State)
+	require.Equal(t, "all_logs_failed_or_stalled", snap.Reason)
+}
+
+func TestLogHealth_HealthyIfAnyLogHealthy(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := NewLogHealthTracker(testStall)
+	tr.RecordWriteSuccess("b", "r", 1, now)
+	tr.RecordWriteFailure("b", "r", 2, now, "f2")
+
+	snap := tr.Snapshot("", "", "node-1", now.Add(time.Second))
+	require.Equal(t, 1, snap.HealthyLogs)
+	require.Equal(t, 1, snap.FailedLogs)
+	require.Equal(t, LogHealthStateHealthy, snap.State)
+	require.Equal(t, "observed_read_write_success", snap.Reason)
+}
+
+func TestLogHealth_MultiTenantAndFilter(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := NewLogHealthTracker(testStall)
+	tr.RecordWriteSuccess("bucket-a", "root-a", 1, now)
+	tr.RecordWriteSuccess("bucket-b", "root-b", 7, now)
+
+	all := tr.Snapshot("", "", "node-1", now.Add(time.Second))
+	require.Equal(t, 2, all.TrackedLogs)
+	// sorted by (bucket, root, logID)
+	require.Equal(t, "bucket-a", all.Logs[0].BucketName)
+	require.Equal(t, "bucket-b", all.Logs[1].BucketName)
+
+	filtered := tr.Snapshot("bucket-b", "root-b", "node-1", now.Add(time.Second))
+	require.Equal(t, 1, filtered.TrackedLogs)
+	require.Equal(t, int64(7), filtered.Logs[0].LogID)
+	require.Equal(t, "bucket-b", filtered.FilterBucketName)
+}
+
+func TestLogHealth_ConcurrentRecordsRaceFree(t *testing.T) {
+	tr := NewLogHealthTracker(testStall)
+	now := time.UnixMilli(1_000_000)
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 1000; i++ {
+				logID := int64(i % 4)
+				tr.RecordWriteAttempt("b", "r", logID, now)
+				tr.RecordWriteSuccess("b", "r", logID, now)
+				_ = tr.Snapshot("", "", "node-1", now)
+			}
+		}(g)
+	}
+	wg.Wait()
+	snap := tr.Snapshot("", "", "node-1", now)
+	require.Equal(t, 4, snap.TrackedLogs)
+}
+
+func TestServer_GetLogHealth_StatusCode(t *testing.T) {
+	s := createTestServer(context.Background(), &membership.ServerConfig{NodeID: "node-1"})
+	defer s.cancel()
+
+	s.logHealthTracker.RecordWriteFailure("bucket-a", "root-a", 1, time.Now(), "sync failed")
+
+	resp, statusCode := s.GetLogHealth(context.Background(), "", "")
+	assert.Equal(t, LogHealthStateUnhealthy, resp.State)
+	assert.Equal(t, 503, statusCode)
+}
+```
+
+- [ ] **Step 2: Replace the implementation file**
+
+```bash
+git rm server/rw_health.go
+```
+
+Create `server/log_health.go`:
+
+```go
+package server
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	// Node-level rollup states.
+	LogHealthStateHealthy   = "Healthy"
+	LogHealthStateUnhealthy = "Unhealthy"
+
+	// Per-log / per-direction states.
+	logStateHealthy = "Healthy"
+	logStateFailed  = "Failed"
+	logStateStalled = "Stalled"
+	logStateIdle    = "Idle"
+
+	defaultLogHealthStallAfter = 10 * time.Minute
+)
+
+type logInstanceKey struct {
+	bucketName string
+	rootPath   string
+}
+
+// logHealth holds the lock-free per-log state. All fields are written from the
+// hot path with atomic stores under a shared RLock.
+type logHealth struct {
+	writeAttemptMS atomic.Int64 // when a write started (writes can hang in-flight)
+	writeSuccessMS atomic.Int64
+	writeFailureMS atomic.Int64
+	readSuccessMS  atomic.Int64 // reads are synchronous -> no attempt timestamp
+	readFailureMS  atomic.Int64
+	failureReason  atomic.Pointer[string]
+}
+
+// LogHealthTracker tracks read/write outcomes per (bucket, rootPath, logID).
+type LogHealthTracker struct {
+	mu         sync.RWMutex // guards map STRUCTURE only
+	stallAfter time.Duration
+	logs       map[logInstanceKey]map[int64]*logHealth
+}
+
+// LogHealthSnapshot is the per-log view. The triple (BucketName, RootPath, LogID)
+// uniquely identifies a log on this node.
+type LogHealthSnapshot struct {
+	BucketName         string `json:"bucket_name"`
+	RootPath           string `json:"root_path"`
+	LogID              int64  `json:"log_id"`
+	State              string `json:"state"`
+	WriteState         string `json:"write_state"`
+	ReadState          string `json:"read_state"`
+	LastWriteSuccessMS int64  `json:"last_write_success_ms,omitempty"`
+	LastWriteFailureMS int64  `json:"last_write_failure_ms,omitempty"`
+	LastReadSuccessMS  int64  `json:"last_read_success_ms,omitempty"`
+	LastReadFailureMS  int64  `json:"last_read_failure_ms,omitempty"`
+	LastFailureReason  string `json:"last_failure_reason,omitempty"`
+}
+
+// LogHealthResponse is the node-wide response, optionally filtered to one tenant.
+type LogHealthResponse struct {
+	State            string              `json:"state"`
+	Reason           string              `json:"reason"`
+	NodeID           string              `json:"node_id,omitempty"`
+	FilterBucketName string              `json:"filter_bucket_name,omitempty"`
+	FilterRootPath   string              `json:"filter_root_path,omitempty"`
+	TimestampMS      int64               `json:"timestamp_ms"`
+	StallAfterMS     int64               `json:"stall_after_ms"`
+	TrackedLogs      int                 `json:"tracked_logs"`
+	HealthyLogs      int                 `json:"healthy_logs"`
+	FailedLogs       int                 `json:"failed_logs"`
+	StalledLogs      int                 `json:"stalled_logs"`
+	IdleLogs         int                 `json:"idle_logs"`
+	Logs             []LogHealthSnapshot `json:"logs"`
+}
+
+func NewLogHealthTracker(stallAfter time.Duration) *LogHealthTracker {
+	if stallAfter <= 0 {
+		stallAfter = defaultLogHealthStallAfter
+	}
+	return &LogHealthTracker{
+		stallAfter: stallAfter,
+		logs:       make(map[logInstanceKey]map[int64]*logHealth),
+	}
+}
+
+// get returns the *logHealth for a log, creating it on first use. The common case
+// (log already exists) takes only a shared RLock; creation takes the write lock once.
+func (t *LogHealthTracker) get(bucketName, rootPath string, logID int64) *logHealth {
+	key := logInstanceKey{bucketName: bucketName, rootPath: rootPath}
+	t.mu.RLock()
+	lh := t.logs[key][logID] // indexing a nil inner map is safe and returns nil
+	t.mu.RUnlock()
+	if lh != nil {
+		return lh
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	instanceLogs := t.logs[key]
+	if instanceLogs == nil {
+		instanceLogs = make(map[int64]*logHealth)
+		t.logs[key] = instanceLogs
+	}
+	if lh = instanceLogs[logID]; lh == nil {
+		lh = &logHealth{}
+		instanceLogs[logID] = lh
+	}
+	return lh
+}
+
+func (t *LogHealthTracker) RecordWriteAttempt(bucketName, rootPath string, logID int64, now time.Time) {
+	if t == nil {
+		return
+	}
+	t.get(bucketName, rootPath, logID).writeAttemptMS.Store(now.UnixMilli())
+}
+
+func (t *LogHealthTracker) RecordWriteSuccess(bucketName, rootPath string, logID int64, now time.Time) {
+	if t == nil {
+		return
+	}
+	t.get(bucketName, rootPath, logID).writeSuccessMS.Store(now.UnixMilli())
+}
+
+func (t *LogHealthTracker) RecordWriteFailure(bucketName, rootPath string, logID int64, now time.Time, reason string) {
+	if t == nil {
+		return
+	}
+	lh := t.get(bucketName, rootPath, logID)
+	lh.writeFailureMS.Store(now.UnixMilli())
+	lh.failureReason.Store(&reason)
+}
+
+func (t *LogHealthTracker) RecordReadSuccess(bucketName, rootPath string, logID int64, now time.Time) {
+	if t == nil {
+		return
+	}
+	t.get(bucketName, rootPath, logID).readSuccessMS.Store(now.UnixMilli())
+}
+
+func (t *LogHealthTracker) RecordReadFailure(bucketName, rootPath string, logID int64, now time.Time, reason string) {
+	if t == nil {
+		return
+	}
+	lh := t.get(bucketName, rootPath, logID)
+	lh.readFailureMS.Store(now.UnixMilli())
+	lh.failureReason.Store(&reason)
+}
+
+// Snapshot returns the health of all tracked logs. When both bucketFilter and
+// rootPathFilter are non-empty, the result is narrowed to that one instance;
+// otherwise all tenants are returned.
+func (t *LogHealthTracker) Snapshot(bucketFilter, rootPathFilter, nodeID string, now time.Time) LogHealthResponse {
+	resp := LogHealthResponse{
+		State:            LogHealthStateHealthy,
+		Reason:           "no_observed_activity",
+		NodeID:           nodeID,
+		FilterBucketName: bucketFilter,
+		FilterRootPath:   rootPathFilter,
+		TimestampMS:      now.UnixMilli(),
+		StallAfterMS:     int64(t.stallAfter / time.Millisecond),
+		Logs:             []LogHealthSnapshot{},
+	}
+	filtered := bucketFilter != "" && rootPathFilter != ""
+
+	t.mu.RLock()
+	for key, instanceLogs := range t.logs {
+		if filtered && (key.bucketName != bucketFilter || key.rootPath != rootPathFilter) {
+			continue
+		}
+		for logID, lh := range instanceLogs {
+			resp.Logs = append(resp.Logs, t.snapshotLog(key, logID, lh, now))
+		}
+	}
+	t.mu.RUnlock()
+
+	sort.Slice(resp.Logs, func(i, j int) bool {
+		a, b := resp.Logs[i], resp.Logs[j]
+		if a.BucketName != b.BucketName {
+			return a.BucketName < b.BucketName
+		}
+		if a.RootPath != b.RootPath {
+			return a.RootPath < b.RootPath
+		}
+		return a.LogID < b.LogID
+	})
+
+	resp.TrackedLogs = len(resp.Logs)
+	for _, s := range resp.Logs {
+		switch s.State {
+		case logStateHealthy:
+			resp.HealthyLogs++
+		case logStateFailed:
+			resp.FailedLogs++
+		case logStateStalled:
+			resp.StalledLogs++
+		case logStateIdle:
+			resp.IdleLogs++
+		}
+	}
+
+	switch {
+	case resp.TrackedLogs == 0:
+		// keep Healthy / no_observed_activity
+	case resp.HealthyLogs > 0:
+		resp.Reason = "observed_read_write_success"
+	case resp.IdleLogs == 0: // all logs are Stalled or Failed
+		resp.State = LogHealthStateUnhealthy
+		resp.Reason = "all_logs_failed_or_stalled"
+	default: // no healthy logs, but some idle -> quiet, not actively broken
+		resp.Reason = "idle_logs_present"
+	}
+	return resp
+}
+
+func (t *LogHealthTracker) snapshotLog(key logInstanceKey, logID int64, lh *logHealth, now time.Time) LogHealthSnapshot {
+	snap := LogHealthSnapshot{
+		BucketName:         key.bucketName,
+		RootPath:           key.rootPath,
+		LogID:              logID,
+		LastWriteSuccessMS: lh.writeSuccessMS.Load(),
+		LastWriteFailureMS: lh.writeFailureMS.Load(),
+		LastReadSuccessMS:  lh.readSuccessMS.Load(),
+		LastReadFailureMS:  lh.readFailureMS.Load(),
+	}
+	if r := lh.failureReason.Load(); r != nil {
+		snap.LastFailureReason = *r
+	}
+	writeAttempt := lh.writeAttemptMS.Load()
+	snap.WriteState = t.classify(snap.LastWriteSuccessMS, snap.LastWriteFailureMS, writeAttempt, now, true)
+	snap.ReadState = t.classify(snap.LastReadSuccessMS, snap.LastReadFailureMS, 0, now, false)
+	snap.State = overallLogState(snap.WriteState, snap.ReadState)
+	return snap
+}
+
+// classify derives one direction's state from its timestamps. Stalled is only
+// reachable when allowStall is true (writes) AND the log was previously healthy
+// (lastSuccess > 0): a never-succeeded log is Failed or Idle, never Stalled.
+func (t *LogHealthTracker) classify(lastSuccess, lastFailure, lastAttempt int64, now time.Time, allowStall bool) string {
+	if lastSuccess == 0 && lastFailure == 0 && lastAttempt == 0 {
+		return logStateIdle // no activity in this direction
+	}
+	nowMS := now.UnixMilli()
+	stallMS := int64(t.stallAfter / time.Millisecond)
+
+	if lastSuccess > 0 && nowMS-lastSuccess <= stallMS {
+		return logStateHealthy
+	}
+	if allowStall && lastSuccess > 0 && nowMS-lastSuccess > stallMS &&
+		lastAttempt > lastSuccess && lastAttempt > lastFailure {
+		return logStateStalled
+	}
+	if lastFailure > lastSuccess && nowMS-lastFailure <= stallMS {
+		return logStateFailed
+	}
+	return logStateIdle
+}
+
+// overallLogState combines the two direction-states, worst-wins:
+// Stalled > Failed > Healthy > Idle.
+func overallLogState(writeState, readState string) string {
+	switch {
+	case writeState == logStateStalled || readState == logStateStalled:
+		return logStateStalled
+	case writeState == logStateFailed || readState == logStateFailed:
+		return logStateFailed
+	case writeState == logStateHealthy || readState == logStateHealthy:
+		return logStateHealthy
+	default:
+		return logStateIdle
+	}
+}
+
+// GetLogHealth builds the node-wide snapshot. Empty filters mean "all tenants".
+func (s *Server) GetLogHealth(_ context.Context, bucketFilter, rootPathFilter string) (LogHealthResponse, int) {
+	tracker := s.logHealthTracker
+	if tracker == nil {
+		tracker = NewLogHealthTracker(defaultLogHealthStallAfter)
+	}
+	nodeID := ""
+	if s.serverConfig != nil {
+		nodeID = s.serverConfig.NodeID
+	}
+	resp := tracker.Snapshot(bucketFilter, rootPathFilter, nodeID, time.Now())
+	if resp.State == LogHealthStateUnhealthy {
+		return resp, http.StatusServiceUnavailable
+	}
+	return resp, http.StatusOK
+}
+```
+
+- [ ] **Step 3: Update `server/service.go`**
+
+3a. Rename the struct field at `server/service.go:54`:
+
+```go
+	logHealthTracker      *LogHealthTracker
+```
+
+3b. Rename the constructor field at `server/service.go:129`:
+
+```go
+		logHealthTracker: NewLogHealthTracker(defaultLogHealthStallAfter),
+```
+
+3c. Replace the write attempt block at `:365-368`:
+
+```go
+	if s.logHealthTracker != nil {
+		s.logHealthTracker.RecordWriteAttempt(request.BucketName, request.RootPath, request.LogId, time.Now())
+	}
+```
+
+3d. Replace the buffer-error block at `:375-377`:
+
+```go
+		if s.logHealthTracker != nil {
+			s.logHealthTracker.RecordWriteFailure(request.BucketName, request.RootPath, request.LogId, time.Now(), err.Error())
+		}
+```
+
+3e. Remove the send-buffered-failure tracking entirely (old `:399-401`). A transport send failure is the client giving up, not a storage fault — so the block becomes just the existing log line:
+
+```go
+	if sendErr != nil {
+		logger.Ctx(streamCtx).Warn("failed to send buffered response", zap.Error(sendErr))
+		return sendErr
+	}
+```
+
+3f. Replace the ReadResult-error block at `:408-414`:
+
+```go
+		if s.logHealthTracker != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				// client gave up — not a storage fault, no-op
+			} else {
+				s.logHealthTracker.RecordWriteFailure(request.BucketName, request.RootPath, request.LogId, time.Now(), err.Error())
+			}
+		}
+```
+
+3g. Replace the result.Err block at `:428-430`:
+
+```go
+		if s.logHealthTracker != nil {
+			s.logHealthTracker.RecordWriteFailure(request.BucketName, request.RootPath, request.LogId, time.Now(), result.Err.Error())
+		}
+```
+
+3h. Replace the success block at `:439-441`:
+
+```go
+	if s.logHealthTracker != nil {
+		s.logHealthTracker.RecordWriteSuccess(request.BucketName, request.RootPath, request.LogId, time.Now())
+	}
+```
+
+3i. Add read instrumentation in `GetBatchEntriesAdv` (`:452-460`). Replace the whole function body:
+
+```go
+func (s *Server) GetBatchEntriesAdv(ctx context.Context, request *proto.GetBatchEntriesAdvRequest) (*proto.GetBatchEntriesAdvResponse, error) {
+	result, err := s.logStore.GetBatchEntriesAdv(ctx, request.BucketName, request.RootPath, request.LogId, request.SegmentId, request.FromEntryId, request.MaxEntries, request.LastReadState)
+	if err != nil {
+		if s.logHealthTracker != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				// client gave up — not a storage fault, no-op
+			} else {
+				s.logHealthTracker.RecordReadFailure(request.BucketName, request.RootPath, request.LogId, time.Now(), err.Error())
+			}
+		}
+		return &proto.GetBatchEntriesAdvResponse{
+			Status: werr.Status(err),
+		}, nil
+	}
+	if s.logHealthTracker != nil {
+		s.logHealthTracker.RecordReadSuccess(request.BucketName, request.RootPath, request.LogId, time.Now())
+	}
+	return &proto.GetBatchEntriesAdvResponse{Status: werr.Success(), Result: result}, nil
+}
+```
+
+(The `errors` import added by the draft at `server/service.go:22` stays — it's still used.)
+
+- [ ] **Step 4: Update `server/service_test.go`**
+
+4a. Rename the field in both helpers (`:55` and `:509`):
+
+```go
+		logHealthTracker: NewLogHealthTracker(defaultLogHealthStallAfter),
+```
+
+4b. Replace the assertions in `TestServer_AddEntry_Success` (`:974-977`):
+
+```go
+	health, statusCode := s.GetLogHealth(context.Background(), "", "")
+	assert.Equal(t, 200, statusCode)
+	assert.Equal(t, LogHealthStateHealthy, health.State)
+	assert.Equal(t, 1, health.HealthyLogs)
+```
+
+4c. Replace the assertions in `TestServer_AddEntry_AddEntryError` (`:1001-1004`):
+
+```go
+	health, statusCode := s.GetLogHealth(context.Background(), "", "")
+	assert.Equal(t, 503, statusCode)
+	assert.Equal(t, LogHealthStateUnhealthy, health.State)
+	assert.Equal(t, 1, health.FailedLogs)
+```
+
+- [ ] **Step 5: Run the server-package tests (with race detector)**
+
+Run: `go test -race ./server/...`
+Expected: PASS (all `TestLogHealth_*`, `TestServer_GetLogHealth_StatusCode`, and the two `TestServer_AddEntry_*` health assertions). Note: `go build ./...` is still expected to fail here because `cmd` and `common/http` reference the old symbols — that is fixed in Task 2.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/log_health.go server/log_health_test.go server/service.go server/service_test.go
+git add -u server/   # stages the rw_health.go / rw_health_test.go deletions
+git commit -m "feat(server): lightweight per-log r/w health tracker (#131)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Rename the HTTP handler, route, and wiring (`management` + `common/http` + `cmd`)
+
+**Files:**
+- Create: `common/http/management/log_health_handler.go`
+- Delete: `common/http/management/rw_health_handler.go`
+- Create: `common/http/management/log_health_handler_test.go`
+- Delete: `common/http/management/rw_health_handler_test.go`
+- Modify: `common/http/router.go:49-53`
+- Modify: `common/http/server.go:62-63`, `:195-206`
+- Modify: `cmd/main.go:224-229`
+
+- [ ] **Step 1: Write the handler test**
+
+```bash
+git rm common/http/management/rw_health_handler_test.go
+```
+
+Create `common/http/management/log_health_handler_test.go`:
+
+```go
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogHealthHandler_NoFilterReturnsAll(t *testing.T) {
+	var gotBucket, gotRoot string
+	handler := NewLogHealthHandler(func(_ context.Context, bucketName, rootPath string) (any, int) {
+		gotBucket, gotRoot = bucketName, rootPath
+		return map[string]string{"state": "Healthy"}, http.StatusOK
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/log-health", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Empty(t, gotBucket)
+	require.Empty(t, gotRoot)
+}
+
+func TestLogHealthHandler_PartialFilterIgnored(t *testing.T) {
+	var gotBucket, gotRoot string
+	handler := NewLogHealthHandler(func(_ context.Context, bucketName, rootPath string) (any, int) {
+		gotBucket, gotRoot = bucketName, rootPath
+		return map[string]string{}, http.StatusOK
+	})
+
+	// only bucket_name -> treated as "no filter"
+	req := httptest.NewRequest(http.MethodGet, "/admin/log-health?bucket_name=b", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	require.Empty(t, gotBucket)
+	require.Empty(t, gotRoot)
+}
+
+func TestLogHealthHandler_FilterPassedThrough(t *testing.T) {
+	var gotBucket, gotRoot string
+	handler := NewLogHealthHandler(func(_ context.Context, bucketName, rootPath string) (any, int) {
+		gotBucket, gotRoot = bucketName, rootPath
+		return map[string]string{}, http.StatusServiceUnavailable
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/log-health?bucket_name=b&root_path=r", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	require.Equal(t, "b", gotBucket)
+	require.Equal(t, "r", gotRoot)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+}
+
+func TestLogHealthHandler_RejectsNonGet(t *testing.T) {
+	handler := NewLogHealthHandler(func(context.Context, string, string) (any, int) {
+		return nil, http.StatusOK
+	})
+	req := httptest.NewRequest(http.MethodPost, "/admin/log-health", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestLogHealthHandler_EncodesJSON(t *testing.T) {
+	handler := NewLogHealthHandler(func(context.Context, string, string) (any, int) {
+		return map[string]any{"state": "Healthy", "tracked_logs": 0}, http.StatusOK
+	})
+	req := httptest.NewRequest(http.MethodGet, "/admin/log-health", nil)
+	rec := httptest.NewRecorder()
+	handler(rec, req)
+
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "Healthy", body["state"])
+}
+```
+
+- [ ] **Step 2: Run the handler test to verify it fails to compile**
+
+Run: `go test ./common/http/management/...`
+Expected: FAIL — `undefined: NewLogHealthHandler`.
+
+- [ ] **Step 3: Write the handler implementation**
+
+```bash
+git rm common/http/management/rw_health_handler.go
+```
+
+Create `common/http/management/log_health_handler.go`:
+
+```go
+package management
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// LogHealthCallback returns the node's log health, optionally filtered to one
+// (bucketName, rootPath) instance. Empty strings mean "all tenants".
+type LogHealthCallback func(ctx context.Context, bucketName, rootPath string) (any, int)
+
+// NewLogHealthHandler serves the node-wide log health endpoint.
+// Optional query params: ?bucket_name=<bucket>&root_path=<root>.
+// A partial filter (only one of the two) is ignored and all tenants are returned.
+func NewLogHealthHandler(get LogHealthCallback) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+			return
+		}
+		bucketName := firstNonEmpty(
+			r.URL.Query().Get("bucket_name"),
+			r.URL.Query().Get("bucketName"),
+			r.URL.Query().Get("bucketname"),
+		)
+		rootPath := firstNonEmpty(
+			r.URL.Query().Get("root_path"),
+			r.URL.Query().Get("rootPath"),
+			r.URL.Query().Get("rootpath"),
+		)
+		if bucketName == "" || rootPath == "" {
+			bucketName, rootPath = "", "" // partial filter -> no filter
+		}
+
+		result, statusCode := get(r.Context(), bucketName, rootPath)
+		if statusCode == 0 {
+			statusCode = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_ = json.NewEncoder(w).Encode(result)
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+```
+
+- [ ] **Step 4: Update `common/http/router.go`**
+
+Replace the two RW consts at `:49-53` with one:
+
+```go
+// AdminLogHealthPath is the path for node-wide per-log read/write health.
+const AdminLogHealthPath = "/admin/log-health"
+```
+
+- [ ] **Step 5: Update `common/http/server.go`**
+
+5a. Replace the two callback fields at `:62-63`:
+
+```go
+	GetLogHealth            management.LogHealthCallback
+```
+
+5b. Replace the two registration blocks at `:195-206`:
+
+```go
+	if callbacks.GetLogHealth != nil {
+		Register(&Handler{
+			Path:        AdminLogHealthPath,
+			HandlerFunc: management.NewLogHealthHandler(callbacks.GetLogHealth),
+		})
+	}
+```
+
+- [ ] **Step 6: Update `cmd/main.go`**
+
+Replace the two callbacks at `:224-229`:
+
+```go
+		GetLogHealth: func(ctx context.Context, bucketName, rootPath string) (any, int) {
+			return srv.GetLogHealth(ctx, bucketName, rootPath)
+		},
+```
+
+- [ ] **Step 7: Build the whole module and run the management tests**
+
+Run: `go build ./... && go test ./common/http/...`
+Expected: build succeeds (module is now consistent), management handler tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add common/http/management/log_health_handler.go common/http/management/log_health_handler_test.go common/http/router.go common/http/server.go cmd/main.go
+git add -u common/http/management/   # stages the rw_health_handler*.go deletions
+git commit -m "feat(http): node-wide /admin/log-health endpoint (#131)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Documentation and final verification
+
+**Files:**
+- Modify: `common/http/README.md:14-15`, `:86-91`
+
+- [ ] **Step 1: Update the endpoints table**
+
+Replace the two RW rows at `common/http/README.md:14-15` with one:
+
+```markdown
+| GET | `/admin/log-health` | Health | Node-wide per-log read/write health (optional `?bucket_name=&root_path=` filter) |
+```
+
+- [ ] **Step 2: Update the examples / notes section**
+
+Replace the RW curl examples and notes at `:86-91`:
+
+```markdown
+curl "http://localhost:9091/admin/log-health"
+curl "http://localhost:9091/admin/log-health?bucket_name=a-bucket&root_path=files"
+```
+
+```markdown
+- `/admin/log-health` reports each log's observed read/write health on this node,
+  derived from real traffic (no injected probe). With no query params it returns all
+  tenants; passing both `bucket_name` and `root_path` narrows to one instance.
+- It is independent of `/healthz`: `/healthz` is process liveness; `/admin/log-health`
+  is data-path health and never affects the `/healthz` result.
+- Returns HTTP `503` when every tracked log is Stalled or Failed, `200` otherwise.
+```
+
+- [ ] **Step 3: Final full verification**
+
+Run: `go build ./... && go vet ./server/... ./common/http/... ./cmd/... && go test -race ./server/... ./common/http/...`
+Expected: build clean, vet clean, all tests PASS.
+
+- [ ] **Step 4: Confirm no stale RW references remain**
+
+Run: `grep -rIn "RWHealth\|rwHealth\|server-rw-health\|cluster-rw-health\|GetClusterRWHealth\|RWWriteAttempt" cmd common server || echo "clean"`
+Expected: `clean`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add common/http/README.md
+git commit -m "docs(http): document /admin/log-health endpoint (#131)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** atomic-timestamp model (Task 1 Step 2), read+write instrumentation (Task 1 Step 3), per-log classification incl. high-QPS stall (Task 1 tests `TestLogHealth_HungWriteBecomesStalledUnderLoad`), node rollup + idle-stays-healthy (`TestLogHealth_IdleNodeStaysHealthy`), node-wide scope + per-log triple + filter (`TestLogHealth_MultiTenantAndFilter`), single endpoint / cluster code deleted (Task 2), `/healthz` independence documented (Task 3), no idle storage probe (not implemented, by design).
+- **Refinement vs spec:** `classify` requires `lastSuccess > 0` for both Healthy and Stalled — a log that has *never* succeeded is Failed (if a recent failure exists) or Idle, never Stalled. This avoids the `now - 0` bootstrap false-positive and matches the intuitive meaning of "stalled" (was healthy, stopped completing). Spec's Stalled row is read with this precondition.
+- **Type consistency:** record methods take `(bucket, rootPath, logID, now[, reason])` everywhere (no more `*RWWriteAttempt`); field is `logHealthTracker`; callback type `LogHealthCallback`; route const `AdminLogHealthPath`; response types `LogHealthResponse` / `LogHealthSnapshot`. Status code is `503` (was `500` in the draft) per spec.

--- a/docs/superpowers/plans/2026-06-01-log-health.md
+++ b/docs/superpowers/plans/2026-06-01-log-health.md
@@ -2,9 +2,9 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Replace the in-progress `rw_health` draft with a lightweight, node-wide, multi-tenant per-log read/write health probe (`log_health`) derived from real traffic, exposed at `GET /admin/log-health`.
+**Goal:** Add a lightweight, node-wide, multi-tenant per-log read/write health probe (`/admin/log-health`) that observes the existing `metrics.Op` stream — with zero changes to data-path business logic.
 
-**Architecture:** A `LogHealthTracker` keeps a few `atomic.Int64` timestamps per `(bucket, rootPath, logID)`. The write path (`AddEntry`) and read path (`GetBatchEntriesAdv`) record attempt/success/failure timestamps with a shared `RLock` + atomic store (no per-write allocation, no exclusive lock). At snapshot time each log is classified Healthy/Stalled/Failed/Idle from those timestamps. One HTTP endpoint returns all tracked logs (optionally filtered to one tenant) plus a node rollup. The earlier cluster fan-out / quorum / pending-map code is deleted.
+**Architecture:** A `loghealth.Tracker` implements `metrics.OpObserver`. It is created and registered once in `cmd/main.go` (mirroring `opReg`). Every logstore op already calls `metrics.StartOp`/`op.End(status)`; the tracker's `OnOpStart`/`OnOpEnd` translate `logstore.add_entry` (write) and `logstore.get_batch_entries` (read) ops into a few `atomic.Int64` timestamps per `(bucket, rootPath, logID)`. At snapshot time each log is classified Healthy/Stalled/Failed/Idle. One HTTP endpoint returns all tracked logs (optionally filtered) plus a node rollup. The earlier `rw_health` draft is reverted.
 
 **Tech Stack:** Go, `sync/atomic`, `net/http`, `testify`.
 
@@ -16,255 +16,338 @@
 
 | File | Action | Responsibility |
 |------|--------|----------------|
-| `server/log_health.go` | Create (replaces `server/rw_health.go`) | `LogHealthTracker`, record methods, classification, `Snapshot`, `Server.GetLogHealth` |
+| `common/metrics/op.go` | Modify | add `BucketName`/`RootPath` to `Op` + `WithInstance` option |
+| `common/metrics/op_test.go` | Modify | test `WithInstance` |
+| `common/runtime/loghealth/tracker.go` | Create | `Tracker` (OpObserver), classification, `Snapshot`, `Report` |
+| `common/runtime/loghealth/tracker_test.go` | Create | tracker + observer-adapter tests |
+| `server/logstore.go` | Modify | add `WithInstance` to 2 `StartOp` calls |
+| `server/service.go` | Revert | restore upstream (remove draft instrumentation) |
+| `server/service_test.go` | Revert | restore upstream |
 | `server/rw_health.go` | Delete | superseded |
-| `server/log_health_test.go` | Create (replaces `server/rw_health_test.go`) | tracker unit tests |
 | `server/rw_health_test.go` | Delete | superseded |
-| `server/service.go` | Modify | rename field; simplify write instrumentation; add read instrumentation |
-| `server/service_test.go` | Modify | rename symbols in helpers + assertions |
-| `common/http/management/log_health_handler.go` | Create (replaces `rw_health_handler.go`) | HTTP handler + optional filter parsing |
+| `common/http/management/log_health_handler.go` | Create (replaces `rw_health_handler.go`) | handler + optional filter |
 | `common/http/management/rw_health_handler.go` | Delete | superseded |
 | `common/http/management/log_health_handler_test.go` | Create (replaces `rw_health_handler_test.go`) | handler tests |
 | `common/http/management/rw_health_handler_test.go` | Delete | superseded |
-| `common/http/router.go` | Modify | one route const `AdminLogHealthPath`, drop the two RW consts |
-| `common/http/server.go` | Modify | one callback field + one registration block |
-| `cmd/main.go` | Modify | one callback wiring |
-| `common/http/README.md` | Modify | document `/admin/log-health`, drop the two RW rows |
+| `common/http/router.go` | Modify | one route const `AdminLogHealthPath` |
+| `common/http/server.go` | Modify | one callback field + registration |
+| `cmd/main.go` | Modify | create + register tracker; wire `GetLogHealth` |
+| `common/http/README.md` | Modify | document `/admin/log-health` |
 
-**Compilation note (Go packages compile as a unit):** `cmd` imports `server` and `common/http`, which imports `common/http/management`. Renaming symbols therefore breaks the full module build until every task is done. So:
-- **Task 1** keeps package `server` self-consistent → verify with `go test ./server/...` (NOT a full `go build ./...`, which stays red until Task 2).
-- **Task 2** completes `management` + `common/http` + `cmd` → `go build ./...` goes green.
-- **Task 3** is docs + final full verification.
+**Compilation ordering (Go compiles packages as a unit):**
+- **Task 1** (`common/metrics`) — standalone → `go test ./common/metrics/...`.
+- **Task 2** (`common/runtime/loghealth`) — needs Task 1 → `go test ./common/runtime/loghealth/...`.
+- **Task 3** (`server`) — reverts the draft + adds `WithInstance` (needs Task 1) → `go test ./server/...`. (Full `go build ./...` is still red here: `cmd` references the now-removed `GetServerRWHealth`, fixed in Task 4.)
+- **Task 4** (`management` + `common/http` + `cmd`) — full module green.
+- **Task 5** — docs + final verification.
 
 ---
 
-## Task 1: Rewrite the tracker and instrument the data path (package `server`)
+## Task 1: Add instance identity to `metrics.Op`
 
 **Files:**
-- Create: `server/log_health.go`
-- Delete: `server/rw_health.go`
-- Create: `server/log_health_test.go`
-- Delete: `server/rw_health_test.go`
-- Modify: `server/service.go` (field at `:54`, constructor at `:129`, `AddEntry` `:365-441`, `GetBatchEntriesAdv` `:452-460`)
-- Modify: `server/service_test.go` (`:55`, `:509`, `:974-977`, `:1001-1004`)
+- Modify: `common/metrics/op.go` (struct ~:11-23, options ~:28-34)
+- Modify: `common/metrics/op_test.go`
 
-- [ ] **Step 1: Write the new tracker test file**
+- [ ] **Step 1: Write the failing test**
 
-Delete the old test and write the new one:
-
-```bash
-git rm server/rw_health_test.go
-```
-
-Create `server/log_health_test.go`:
+Add to `common/metrics/op_test.go`:
 
 ```go
-package server
+func TestWithInstance_SetsBucketAndRoot(t *testing.T) {
+	ResetObservers()
+	defer ResetObservers()
+	op := StartOp("test.op", nil, nil, WithInstance("bucket-a", "root-a"), WithLogSegment(7, 3))
+	if op.BucketName != "bucket-a" || op.RootPath != "root-a" {
+		t.Fatalf("got bucket=%q root=%q", op.BucketName, op.RootPath)
+	}
+	if op.LogID != 7 || op.SegmentID != 3 {
+		t.Fatalf("WithLogSegment regressed: log=%d seg=%d", op.LogID, op.SegmentID)
+	}
+}
+```
+
+- [ ] **Step 2: Run it — verify it fails**
+
+Run: `go test ./common/metrics/ -run TestWithInstance_SetsBucketAndRoot`
+Expected: FAIL — `op.BucketName undefined` / `undefined: WithInstance`.
+
+- [ ] **Step 3: Implement the field + option**
+
+In `common/metrics/op.go`, add two fields to `Op` (after `Labels`):
+
+```go
+type Op struct {
+	OpType     string
+	Labels     prometheus.Labels
+	BucketName string
+	RootPath   string
+	LogID      int64
+	SegmentID  int64
+	TraceID    string
+	SpanID     string
+
+	histo   prometheus.Observer // may be nil
+	start   time.Time
+	ended   atomic.Bool
+	handles []uint64 // one per observer
+}
+```
+
+Add the option next to `WithLogSegment`:
+
+```go
+// WithInstance sets the multi-tenant identity (bucket + root path) for the op.
+func WithInstance(bucketName, rootPath string) OpOption {
+	return func(op *Op) {
+		op.BucketName = bucketName
+		op.RootPath = rootPath
+	}
+}
+```
+
+- [ ] **Step 4: Run tests — verify pass**
+
+Run: `go test ./common/metrics/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add common/metrics/op.go common/metrics/op_test.go
+git commit -m "feat(metrics): add instance identity (bucket/root) to Op (#131)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: The `loghealth.Tracker` observer
+
+**Files:**
+- Create: `common/runtime/loghealth/tracker.go`
+- Create: `common/runtime/loghealth/tracker_test.go`
+
+- [ ] **Step 1: Write the test file**
+
+Create `common/runtime/loghealth/tracker_test.go`:
+
+```go
+package loghealth
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/zilliztech/woodpecker/common/membership"
+	"github.com/zilliztech/woodpecker/common/metrics"
 )
 
 const testStall = 10 * time.Minute
 
-func TestLogHealth_NilTrackerSafe(t *testing.T) {
-	var tr *LogHealthTracker
-	// none of these should panic
-	tr.RecordWriteAttempt("b", "r", 1, time.UnixMilli(1000))
-	tr.RecordWriteSuccess("b", "r", 1, time.UnixMilli(1000))
-	tr.RecordWriteFailure("b", "r", 1, time.UnixMilli(1000), "x")
-	tr.RecordReadSuccess("b", "r", 1, time.UnixMilli(1000))
-	tr.RecordReadFailure("b", "r", 1, time.UnixMilli(1000), "x")
+func TestTracker_NilSafe(t *testing.T) {
+	var tr *Tracker
+	tr.OnOpStart(&metrics.Op{OpType: opAddEntry})
+	tr.OnOpEnd(&metrics.Op{OpType: opAddEntry}, 0, time.Second, "success")
+	resp, code := tr.Report("", "")
+	require.Equal(t, StateHealthy, resp.State)
+	require.Equal(t, 200, code)
 }
 
-func TestLogHealth_NoActivityHealthy(t *testing.T) {
-	tr := NewLogHealthTracker(testStall)
+func TestTracker_NoActivityHealthy(t *testing.T) {
+	tr := New(testStall)
 	snap := tr.Snapshot("", "", "node-1", time.UnixMilli(1000))
-	require.Equal(t, LogHealthStateHealthy, snap.State)
+	require.Equal(t, StateHealthy, snap.State)
 	require.Equal(t, "no_observed_activity", snap.Reason)
 	require.Equal(t, 0, snap.TrackedLogs)
 	require.Equal(t, "node-1", snap.NodeID)
 }
 
-func TestLogHealth_RecentWriteSuccessIsHealthy(t *testing.T) {
+func TestTracker_RecentWriteSuccessHealthy(t *testing.T) {
 	now := time.UnixMilli(1_000_000)
-	tr := NewLogHealthTracker(testStall)
-	tr.RecordWriteAttempt("b", "r", 1, now)
-	tr.RecordWriteSuccess("b", "r", 1, now.Add(time.Second))
-
-	snap := tr.Snapshot("", "", "node-1", now.Add(2*time.Second))
-	require.Equal(t, 1, snap.TrackedLogs)
+	tr := New(testStall)
+	tr.recordWriteAttempt("b", "r", 1, now)
+	tr.recordWriteSuccess("b", "r", 1, now.Add(time.Second))
+	snap := tr.Snapshot("", "", "n", now.Add(2*time.Second))
 	require.Equal(t, 1, snap.HealthyLogs)
-	require.Equal(t, LogHealthStateHealthy, snap.State)
 	require.Equal(t, logStateHealthy, snap.Logs[0].WriteState)
 	require.Equal(t, "b", snap.Logs[0].BucketName)
 	require.Equal(t, "r", snap.Logs[0].RootPath)
 	require.Equal(t, int64(1), snap.Logs[0].LogID)
 }
 
-func TestLogHealth_RecentReadFailureIsFailed(t *testing.T) {
+func TestTracker_OverallWorstOfReadWrite(t *testing.T) {
 	now := time.UnixMilli(1_000_000)
-	tr := NewLogHealthTracker(testStall)
-	tr.RecordWriteSuccess("b", "r", 1, now)            // write healthy
-	tr.RecordReadFailure("b", "r", 1, now.Add(time.Second), "read boom")
-
-	snap := tr.Snapshot("", "", "node-1", now.Add(2*time.Second))
-	// overall = worst(Healthy write, Failed read) = Failed
+	tr := New(testStall)
+	tr.recordWriteSuccess("b", "r", 1, now)
+	tr.recordReadFailure("b", "r", 1, now.Add(time.Second), "read boom")
+	snap := tr.Snapshot("", "", "n", now.Add(2*time.Second))
 	require.Equal(t, logStateHealthy, snap.Logs[0].WriteState)
 	require.Equal(t, logStateFailed, snap.Logs[0].ReadState)
 	require.Equal(t, logStateFailed, snap.Logs[0].State)
 	require.Equal(t, "read boom", snap.Logs[0].LastFailureReason)
 }
 
-func TestLogHealth_HungWriteBecomesStalledUnderLoad(t *testing.T) {
+func TestTracker_HungWriteStalledUnderLoad(t *testing.T) {
 	now := time.UnixMilli(1_000_000)
-	tr := NewLogHealthTracker(testStall)
-	// One real success long ago, then attempts keep coming but never complete.
-	tr.RecordWriteSuccess("b", "r", 1, now)
-	tr.RecordWriteAttempt("b", "r", 1, now.Add(12*time.Minute)) // recent attempt, no success/failure after
-
-	snap := tr.Snapshot("", "", "node-1", now.Add(12*time.Minute+time.Second))
+	tr := New(testStall)
+	tr.recordWriteSuccess("b", "r", 1, now)                    // last success
+	tr.recordWriteAttempt("b", "r", 1, now.Add(12*time.Minute)) // recent attempt, never completes
+	snap := tr.Snapshot("", "", "n", now.Add(12*time.Minute+time.Second))
 	require.Equal(t, logStateStalled, snap.Logs[0].WriteState)
 	require.Equal(t, 1, snap.StalledLogs)
-	require.Equal(t, LogHealthStateUnhealthy, snap.State)
+	require.Equal(t, StateUnhealthy, snap.State)
 	require.Equal(t, "all_logs_failed_or_stalled", snap.Reason)
 }
 
-func TestLogHealth_ReadNeverStalls(t *testing.T) {
+func TestTracker_NeverSucceededNotStalled(t *testing.T) {
 	now := time.UnixMilli(1_000_000)
-	tr := NewLogHealthTracker(testStall)
-	tr.RecordReadSuccess("b", "r", 1, now) // success then 20 min of silence on reads
+	tr := New(testStall)
+	tr.recordWriteAttempt("b", "r", 1, now) // only an attempt, never success/failure
+	snap := tr.Snapshot("", "", "n", now.Add(30*time.Minute))
+	require.Equal(t, logStateIdle, snap.Logs[0].WriteState) // not Stalled
+}
 
-	snap := tr.Snapshot("", "", "node-1", now.Add(20*time.Minute))
-	// reads have no attempt timestamp; stale success -> Idle, never Stalled
+func TestTracker_ReadNeverStalls(t *testing.T) {
+	now := time.UnixMilli(1_000_000)
+	tr := New(testStall)
+	tr.recordReadSuccess("b", "r", 1, now)
+	snap := tr.Snapshot("", "", "n", now.Add(20*time.Minute))
 	require.Equal(t, logStateIdle, snap.Logs[0].ReadState)
 	require.Equal(t, logStateIdle, snap.Logs[0].State)
-	require.Equal(t, 1, snap.IdleLogs)
-	require.Equal(t, LogHealthStateHealthy, snap.State) // idle never forces Unhealthy
+	require.Equal(t, StateHealthy, snap.State)
 }
 
-func TestLogHealth_IdleNodeStaysHealthy(t *testing.T) {
+func TestTracker_IdleNodeStaysHealthy(t *testing.T) {
 	now := time.UnixMilli(1_000_000)
-	tr := NewLogHealthTracker(testStall)
-	tr.RecordWriteSuccess("b", "r", 1, now) // healthy log, goes quiet
-	tr.RecordWriteFailure("b", "r", 2, now, "old fail") // a stale failure
-
-	snap := tr.Snapshot("", "", "node-1", now.Add(30*time.Minute))
-	require.Equal(t, 2, snap.TrackedLogs)
-	require.Equal(t, 2, snap.IdleLogs) // both went idle (stale)
+	tr := New(testStall)
+	tr.recordWriteSuccess("b", "r", 1, now)
+	tr.recordWriteFailure("b", "r", 2, now, "old fail")
+	snap := tr.Snapshot("", "", "n", now.Add(30*time.Minute))
+	require.Equal(t, 2, snap.IdleLogs)
 	require.Equal(t, 0, snap.HealthyLogs)
 	require.Equal(t, 0, snap.FailedLogs)
-	require.Equal(t, LogHealthStateHealthy, snap.State) // quiet node not pulled out
+	require.Equal(t, StateHealthy, snap.State)
 }
 
-func TestLogHealth_UnhealthyOnlyWhenAllActiveFailures(t *testing.T) {
+func TestTracker_UnhealthyOnlyWhenAllActiveFailures(t *testing.T) {
 	now := time.UnixMilli(1_000_000)
-	tr := NewLogHealthTracker(testStall)
-	tr.RecordWriteFailure("b", "r", 1, now, "f1")
-	tr.RecordWriteFailure("b", "r", 2, now, "f2")
-
-	snap := tr.Snapshot("", "", "node-1", now.Add(time.Second))
+	tr := New(testStall)
+	tr.recordWriteFailure("b", "r", 1, now, "f1")
+	tr.recordWriteFailure("b", "r", 2, now, "f2")
+	snap := tr.Snapshot("", "", "n", now.Add(time.Second))
 	require.Equal(t, 2, snap.FailedLogs)
-	require.Equal(t, LogHealthStateUnhealthy, snap.State)
+	require.Equal(t, StateUnhealthy, snap.State)
 	require.Equal(t, "all_logs_failed_or_stalled", snap.Reason)
 }
 
-func TestLogHealth_HealthyIfAnyLogHealthy(t *testing.T) {
+func TestTracker_HealthyIfAnyHealthy(t *testing.T) {
 	now := time.UnixMilli(1_000_000)
-	tr := NewLogHealthTracker(testStall)
-	tr.RecordWriteSuccess("b", "r", 1, now)
-	tr.RecordWriteFailure("b", "r", 2, now, "f2")
-
-	snap := tr.Snapshot("", "", "node-1", now.Add(time.Second))
+	tr := New(testStall)
+	tr.recordWriteSuccess("b", "r", 1, now)
+	tr.recordWriteFailure("b", "r", 2, now, "f2")
+	snap := tr.Snapshot("", "", "n", now.Add(time.Second))
 	require.Equal(t, 1, snap.HealthyLogs)
 	require.Equal(t, 1, snap.FailedLogs)
-	require.Equal(t, LogHealthStateHealthy, snap.State)
+	require.Equal(t, StateHealthy, snap.State)
 	require.Equal(t, "observed_read_write_success", snap.Reason)
 }
 
-func TestLogHealth_MultiTenantAndFilter(t *testing.T) {
+func TestTracker_MultiTenantAndFilter(t *testing.T) {
 	now := time.UnixMilli(1_000_000)
-	tr := NewLogHealthTracker(testStall)
-	tr.RecordWriteSuccess("bucket-a", "root-a", 1, now)
-	tr.RecordWriteSuccess("bucket-b", "root-b", 7, now)
-
-	all := tr.Snapshot("", "", "node-1", now.Add(time.Second))
+	tr := New(testStall)
+	tr.recordWriteSuccess("bucket-a", "root-a", 1, now)
+	tr.recordWriteSuccess("bucket-b", "root-b", 7, now)
+	all := tr.Snapshot("", "", "n", now.Add(time.Second))
 	require.Equal(t, 2, all.TrackedLogs)
-	// sorted by (bucket, root, logID)
-	require.Equal(t, "bucket-a", all.Logs[0].BucketName)
+	require.Equal(t, "bucket-a", all.Logs[0].BucketName) // sorted by (bucket, root, logID)
 	require.Equal(t, "bucket-b", all.Logs[1].BucketName)
-
-	filtered := tr.Snapshot("bucket-b", "root-b", "node-1", now.Add(time.Second))
+	filtered := tr.Snapshot("bucket-b", "root-b", "n", now.Add(time.Second))
 	require.Equal(t, 1, filtered.TrackedLogs)
 	require.Equal(t, int64(7), filtered.Logs[0].LogID)
 	require.Equal(t, "bucket-b", filtered.FilterBucketName)
 }
 
-func TestLogHealth_ConcurrentRecordsRaceFree(t *testing.T) {
-	tr := NewLogHealthTracker(testStall)
+func TestTracker_ReportStatusCode(t *testing.T) {
+	now := time.Now()
+	tr := New(testStall)
+	tr.recordWriteFailure("b", "r", 1, now, "boom")
+	resp, code := tr.Report("", "")
+	require.Equal(t, StateUnhealthy, resp.State)
+	require.Equal(t, 503, code)
+}
+
+func TestTracker_ConcurrentRaceFree(t *testing.T) {
+	tr := New(testStall)
 	now := time.UnixMilli(1_000_000)
 	var wg sync.WaitGroup
 	for g := 0; g < 8; g++ {
 		wg.Add(1)
-		go func(g int) {
+		go func() {
 			defer wg.Done()
 			for i := 0; i < 1000; i++ {
-				logID := int64(i % 4)
-				tr.RecordWriteAttempt("b", "r", logID, now)
-				tr.RecordWriteSuccess("b", "r", logID, now)
-				_ = tr.Snapshot("", "", "node-1", now)
+				id := int64(i % 4)
+				tr.recordWriteAttempt("b", "r", id, now)
+				tr.recordWriteSuccess("b", "r", id, now)
+				_ = tr.Snapshot("", "", "n", now)
 			}
-		}(g)
+		}()
 	}
 	wg.Wait()
-	snap := tr.Snapshot("", "", "node-1", now)
-	require.Equal(t, 4, snap.TrackedLogs)
+	require.Equal(t, 4, tr.Snapshot("", "", "n", now).TrackedLogs)
 }
 
-func TestServer_GetLogHealth_StatusCode(t *testing.T) {
-	s := createTestServer(context.Background(), &membership.ServerConfig{NodeID: "node-1"})
-	defer s.cancel()
+// Observer adapter: drive through the real StartOp/End path.
+func TestTracker_ObserverMapsOps(t *testing.T) {
+	metrics.ResetObservers()
+	defer metrics.ResetObservers()
+	tr := New(testStall)
+	metrics.RegisterOpObserver(tr)
 
-	s.logHealthTracker.RecordWriteFailure("bucket-a", "root-a", 1, time.Now(), "sync failed")
+	w := metrics.StartOp(opAddEntry, nil, nil, metrics.WithInstance("b", "r"), metrics.WithLogSegment(1, 0))
+	w.End("success")
+	r := metrics.StartOp(opGetBatchEntries, nil, nil, metrics.WithInstance("b", "r"), metrics.WithLogSegment(2, 0))
+	r.End("error")
 
-	resp, statusCode := s.GetLogHealth(context.Background(), "", "")
-	assert.Equal(t, LogHealthStateUnhealthy, resp.State)
-	assert.Equal(t, 503, statusCode)
+	snap := tr.Snapshot("", "", "n", time.Now())
+	require.Equal(t, 2, snap.TrackedLogs)
+	byLog := map[int64]LogSnapshot{}
+	for _, l := range snap.Logs {
+		byLog[l.LogID] = l
+	}
+	require.Equal(t, logStateHealthy, byLog[1].WriteState)
+	require.Equal(t, logStateFailed, byLog[2].ReadState)
 }
 ```
 
-- [ ] **Step 2: Replace the implementation file**
+- [ ] **Step 2: Run it — verify it fails to compile**
 
-```bash
-git rm server/rw_health.go
-```
+Run: `go test ./common/runtime/loghealth/...`
+Expected: FAIL — package/`New`/`Tracker` undefined.
 
-Create `server/log_health.go`:
+- [ ] **Step 3: Write the implementation**
+
+Create `common/runtime/loghealth/tracker.go`:
 
 ```go
-package server
+package loghealth
 
 import (
-	"context"
 	"net/http"
 	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/zilliztech/woodpecker/common/metrics"
 )
 
 const (
-	// Node-level rollup states.
-	LogHealthStateHealthy   = "Healthy"
-	LogHealthStateUnhealthy = "Unhealthy"
+	// Node rollup states.
+	StateHealthy   = "Healthy"
+	StateUnhealthy = "Unhealthy"
 
 	// Per-log / per-direction states.
 	logStateHealthy = "Healthy"
@@ -272,35 +355,45 @@ const (
 	logStateStalled = "Stalled"
 	logStateIdle    = "Idle"
 
-	defaultLogHealthStallAfter = 10 * time.Minute
+	// DefaultStallAfter is the no-success window after which an active-but-not-
+	// completing log is considered Stalled.
+	DefaultStallAfter = 10 * time.Minute
+
+	// Observed op types — MUST match the opType strings passed to metrics.StartOp
+	// in server/logstore.go.
+	opAddEntry        = "logstore.add_entry"
+	opGetBatchEntries = "logstore.get_batch_entries"
+	// statusSuccess is the literal status server/logstore.go sets on success.
+	statusSuccess = "success"
 )
+
+// Compile-time assertion that Tracker is an OpObserver.
+var _ metrics.OpObserver = (*Tracker)(nil)
 
 type logInstanceKey struct {
 	bucketName string
 	rootPath   string
 }
 
-// logHealth holds the lock-free per-log state. All fields are written from the
-// hot path with atomic stores under a shared RLock.
+// logHealth is the lock-free per-log state, written via atomic stores under RLock.
 type logHealth struct {
-	writeAttemptMS atomic.Int64 // when a write started (writes can hang in-flight)
+	writeAttemptMS atomic.Int64
 	writeSuccessMS atomic.Int64
 	writeFailureMS atomic.Int64
-	readSuccessMS  atomic.Int64 // reads are synchronous -> no attempt timestamp
+	readSuccessMS  atomic.Int64
 	readFailureMS  atomic.Int64
 	failureReason  atomic.Pointer[string]
 }
 
-// LogHealthTracker tracks read/write outcomes per (bucket, rootPath, logID).
-type LogHealthTracker struct {
+// Tracker observes the metrics.Op stream and derives per-log read/write health.
+type Tracker struct {
 	mu         sync.RWMutex // guards map STRUCTURE only
 	stallAfter time.Duration
 	logs       map[logInstanceKey]map[int64]*logHealth
 }
 
-// LogHealthSnapshot is the per-log view. The triple (BucketName, RootPath, LogID)
-// uniquely identifies a log on this node.
-type LogHealthSnapshot struct {
+// LogSnapshot is the per-log view; (BucketName, RootPath, LogID) is the unique key.
+type LogSnapshot struct {
 	BucketName         string `json:"bucket_name"`
 	RootPath           string `json:"root_path"`
 	LogID              int64  `json:"log_id"`
@@ -314,39 +407,74 @@ type LogHealthSnapshot struct {
 	LastFailureReason  string `json:"last_failure_reason,omitempty"`
 }
 
-// LogHealthResponse is the node-wide response, optionally filtered to one tenant.
-type LogHealthResponse struct {
-	State            string              `json:"state"`
-	Reason           string              `json:"reason"`
-	NodeID           string              `json:"node_id,omitempty"`
-	FilterBucketName string              `json:"filter_bucket_name,omitempty"`
-	FilterRootPath   string              `json:"filter_root_path,omitempty"`
-	TimestampMS      int64               `json:"timestamp_ms"`
-	StallAfterMS     int64               `json:"stall_after_ms"`
-	TrackedLogs      int                 `json:"tracked_logs"`
-	HealthyLogs      int                 `json:"healthy_logs"`
-	FailedLogs       int                 `json:"failed_logs"`
-	StalledLogs      int                 `json:"stalled_logs"`
-	IdleLogs         int                 `json:"idle_logs"`
-	Logs             []LogHealthSnapshot `json:"logs"`
+// Response is the node-wide payload, optionally filtered to one tenant.
+type Response struct {
+	State            string        `json:"state"`
+	Reason           string        `json:"reason"`
+	NodeID           string        `json:"node_id,omitempty"`
+	FilterBucketName string        `json:"filter_bucket_name,omitempty"`
+	FilterRootPath   string        `json:"filter_root_path,omitempty"`
+	TimestampMS      int64         `json:"timestamp_ms"`
+	StallAfterMS     int64         `json:"stall_after_ms"`
+	TrackedLogs      int           `json:"tracked_logs"`
+	HealthyLogs      int           `json:"healthy_logs"`
+	FailedLogs       int           `json:"failed_logs"`
+	StalledLogs      int           `json:"stalled_logs"`
+	IdleLogs         int           `json:"idle_logs"`
+	Logs             []LogSnapshot `json:"logs"`
 }
 
-func NewLogHealthTracker(stallAfter time.Duration) *LogHealthTracker {
+// New creates a Tracker. stallAfter <= 0 uses DefaultStallAfter.
+func New(stallAfter time.Duration) *Tracker {
 	if stallAfter <= 0 {
-		stallAfter = defaultLogHealthStallAfter
+		stallAfter = DefaultStallAfter
 	}
-	return &LogHealthTracker{
+	return &Tracker{
 		stallAfter: stallAfter,
 		logs:       make(map[logInstanceKey]map[int64]*logHealth),
 	}
 }
 
-// get returns the *logHealth for a log, creating it on first use. The common case
-// (log already exists) takes only a shared RLock; creation takes the write lock once.
-func (t *LogHealthTracker) get(bucketName, rootPath string, logID int64) *logHealth {
+// --- metrics.OpObserver ---
+
+func (t *Tracker) OnOpStart(op *metrics.Op) uint64 {
+	if t == nil || op == nil {
+		return 0
+	}
+	if op.OpType == opAddEntry {
+		t.recordWriteAttempt(op.BucketName, op.RootPath, op.LogID, op.StartedAt())
+	}
+	return 0 // the tracker keeps no per-op handle
+}
+
+func (t *Tracker) OnOpEnd(op *metrics.Op, _ uint64, elapsed time.Duration, status string) {
+	if t == nil || op == nil {
+		return
+	}
+	now := op.StartedAt().Add(elapsed)
+	ok := status == statusSuccess
+	switch op.OpType {
+	case opAddEntry:
+		if ok {
+			t.recordWriteSuccess(op.BucketName, op.RootPath, op.LogID, now)
+		} else {
+			t.recordWriteFailure(op.BucketName, op.RootPath, op.LogID, now, status)
+		}
+	case opGetBatchEntries:
+		if ok {
+			t.recordReadSuccess(op.BucketName, op.RootPath, op.LogID, now)
+		} else {
+			t.recordReadFailure(op.BucketName, op.RootPath, op.LogID, now, status)
+		}
+	}
+}
+
+// --- internal record methods (unit-testable without metrics.Op) ---
+
+func (t *Tracker) get(bucketName, rootPath string, logID int64) *logHealth {
 	key := logInstanceKey{bucketName: bucketName, rootPath: rootPath}
 	t.mu.RLock()
-	lh := t.logs[key][logID] // indexing a nil inner map is safe and returns nil
+	lh := t.logs[key][logID] // indexing a nil inner map is safe -> nil
 	t.mu.RUnlock()
 	if lh != nil {
 		return lh
@@ -365,58 +493,58 @@ func (t *LogHealthTracker) get(bucketName, rootPath string, logID int64) *logHea
 	return lh
 }
 
-func (t *LogHealthTracker) RecordWriteAttempt(bucketName, rootPath string, logID int64, now time.Time) {
+func (t *Tracker) recordWriteAttempt(b, r string, logID int64, now time.Time) {
 	if t == nil {
 		return
 	}
-	t.get(bucketName, rootPath, logID).writeAttemptMS.Store(now.UnixMilli())
+	t.get(b, r, logID).writeAttemptMS.Store(now.UnixMilli())
 }
 
-func (t *LogHealthTracker) RecordWriteSuccess(bucketName, rootPath string, logID int64, now time.Time) {
+func (t *Tracker) recordWriteSuccess(b, r string, logID int64, now time.Time) {
 	if t == nil {
 		return
 	}
-	t.get(bucketName, rootPath, logID).writeSuccessMS.Store(now.UnixMilli())
+	t.get(b, r, logID).writeSuccessMS.Store(now.UnixMilli())
 }
 
-func (t *LogHealthTracker) RecordWriteFailure(bucketName, rootPath string, logID int64, now time.Time, reason string) {
+func (t *Tracker) recordWriteFailure(b, r string, logID int64, now time.Time, reason string) {
 	if t == nil {
 		return
 	}
-	lh := t.get(bucketName, rootPath, logID)
+	lh := t.get(b, r, logID)
 	lh.writeFailureMS.Store(now.UnixMilli())
 	lh.failureReason.Store(&reason)
 }
 
-func (t *LogHealthTracker) RecordReadSuccess(bucketName, rootPath string, logID int64, now time.Time) {
+func (t *Tracker) recordReadSuccess(b, r string, logID int64, now time.Time) {
 	if t == nil {
 		return
 	}
-	t.get(bucketName, rootPath, logID).readSuccessMS.Store(now.UnixMilli())
+	t.get(b, r, logID).readSuccessMS.Store(now.UnixMilli())
 }
 
-func (t *LogHealthTracker) RecordReadFailure(bucketName, rootPath string, logID int64, now time.Time, reason string) {
+func (t *Tracker) recordReadFailure(b, r string, logID int64, now time.Time, reason string) {
 	if t == nil {
 		return
 	}
-	lh := t.get(bucketName, rootPath, logID)
+	lh := t.get(b, r, logID)
 	lh.readFailureMS.Store(now.UnixMilli())
 	lh.failureReason.Store(&reason)
 }
 
-// Snapshot returns the health of all tracked logs. When both bucketFilter and
-// rootPathFilter are non-empty, the result is narrowed to that one instance;
-// otherwise all tenants are returned.
-func (t *LogHealthTracker) Snapshot(bucketFilter, rootPathFilter, nodeID string, now time.Time) LogHealthResponse {
-	resp := LogHealthResponse{
-		State:            LogHealthStateHealthy,
+// --- snapshot / classification ---
+
+// Snapshot is pure and deterministic (nodeID + now injected). Empty filters = all.
+func (t *Tracker) Snapshot(bucketFilter, rootPathFilter, nodeID string, now time.Time) Response {
+	resp := Response{
+		State:            StateHealthy,
 		Reason:           "no_observed_activity",
 		NodeID:           nodeID,
 		FilterBucketName: bucketFilter,
 		FilterRootPath:   rootPathFilter,
 		TimestampMS:      now.UnixMilli(),
 		StallAfterMS:     int64(t.stallAfter / time.Millisecond),
-		Logs:             []LogHealthSnapshot{},
+		Logs:             []LogSnapshot{},
 	}
 	filtered := bucketFilter != "" && rootPathFilter != ""
 
@@ -458,20 +586,20 @@ func (t *LogHealthTracker) Snapshot(bucketFilter, rootPathFilter, nodeID string,
 
 	switch {
 	case resp.TrackedLogs == 0:
-		// keep Healthy / no_observed_activity
+		// Healthy / no_observed_activity
 	case resp.HealthyLogs > 0:
 		resp.Reason = "observed_read_write_success"
-	case resp.IdleLogs == 0: // all logs are Stalled or Failed
-		resp.State = LogHealthStateUnhealthy
+	case resp.IdleLogs == 0: // all Stalled or Failed
+		resp.State = StateUnhealthy
 		resp.Reason = "all_logs_failed_or_stalled"
-	default: // no healthy logs, but some idle -> quiet, not actively broken
+	default: // no healthy, but some idle -> quiet, not actively broken
 		resp.Reason = "idle_logs_present"
 	}
 	return resp
 }
 
-func (t *LogHealthTracker) snapshotLog(key logInstanceKey, logID int64, lh *logHealth, now time.Time) LogHealthSnapshot {
-	snap := LogHealthSnapshot{
+func (t *Tracker) snapshotLog(key logInstanceKey, logID int64, lh *logHealth, now time.Time) LogSnapshot {
+	snap := LogSnapshot{
 		BucketName:         key.bucketName,
 		RootPath:           key.rootPath,
 		LogID:              logID,
@@ -480,8 +608,8 @@ func (t *LogHealthTracker) snapshotLog(key logInstanceKey, logID int64, lh *logH
 		LastReadSuccessMS:  lh.readSuccessMS.Load(),
 		LastReadFailureMS:  lh.readFailureMS.Load(),
 	}
-	if r := lh.failureReason.Load(); r != nil {
-		snap.LastFailureReason = *r
+	if rp := lh.failureReason.Load(); rp != nil {
+		snap.LastFailureReason = *rp
 	}
 	writeAttempt := lh.writeAttemptMS.Load()
 	snap.WriteState = t.classify(snap.LastWriteSuccessMS, snap.LastWriteFailureMS, writeAttempt, now, true)
@@ -490,12 +618,11 @@ func (t *LogHealthTracker) snapshotLog(key logInstanceKey, logID int64, lh *logH
 	return snap
 }
 
-// classify derives one direction's state from its timestamps. Stalled is only
-// reachable when allowStall is true (writes) AND the log was previously healthy
-// (lastSuccess > 0): a never-succeeded log is Failed or Idle, never Stalled.
-func (t *LogHealthTracker) classify(lastSuccess, lastFailure, lastAttempt int64, now time.Time, allowStall bool) string {
+// classify derives one direction's state. Stalled requires allowStall (writes) AND a
+// prior success (lastSuccess > 0): a never-succeeded log is Failed or Idle, not Stalled.
+func (t *Tracker) classify(lastSuccess, lastFailure, lastAttempt int64, now time.Time, allowStall bool) string {
 	if lastSuccess == 0 && lastFailure == 0 && lastAttempt == 0 {
-		return logStateIdle // no activity in this direction
+		return logStateIdle
 	}
 	nowMS := now.UnixMilli()
 	stallMS := int64(t.stallAfter / time.Millisecond)
@@ -513,8 +640,7 @@ func (t *LogHealthTracker) classify(lastSuccess, lastFailure, lastAttempt int64,
 	return logStateIdle
 }
 
-// overallLogState combines the two direction-states, worst-wins:
-// Stalled > Failed > Healthy > Idle.
+// overallLogState combines the two directions, worst-wins: Stalled > Failed > Healthy > Idle.
 func overallLogState(writeState, readState string) string {
 	switch {
 	case writeState == logStateStalled || readState == logStateStalled:
@@ -528,161 +654,88 @@ func overallLogState(writeState, readState string) string {
 	}
 }
 
-// GetLogHealth builds the node-wide snapshot. Empty filters mean "all tenants".
-func (s *Server) GetLogHealth(_ context.Context, bucketFilter, rootPathFilter string) (LogHealthResponse, int) {
-	tracker := s.logHealthTracker
-	if tracker == nil {
-		tracker = NewLogHealthTracker(defaultLogHealthStallAfter)
+// Report is the production entry point for the admin callback: nodeID from
+// metrics.NodeID, now from time.Now(), and state -> HTTP status.
+func (t *Tracker) Report(bucketFilter, rootPathFilter string) (Response, int) {
+	if t == nil {
+		return Response{State: StateHealthy, Reason: "no_observed_activity", Logs: []LogSnapshot{}}, http.StatusOK
 	}
-	nodeID := ""
-	if s.serverConfig != nil {
-		nodeID = s.serverConfig.NodeID
-	}
-	resp := tracker.Snapshot(bucketFilter, rootPathFilter, nodeID, time.Now())
-	if resp.State == LogHealthStateUnhealthy {
+	resp := t.Snapshot(bucketFilter, rootPathFilter, metrics.NodeID, time.Now())
+	if resp.State == StateUnhealthy {
 		return resp, http.StatusServiceUnavailable
 	}
 	return resp, http.StatusOK
 }
 ```
 
-- [ ] **Step 3: Update `server/service.go`**
+- [ ] **Step 4: Run tests (with race detector)**
 
-3a. Rename the struct field at `server/service.go:54`:
+Run: `go test -race ./common/runtime/loghealth/...`
+Expected: PASS.
 
-```go
-	logHealthTracker      *LogHealthTracker
-```
-
-3b. Rename the constructor field at `server/service.go:129`:
-
-```go
-		logHealthTracker: NewLogHealthTracker(defaultLogHealthStallAfter),
-```
-
-3c. Replace the write attempt block at `:365-368`:
-
-```go
-	if s.logHealthTracker != nil {
-		s.logHealthTracker.RecordWriteAttempt(request.BucketName, request.RootPath, request.LogId, time.Now())
-	}
-```
-
-3d. Replace the buffer-error block at `:375-377`:
-
-```go
-		if s.logHealthTracker != nil {
-			s.logHealthTracker.RecordWriteFailure(request.BucketName, request.RootPath, request.LogId, time.Now(), err.Error())
-		}
-```
-
-3e. Remove the send-buffered-failure tracking entirely (old `:399-401`). A transport send failure is the client giving up, not a storage fault — so the block becomes just the existing log line:
-
-```go
-	if sendErr != nil {
-		logger.Ctx(streamCtx).Warn("failed to send buffered response", zap.Error(sendErr))
-		return sendErr
-	}
-```
-
-3f. Replace the ReadResult-error block at `:408-414`:
-
-```go
-		if s.logHealthTracker != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				// client gave up — not a storage fault, no-op
-			} else {
-				s.logHealthTracker.RecordWriteFailure(request.BucketName, request.RootPath, request.LogId, time.Now(), err.Error())
-			}
-		}
-```
-
-3g. Replace the result.Err block at `:428-430`:
-
-```go
-		if s.logHealthTracker != nil {
-			s.logHealthTracker.RecordWriteFailure(request.BucketName, request.RootPath, request.LogId, time.Now(), result.Err.Error())
-		}
-```
-
-3h. Replace the success block at `:439-441`:
-
-```go
-	if s.logHealthTracker != nil {
-		s.logHealthTracker.RecordWriteSuccess(request.BucketName, request.RootPath, request.LogId, time.Now())
-	}
-```
-
-3i. Add read instrumentation in `GetBatchEntriesAdv` (`:452-460`). Replace the whole function body:
-
-```go
-func (s *Server) GetBatchEntriesAdv(ctx context.Context, request *proto.GetBatchEntriesAdvRequest) (*proto.GetBatchEntriesAdvResponse, error) {
-	result, err := s.logStore.GetBatchEntriesAdv(ctx, request.BucketName, request.RootPath, request.LogId, request.SegmentId, request.FromEntryId, request.MaxEntries, request.LastReadState)
-	if err != nil {
-		if s.logHealthTracker != nil {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				// client gave up — not a storage fault, no-op
-			} else {
-				s.logHealthTracker.RecordReadFailure(request.BucketName, request.RootPath, request.LogId, time.Now(), err.Error())
-			}
-		}
-		return &proto.GetBatchEntriesAdvResponse{
-			Status: werr.Status(err),
-		}, nil
-	}
-	if s.logHealthTracker != nil {
-		s.logHealthTracker.RecordReadSuccess(request.BucketName, request.RootPath, request.LogId, time.Now())
-	}
-	return &proto.GetBatchEntriesAdvResponse{Status: werr.Success(), Result: result}, nil
-}
-```
-
-(The `errors` import added by the draft at `server/service.go:22` stays — it's still used.)
-
-- [ ] **Step 4: Update `server/service_test.go`**
-
-4a. Rename the field in both helpers (`:55` and `:509`):
-
-```go
-		logHealthTracker: NewLogHealthTracker(defaultLogHealthStallAfter),
-```
-
-4b. Replace the assertions in `TestServer_AddEntry_Success` (`:974-977`):
-
-```go
-	health, statusCode := s.GetLogHealth(context.Background(), "", "")
-	assert.Equal(t, 200, statusCode)
-	assert.Equal(t, LogHealthStateHealthy, health.State)
-	assert.Equal(t, 1, health.HealthyLogs)
-```
-
-4c. Replace the assertions in `TestServer_AddEntry_AddEntryError` (`:1001-1004`):
-
-```go
-	health, statusCode := s.GetLogHealth(context.Background(), "", "")
-	assert.Equal(t, 503, statusCode)
-	assert.Equal(t, LogHealthStateUnhealthy, health.State)
-	assert.Equal(t, 1, health.FailedLogs)
-```
-
-- [ ] **Step 5: Run the server-package tests (with race detector)**
-
-Run: `go test -race ./server/...`
-Expected: PASS (all `TestLogHealth_*`, `TestServer_GetLogHealth_StatusCode`, and the two `TestServer_AddEntry_*` health assertions). Note: `go build ./...` is still expected to fail here because `cmd` and `common/http` reference the old symbols — that is fixed in Task 2.
-
-- [ ] **Step 6: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add server/log_health.go server/log_health_test.go server/service.go server/service_test.go
-git add -u server/   # stages the rw_health.go / rw_health_test.go deletions
-git commit -m "feat(server): lightweight per-log r/w health tracker (#131)
+git add common/runtime/loghealth/
+git commit -m "feat(loghealth): per-log r/w health tracker as OpObserver (#131)
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ```
 
 ---
 
-## Task 2: Rename the HTTP handler, route, and wiring (`management` + `common/http` + `cmd`)
+## Task 3: Label the logstore ops; revert the draft in package `server`
+
+**Files:**
+- Modify: `server/logstore.go:197`, `:300`
+- Revert: `server/service.go`, `server/service_test.go`
+- Delete: `server/rw_health.go`, `server/rw_health_test.go`
+
+- [ ] **Step 1: Add `WithInstance` to the two observed StartOp calls**
+
+`server/logstore.go:197` (add_entry) — add `metrics.WithInstance(bucketName, rootPath)`:
+
+```go
+	op := metrics.StartOp("logstore.add_entry", nil, nil, metrics.WithInstance(bucketName, rootPath), metrics.WithLogSegment(logId, entry.SegId))
+```
+
+`server/logstore.go:300` (get_batch_entries):
+
+```go
+	op := metrics.StartOp("logstore.get_batch_entries", nil, nil, metrics.WithInstance(bucketName, rootPath), metrics.WithLogSegment(logId, segmentId))
+```
+
+- [ ] **Step 2: Revert the draft instrumentation and delete the superseded files**
+
+```bash
+git checkout HEAD -- server/service.go server/service_test.go
+git rm server/rw_health.go server/rw_health_test.go
+```
+
+This restores the upstream `AddEntry` / `GetBatchEntriesAdv` (no `rwHealthTracker`
+field, no manual record calls) and removes the old tracker + its tests. The health
+feature now lives entirely in the observer wired from `main` (Task 4) — package
+`server` carries no health logic beyond emitting the already-labelled ops.
+
+- [ ] **Step 3: Build and test package `server`**
+
+Run: `go build ./server/... && go test ./server/...`
+Expected: PASS. (Full `go build ./...` is still red — `cmd` references the removed
+`srv.GetServerRWHealth`; fixed in Task 4.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add server/logstore.go
+git add -u server/   # stages service.go/service_test.go revert + rw_health*.go deletions
+git commit -m "feat(logstore): tag add_entry/get_batch_entries ops with instance; drop rw_health draft (#131)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: HTTP handler, route, and `main` wiring
 
 **Files:**
 - Create: `common/http/management/log_health_handler.go`
@@ -691,7 +744,7 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 - Delete: `common/http/management/rw_health_handler_test.go`
 - Modify: `common/http/router.go:49-53`
 - Modify: `common/http/server.go:62-63`, `:195-206`
-- Modify: `cmd/main.go:224-229`
+- Modify: `cmd/main.go` (imports, `:201` area, `:224-229`)
 
 - [ ] **Step 1: Write the handler test**
 
@@ -716,15 +769,12 @@ import (
 
 func TestLogHealthHandler_NoFilterReturnsAll(t *testing.T) {
 	var gotBucket, gotRoot string
-	handler := NewLogHealthHandler(func(_ context.Context, bucketName, rootPath string) (any, int) {
-		gotBucket, gotRoot = bucketName, rootPath
+	h := NewLogHealthHandler(func(_ context.Context, b, r string) (any, int) {
+		gotBucket, gotRoot = b, r
 		return map[string]string{"state": "Healthy"}, http.StatusOK
 	})
-
-	req := httptest.NewRequest(http.MethodGet, "/admin/log-health", nil)
 	rec := httptest.NewRecorder()
-	handler(rec, req)
-
+	h(rec, httptest.NewRequest(http.MethodGet, "/admin/log-health", nil))
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Empty(t, gotBucket)
 	require.Empty(t, gotRoot)
@@ -732,54 +782,42 @@ func TestLogHealthHandler_NoFilterReturnsAll(t *testing.T) {
 
 func TestLogHealthHandler_PartialFilterIgnored(t *testing.T) {
 	var gotBucket, gotRoot string
-	handler := NewLogHealthHandler(func(_ context.Context, bucketName, rootPath string) (any, int) {
-		gotBucket, gotRoot = bucketName, rootPath
+	h := NewLogHealthHandler(func(_ context.Context, b, r string) (any, int) {
+		gotBucket, gotRoot = b, r
 		return map[string]string{}, http.StatusOK
 	})
-
-	// only bucket_name -> treated as "no filter"
-	req := httptest.NewRequest(http.MethodGet, "/admin/log-health?bucket_name=b", nil)
 	rec := httptest.NewRecorder()
-	handler(rec, req)
-
+	h(rec, httptest.NewRequest(http.MethodGet, "/admin/log-health?bucket_name=b", nil))
 	require.Empty(t, gotBucket)
 	require.Empty(t, gotRoot)
 }
 
 func TestLogHealthHandler_FilterPassedThrough(t *testing.T) {
 	var gotBucket, gotRoot string
-	handler := NewLogHealthHandler(func(_ context.Context, bucketName, rootPath string) (any, int) {
-		gotBucket, gotRoot = bucketName, rootPath
+	h := NewLogHealthHandler(func(_ context.Context, b, r string) (any, int) {
+		gotBucket, gotRoot = b, r
 		return map[string]string{}, http.StatusServiceUnavailable
 	})
-
-	req := httptest.NewRequest(http.MethodGet, "/admin/log-health?bucket_name=b&root_path=r", nil)
 	rec := httptest.NewRecorder()
-	handler(rec, req)
-
+	h(rec, httptest.NewRequest(http.MethodGet, "/admin/log-health?bucket_name=b&root_path=r", nil))
 	require.Equal(t, "b", gotBucket)
 	require.Equal(t, "r", gotRoot)
 	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }
 
 func TestLogHealthHandler_RejectsNonGet(t *testing.T) {
-	handler := NewLogHealthHandler(func(context.Context, string, string) (any, int) {
-		return nil, http.StatusOK
-	})
-	req := httptest.NewRequest(http.MethodPost, "/admin/log-health", nil)
+	h := NewLogHealthHandler(func(context.Context, string, string) (any, int) { return nil, http.StatusOK })
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	h(rec, httptest.NewRequest(http.MethodPost, "/admin/log-health", nil))
 	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
 }
 
 func TestLogHealthHandler_EncodesJSON(t *testing.T) {
-	handler := NewLogHealthHandler(func(context.Context, string, string) (any, int) {
+	h := NewLogHealthHandler(func(context.Context, string, string) (any, int) {
 		return map[string]any{"state": "Healthy", "tracked_logs": 0}, http.StatusOK
 	})
-	req := httptest.NewRequest(http.MethodGet, "/admin/log-health", nil)
 	rec := httptest.NewRecorder()
-	handler(rec, req)
-
+	h(rec, httptest.NewRequest(http.MethodGet, "/admin/log-health", nil))
 	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
@@ -787,12 +825,12 @@ func TestLogHealthHandler_EncodesJSON(t *testing.T) {
 }
 ```
 
-- [ ] **Step 2: Run the handler test to verify it fails to compile**
+- [ ] **Step 2: Run it — verify it fails to compile**
 
 Run: `go test ./common/http/management/...`
 Expected: FAIL — `undefined: NewLogHealthHandler`.
 
-- [ ] **Step 3: Write the handler implementation**
+- [ ] **Step 3: Write the handler**
 
 ```bash
 git rm common/http/management/rw_health_handler.go
@@ -815,7 +853,7 @@ type LogHealthCallback func(ctx context.Context, bucketName, rootPath string) (a
 
 // NewLogHealthHandler serves the node-wide log health endpoint.
 // Optional query params: ?bucket_name=<bucket>&root_path=<root>.
-// A partial filter (only one of the two) is ignored and all tenants are returned.
+// A partial filter (only one of the two) is ignored — all tenants are returned.
 func NewLogHealthHandler(get LogHealthCallback) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -884,34 +922,47 @@ const AdminLogHealthPath = "/admin/log-health"
 	}
 ```
 
-- [ ] **Step 6: Update `cmd/main.go`**
+- [ ] **Step 6: Wire `cmd/main.go`**
 
-Replace the two callbacks at `:224-229`:
+6a. Add the import (with the other `common/runtime/...` imports):
 
 ```go
-		GetLogHealth: func(ctx context.Context, bucketName, rootPath string) (any, int) {
-			return srv.GetLogHealth(ctx, bucketName, rootPath)
+	"github.com/zilliztech/woodpecker/common/runtime/loghealth"
+```
+
+6b. Create + register the tracker next to `opReg` (after `cmd/main.go:201`):
+
+```go
+	logHealth := loghealth.New(loghealth.DefaultStallAfter)
+	metrics.RegisterOpObserver(logHealth)
+```
+
+6c. Replace the two RW callbacks at `:224-229` with:
+
+```go
+		GetLogHealth: func(_ context.Context, bucketName, rootPath string) (any, int) {
+			return logHealth.Report(bucketName, rootPath)
 		},
 ```
 
-- [ ] **Step 7: Build the whole module and run the management tests**
+- [ ] **Step 7: Build the module and run http tests**
 
 Run: `go build ./... && go test ./common/http/...`
-Expected: build succeeds (module is now consistent), management handler tests PASS.
+Expected: build succeeds (module consistent), handler tests PASS.
 
 - [ ] **Step 8: Commit**
 
 ```bash
 git add common/http/management/log_health_handler.go common/http/management/log_health_handler_test.go common/http/router.go common/http/server.go cmd/main.go
-git add -u common/http/management/   # stages the rw_health_handler*.go deletions
-git commit -m "feat(http): node-wide /admin/log-health endpoint (#131)
+git add -u common/http/management/   # stages rw_health_handler*.go deletions
+git commit -m "feat(http): /admin/log-health endpoint wired to loghealth observer (#131)
 
 Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 ```
 
 ---
 
-## Task 3: Documentation and final verification
+## Task 5: Documentation and final verification
 
 **Files:**
 - Modify: `common/http/README.md:14-15`, `:86-91`
@@ -935,16 +986,18 @@ curl "http://localhost:9091/admin/log-health?bucket_name=a-bucket&root_path=file
 
 ```markdown
 - `/admin/log-health` reports each log's observed read/write health on this node,
-  derived from real traffic (no injected probe). With no query params it returns all
-  tenants; passing both `bucket_name` and `root_path` narrows to one instance.
-- It is independent of `/healthz`: `/healthz` is process liveness; `/admin/log-health`
-  is data-path health and never affects the `/healthz` result.
+  derived from real traffic via the metrics op stream (no injected probe). With no
+  query params it returns all tenants; passing both `bucket_name` and `root_path`
+  narrows to one instance.
+- Write health is the logstore "accept" outcome (`logstore.add_entry`); read health is
+  `logstore.get_batch_entries`. Independent of `/healthz` (process liveness) — a
+  stalled log never affects the `/healthz` result.
 - Returns HTTP `503` when every tracked log is Stalled or Failed, `200` otherwise.
 ```
 
 - [ ] **Step 3: Final full verification**
 
-Run: `go build ./... && go vet ./server/... ./common/http/... ./cmd/... && go test -race ./server/... ./common/http/...`
+Run: `go build ./... && go vet ./common/... ./server/... ./cmd/... && go test -race ./common/metrics/... ./common/runtime/loghealth/... ./common/http/... ./server/...`
 Expected: build clean, vet clean, all tests PASS.
 
 - [ ] **Step 4: Confirm no stale RW references remain**
@@ -965,6 +1018,20 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ## Self-Review Notes
 
-- **Spec coverage:** atomic-timestamp model (Task 1 Step 2), read+write instrumentation (Task 1 Step 3), per-log classification incl. high-QPS stall (Task 1 tests `TestLogHealth_HungWriteBecomesStalledUnderLoad`), node rollup + idle-stays-healthy (`TestLogHealth_IdleNodeStaysHealthy`), node-wide scope + per-log triple + filter (`TestLogHealth_MultiTenantAndFilter`), single endpoint / cluster code deleted (Task 2), `/healthz` independence documented (Task 3), no idle storage probe (not implemented, by design).
-- **Refinement vs spec:** `classify` requires `lastSuccess > 0` for both Healthy and Stalled — a log that has *never* succeeded is Failed (if a recent failure exists) or Idle, never Stalled. This avoids the `now - 0` bootstrap false-positive and matches the intuitive meaning of "stalled" (was healthy, stopped completing). Spec's Stalled row is read with this precondition.
-- **Type consistency:** record methods take `(bucket, rootPath, logID, now[, reason])` everywhere (no more `*RWWriteAttempt`); field is `logHealthTracker`; callback type `LogHealthCallback`; route const `AdminLogHealthPath`; response types `LogHealthResponse` / `LogHealthSnapshot`. Status code is `503` (was `500` in the draft) per spec.
+- **Spec coverage:** observer-based data source + ownership in main (Task 2 + Task 4
+  Step 6); `WithInstance` for the multi-tenant triple (Task 1, Task 3 Step 1);
+  zero data-path intrusion / draft reverted (Task 3 Step 2); classification incl.
+  high-QPS stall and never-succeeded≠stalled (Task 2 tests); node rollup + idle-stays-
+  healthy; node-wide scope + filter; single endpoint, cluster code deleted (Task 4);
+  `/healthz` independence + logstore-layer semantics documented (Task 5); no idle
+  storage probe (by design, not implemented).
+- **Placeholder scan:** none — every code/test step contains full content.
+- **Type consistency:** package `loghealth`; `Tracker`, `Response`, `LogSnapshot`;
+  `New`/`Snapshot`/`Report`; observer methods `OnOpStart`/`OnOpEnd`; op-type consts
+  match `server/logstore.go` strings; `metrics.WithInstance`/`Op.BucketName`/`RootPath`;
+  callback `management.LogHealthCallback`; route `AdminLogHealthPath`; HTTP status 503
+  on Unhealthy.
+- **Observer registration** lives only in `main` (not a constructor) → no global
+  observer-chain pollution across test `Server`s; tracker tests use
+  `metrics.ResetObservers()`.
+```

--- a/docs/superpowers/specs/2026-06-01-log-health-design.md
+++ b/docs/superpowers/specs/2026-06-01-log-health-design.md
@@ -146,7 +146,7 @@ For a direction with `lastSuccess`, `lastFailure`, and (write only) `lastAttempt
 | Direction state | Rule |
 |---|---|
 | **Healthy** | `now - lastSuccess ≤ stallAfter` (succeeded recently) |
-| **Stalled** (write only) | `now - lastSuccess > stallAfter` **AND** `lastAttempt > lastSuccess` **AND** `lastAttempt > lastFailure` — work is flowing in but nothing completes (catches hung writes even under high QPS, because the rule keys off the age of the last *success*, not the last attempt) |
+| **Stalled** (write only) | `lastSuccess > 0` **AND** `now - lastSuccess > stallAfter` **AND** `lastAttempt > lastSuccess` **AND** `lastAttempt > lastFailure` — was healthy, then work keeps flowing in but nothing completes (catches hung writes even under high QPS, because the rule keys off the age of the last *success*, not the last attempt). A log that has *never* succeeded is never Stalled — it is Failed (recent failure) or Idle. |
 | **Failed** | `lastFailure > lastSuccess` **AND** `now - lastFailure ≤ stallAfter` (recent terminal failures) |
 | **Idle** | no observed activity, or success & failure both stale (older than `stallAfter`) and not Stalled. Idle is informational — the last terminal outcome is still visible via the `last_*_ms` timestamps in the response, so an operator can read "last known status" directly. |
 

--- a/docs/superpowers/specs/2026-06-01-log-health-design.md
+++ b/docs/superpowers/specs/2026-06-01-log-health-design.md
@@ -8,8 +8,8 @@
 
 The existing `/healthz` probe only confirms the **process** is up and its role is
 registered. It does **not** verify that logs can actually be written to and read
-from the underlying storage. A node can pass `/healthz` while every write to
-storage hangs or fails.
+from the underlying storage/buffer. A node can pass `/healthz` while every write
+hangs or fails.
 
 We want a second, **orthogonal** probe that answers: *"can this node still read and
 write its logs?"* — derived purely from the read/write activity the node already
@@ -21,8 +21,11 @@ performs, with no injected probe traffic and no measurable cost on the hot path.
   messages injected — explicitly per the issue).
 - A single per-node HTTP endpoint that reports each tracked log's state plus a
   node-level rollup.
-- Hot-path cost ≈ a shared `RLock` + a map lookup + one `atomic.Store`. No
-  allocation, no exclusive lock, no per-write bookkeeping.
+- **Minimal code intrusion:** reuse the existing `metrics.Op` / `OpObserver`
+  instrumentation that already wraps every logstore operation. The data-path
+  business code (`server/service.go`, the body of `logstore` ops) is **not** touched.
+- Hot-path cost ≈ a shared `RLock` + a map lookup + one `atomic.Store` per observed
+  op. No allocation, no exclusive lock, no per-op bookkeeping in the tracker.
 
 ## Non-Goals
 
@@ -34,12 +37,16 @@ performs, with no injected probe traffic and no measurable cost on the hot path.
 - **No active/injected probe** (unlike Pulsar's topic `healthcheck`, which produces
   and consumes a probe message). We only observe traffic that already happens.
 - **No idle storage fallback** (no `HeadBucket`). An idle log with no observed
-  activity reports `Healthy` — see Idle handling below. Active probing is a
-  possible future feature, out of scope here.
+  activity reports `Healthy` — see Idle handling below. Active probing is a possible
+  future feature, out of scope here.
 - **No cluster-wide aggregation.** Each node answers only for itself; any caller
   (monitor / load balancer / operator) aggregates across nodes. The previously
   drafted `GetClusterRWHealth` / peer HTTP fan-out / memberlist parsing / quorum
   logic is removed.
+- **No storage-layer signal.** Write health is taken from the **logstore layer**
+  (`logstore.add_entry`), i.e. the client-observed "request accepted" outcome — not
+  from `file.flush`/`file.sync`. See "Signal source & semantics" for the accepted
+  consequence.
 
 ## Relationship to `/healthz`
 
@@ -47,40 +54,112 @@ performs, with no injected probe traffic and no measurable cost on the hot path.
 |---|---|---|
 | Package | `common/http/health/` | `common/http/management/` |
 | Meaning | Process liveness — process up, role registered | Data-path health — real R/W path works, per log |
-| Data source | role indicators | `LogHealthTracker` atomic timestamps |
-| Response type | `health.HealthResponse` | `LogHealthResponse` |
+| Data source | role indicators | `loghealth.Tracker` atomic timestamps, fed by `OpObserver` |
+| Response type | `health.HealthResponse` | `loghealth.Response` |
 
 They are two orthogonal layers of liveness and share no code.
 
+## How we observe (the key design decision)
+
+Woodpecker already instruments every logstore operation. In `server/logstore.go`:
+
+```go
+op := metrics.StartOp("logstore.add_entry", nil, nil, metrics.WithLogSegment(logId, entry.SegId))
+status := "success"
+defer func() { op.End(status); /* ...prometheus... */ }()
+```
+
+`metrics.StartOp`/`op.End(status)` notify a **global chain of `OpObserver`s**
+(`common/metrics/op_observer.go`); the `opregistry.Registry` is already such an
+observer. We add a second observer instead of hand-writing record calls in the
+hot path.
+
+### Ownership & lifecycle
+
+The tracker is a self-contained object. Whoever creates it and calls
+`metrics.RegisterOpObserver(t)` receives the op stream; the tracker holds the only
+state. There is **no hard constraint** on where it lives, only two soft ones:
+
+1. The same instance must be reachable by both the hot path (via the global observer
+   chain — automatic once registered) and the admin endpoint (via the
+   `GetLogHealth` callback closure).
+2. It must be registered **once, at startup, before serving traffic** (per
+   `RegisterOpObserver`'s contract) — so registration belongs in `main`, not in a
+   per-instance constructor (which would re-register on every test `Server`).
+
+We therefore mirror the existing `opReg` pattern exactly: **create and register the
+tracker in `cmd/main.go`**, and wire the same instance into the admin callback. The
+tracker lives in its own package `common/runtime/loghealth`, sibling to
+`opregistry`. `server/service.go` and `server/logstore.go` business logic are
+untouched (the only `logstore.go` change is adding instance labels to two `StartOp`
+calls — see Wiring).
+
+```
+              cmd/main.go (process scope, runs once)
+                 t := loghealth.New(stallAfter)
+                 metrics.RegisterOpObserver(t)            ← into global chain
+                 GetLogHealth: func(b,r){ return t.Report(b,r) }
+                          │ same *t referenced twice
+        ┌─────────────────┴──────────────────┐
+        ▼                                     ▼
+   hot path (write/read)                 admin endpoint (read)
+ logstore.add_entry / get_batch_entries   GET /admin/log-health
+   → StartOp / op.End(status)               → t.Report(...)
+   → metrics fans out to observers          → RLock + read atomics
+   → t.OnOpStart / t.OnOpEnd
+   → updates t.logs map (atomic stores)  ← the only data structure
+```
+
+### Signal source & semantics
+
+- **Write** = `logstore.add_entry` op. Its `End(status)` fires when the entry is
+  **accepted into the buffer** (the sync-to-storage is asynchronous and not part of
+  this op). So "Healthy write" means "the node is accepting writes", which is the
+  client-observed outcome. **Accepted consequence:** a storage backend that hangs on
+  flush while buffering still succeeds will *not* show Unhealthy until back-pressure
+  makes `add_entry` itself error. This is the deliberate trade-off of choosing the
+  logstore layer over `file.flush`.
+- **Read** = `logstore.get_batch_entries` op `End(status)`.
+- **Success vs failure** = `status == "success"` (the literal logstore uses) →
+  success; any other status → failure.
+- **Client cancel:** because `add_entry`'s op ends at buffering (it does not span the
+  client's sync-wait), client cancellation during the sync-wait is naturally not
+  observed as a write failure. A `get_batch_entries` cancelled mid-call ends with a
+  non-success status and is counted as a read failure; this minor noise is accepted
+  and can be refined later by inspecting the status string if needed.
+
 ## Naming
 
-Renamed from the earlier `rw_health` draft to `log_health` — the granularity is "per
-log", matching the granularity (not the mechanism) of Pulsar's per-topic health
-check.
+Granularity is "per log", matching the granularity (not the mechanism) of Pulsar's
+per-topic health check. The earlier `rw_health` draft is superseded.
 
-| Earlier draft | This design |
+| Earlier `rw_health` draft | This design |
 |---|---|
-| `server/rw_health.go` | `server/log_health.go` |
+| `server/rw_health.go` (Server-owned tracker) | `common/runtime/loghealth/tracker.go` (standalone observer) |
+| manual record calls in `server/service.go` | **reverted** — observer instead |
+| `RWHealthTracker` | `loghealth.Tracker` |
+| `ServerRWHealthResponse` | `loghealth.Response` |
+| `RWLogHealthSnapshot` | `loghealth.LogSnapshot` |
 | `common/http/management/rw_health_handler.go` | `common/http/management/log_health_handler.go` |
-| `RWHealthTracker` | `LogHealthTracker` |
-| `ServerRWHealthResponse` | `LogHealthResponse` |
-| `RWLogHealthSnapshot` | `LogHealthSnapshot` |
-| `RWHealthStateHealthy` / `…Unhealthy` | `LogHealthStateHealthy` / `…Unhealthy` |
 | route `/admin/server-rw-health` | `/admin/log-health` |
-| `ClusterRWHealthResponse`, `GetClusterRWHealth`, `fetchPeerRWHealth`, `rwHealthPeer`, quorum aggregation | **deleted** |
+| `ClusterRWHealthResponse`, `GetClusterRWHealth`, `fetchPeerRWHealth`, quorum | **deleted** |
 
 ## Architecture
 
 ### Components
 
-1. **`LogHealthTracker`** (`server/log_health.go`) — owns the in-memory state, the
-   record methods called from the hot path, and snapshot/classification logic.
-2. **Hot-path instrumentation** — calls into the tracker from `Server.AddEntry`
-   (write) and `Server.GetBatchEntriesAdv` (read).
-3. **HTTP handler** (`common/http/management/log_health_handler.go`) — parses the
+1. **`loghealth.Tracker`** (`common/runtime/loghealth/tracker.go`) — implements
+   `metrics.OpObserver`; owns the in-memory state and the classification / snapshot
+   logic. The single source of truth.
+2. **`metrics.Op` instance fields** (`common/metrics/op.go`) — new `BucketName` /
+   `RootPath` fields + a `WithInstance(bucket, root)` option, so observers receive the
+   multi-tenant identity. (Today `Op` only carries `LogID`/`SegmentID`.)
+3. **Two `StartOp` call sites** (`server/logstore.go`) — pass
+   `WithInstance(bucketName, rootPath)` for `add_entry` and `get_batch_entries`.
+4. **HTTP handler** (`common/http/management/log_health_handler.go`) — parses the
    optional `bucket_name` / `root_path` filter and serializes the response.
-4. **Wiring** — `Server.GetLogHealth` callback, registered at route
-   `/admin/log-health` in `common/http/server.go`, exposed from `cmd/main.go`.
+5. **Wiring** (`cmd/main.go`, `common/http/{router,server}.go`) — create + register
+   the tracker, expose route `/admin/log-health`.
 
 ### Data model — lock-free hot path
 
@@ -88,77 +167,89 @@ check.
 type logInstanceKey struct{ bucketName, rootPath string }
 
 type logHealth struct {
-    writeAttemptMS atomic.Int64 // set when AddEntry starts (writes can hang in-flight)
+    writeAttemptMS atomic.Int64 // OnOpStart(add_entry); writes can hang in-flight
     writeSuccessMS atomic.Int64
     writeFailureMS atomic.Int64
-    readSuccessMS  atomic.Int64 // reads are synchronous — no attempt timestamp
+    readSuccessMS  atomic.Int64 // reads: only success/failure, no attempt timestamp
     readFailureMS  atomic.Int64
-    failureReason  atomic.Pointer[string] // last failure reason, optional/diagnostic
+    failureReason  atomic.Pointer[string] // last failure reason, diagnostic
 }
 
-type LogHealthTracker struct {
+type Tracker struct {
     mu         sync.RWMutex // guards map STRUCTURE only
     stallAfter time.Duration
     logs       map[logInstanceKey]map[int64]*logHealth
 }
 ```
 
-**Hot path:** `RLock` (shared) → map lookup → `atomic.Store` on the relevant field →
-`RUnlock`. The first write/read ever seen for a `(bucket, rootPath, logID)` takes the
+**Hot path** (inside `OnOpStart`/`OnOpEnd`): `RLock` (shared) → map lookup →
+`atomic.Store`. The first op ever seen for a `(bucket, rootPath, logID)` takes the
 write lock once to create the `*logHealth`; every subsequent record is shared-lock +
-atomic only. No allocation per write, no exclusive lock per write, no per-write ID.
+atomic only. No allocation, no exclusive lock, no per-op ID.
 
-### Record methods
+### Observer integration
 
-- `RecordWriteAttempt(bucket, rootPath, logID, now)` — store `writeAttemptMS`.
-- `RecordWriteSuccess(bucket, rootPath, logID, now)` — store `writeSuccessMS`.
-- `RecordWriteFailure(bucket, rootPath, logID, now, reason)` — store `writeFailureMS`
-  + `failureReason`.
-- `RecordReadSuccess(bucket, rootPath, logID, now)` — store `readSuccessMS`.
-- `RecordReadFailure(bucket, rootPath, logID, now, reason)` — store `readFailureMS`
-  + `failureReason`.
+The tracker implements `metrics.OpObserver`. The observer methods are thin adapters
+that translate an `*metrics.Op` into an internal record call; the internal record
+methods take explicit `(bucket, rootPath, logID, now[, reason])` so they are unit
+testable without constructing `metrics.Op`.
 
-All methods are no-ops when the tracker is `nil`.
+```go
+const (
+    opAddEntry        = "logstore.add_entry"        // must match server/logstore.go StartOp
+    opGetBatchEntries = "logstore.get_batch_entries"
+    statusSuccess     = "success"                   // the literal logstore.go uses
+)
 
-### Instrumentation points
+func (t *Tracker) OnOpStart(op *metrics.Op) uint64 {
+    if op.OpType == opAddEntry {
+        t.recordWriteAttempt(op.BucketName, op.RootPath, op.LogID, op.StartedAt())
+    }
+    return 0 // tracker keeps no per-op handle
+}
 
-- **Write — `Server.AddEntry`:**
-  - `RecordWriteAttempt` at entry start.
-  - `RecordWriteSuccess` when the entry is synced.
-  - `RecordWriteFailure` on buffer error / result error.
-  - **Context cancel / deadline exceeded → no-op** (client gave up; not a storage
-    fault). Simpler than the old "abandoned" path because there is no map entry to
-    clean up.
-- **Read — `Server.GetBatchEntriesAdv`:**
-  - `RecordReadFailure` if the call returns `err`, else `RecordReadSuccess`.
-  - Reads are synchronous, so they have no attempt timestamp and never reach the
-    `Stalled` state — only `Healthy` / `Failed` / `Idle`.
+func (t *Tracker) OnOpEnd(op *metrics.Op, _ uint64, elapsed time.Duration, status string) {
+    now := op.StartedAt().Add(elapsed)
+    ok := status == statusSuccess
+    switch op.OpType {
+    case opAddEntry:
+        if ok { t.recordWriteSuccess(op.BucketName, op.RootPath, op.LogID, now) } else
+        { t.recordWriteFailure(op.BucketName, op.RootPath, op.LogID, now, status) }
+    case opGetBatchEntries:
+        if ok { t.recordReadSuccess(op.BucketName, op.RootPath, op.LogID, now) } else
+        { t.recordReadFailure(op.BucketName, op.RootPath, op.LogID, now, status) }
+    }
+}
+```
+
+Other op types are ignored. All record methods are no-ops when the tracker is `nil`.
+Observer methods must be fast and goroutine-safe (per the `OpObserver` contract) —
+satisfied by the RLock + atomic model.
 
 ### Per-log classification (snapshot time)
 
 `stallAfter` defaults to 10 minutes. Each direction (read, write) is first classified
 independently from its timestamps into a raw direction-state, exposed as
 `write_state` / `read_state` for transparency. The log's single overall `state` is
-then derived from both directions (see "Log overall state" below).
+then derived from both directions (see "Log overall state").
 
 For a direction with `lastSuccess`, `lastFailure`, and (write only) `lastAttempt`:
 
 | Direction state | Rule |
 |---|---|
-| **Healthy** | `now - lastSuccess ≤ stallAfter` (succeeded recently) |
-| **Stalled** (write only) | `lastSuccess > 0` **AND** `now - lastSuccess > stallAfter` **AND** `lastAttempt > lastSuccess` **AND** `lastAttempt > lastFailure` — was healthy, then work keeps flowing in but nothing completes (catches hung writes even under high QPS, because the rule keys off the age of the last *success*, not the last attempt). A log that has *never* succeeded is never Stalled — it is Failed (recent failure) or Idle. |
+| **Healthy** | `lastSuccess > 0` **AND** `now - lastSuccess ≤ stallAfter` (succeeded recently) |
+| **Stalled** (write only) | `lastSuccess > 0` **AND** `now - lastSuccess > stallAfter` **AND** `lastAttempt > lastSuccess` **AND** `lastAttempt > lastFailure` — was healthy, then ops keep starting but none complete (catches a hung `add_entry` even under high QPS, because the rule keys off the age of the last *success*, not the last attempt). A log that has *never* succeeded is never Stalled — it is Failed or Idle. |
 | **Failed** | `lastFailure > lastSuccess` **AND** `now - lastFailure ≤ stallAfter` (recent terminal failures) |
-| **Idle** | no observed activity, or success & failure both stale (older than `stallAfter`) and not Stalled. Idle is informational — the last terminal outcome is still visible via the `last_*_ms` timestamps in the response, so an operator can read "last known status" directly. |
+| **Idle** | no observed activity, or success & failure both stale (older than `stallAfter`) and not Stalled. Idle is informational — the last terminal outcome is still visible via the `last_*_ms` timestamps. |
 
 ### Log overall state
 
-A single enum per log, computed from the two direction-states with worst-wins
-precedence `Stalled > Failed > Healthy > Idle`:
+A single enum per log, worst-wins precedence `Stalled > Failed > Healthy > Idle`:
 
 - `Stalled` if the write direction is Stalled.
 - else `Failed` if either direction is Failed.
 - else `Healthy` if either direction is Healthy.
-- else `Idle` (no recent activity in either direction).
+- else `Idle`.
 
 The four counters (`healthy_logs` / `failed_logs` / `stalled_logs` / `idle_logs`) are
 mutually exclusive and partition `tracked_logs` by this overall state.
@@ -166,42 +257,38 @@ mutually exclusive and partition `tracked_logs` by this overall state.
 ### Node-level rollup
 
 The rollup spans **all logs in scope** (all tenants when unfiltered, or the one
-filtered instance). It deliberately keys off **active evidence**, so a merely quiet
-node is never pulled out of rotation:
+filtered instance). It keys off **active evidence**, so a merely quiet node is never
+pulled out of rotation:
 
 - Node `state = Unhealthy` **iff** `tracked_logs > 0` **AND** every tracked log is
-  `Stalled` or `Failed` (zero Healthy, zero Idle — there is current, active evidence
-  the data path is broken across all logs).
-- Otherwise `state = Healthy`: ≥ 1 Healthy log, **or** all/some logs Idle (a quiet
-  node is healthy), **or** no tracked logs at all (reason `no_observed_activity`).
+  `Stalled` or `Failed` (zero Healthy, zero Idle).
+- Otherwise `state = Healthy`: ≥ 1 Healthy log, **or** some/all logs Idle (quiet node
+  is healthy), **or** no tracked logs at all (reason `no_observed_activity`).
 
 This matches the issue's "at least one successfully reading/writing log = Healthy;
-multiple logs stalled simultaneously = Unhealthy", and resolves the idle case
-conservatively (idle alone never forces Unhealthy).
+multiple logs stalled simultaneously = Unhealthy", resolving idle conservatively.
 
 ### HTTP endpoint
 
 **Node-level scope.** Woodpecker is multi-tenant: a node serves many
 `(bucket_name, root_path)` instances at once, and a log is uniquely identified by the
 triple `(bucket_name, root_path, log_id)` (there is no `logName` at the logstore
-layer). So one probe call returns **every** log the node tracks, across all tenants,
-and each log carries its own triple.
+layer). One probe call returns **every** log the node tracks, across all tenants, each
+carrying its own triple.
 
 `GET /admin/log-health[?bucket_name=<bucket>&root_path=<root>]`
 
 - `bucket_name` / `root_path` are **optional filters** (accepts snake/camel/lower
-  variants). When both are supplied, the response is narrowed to that one instance;
-  when omitted, all tracked logs across all tenants are returned. Supplying only one
-  of the two is treated as "no filter" (or 400 — see open detail below); default is
-  to ignore a lone param and return everything.
+  variants). Both supplied → narrowed to that one instance; omitted → all tenants. A
+  lone param (only one of the two) is ignored → returns everything.
 - 405 on non-GET.
-- Body `LogHealthResponse`:
+- Body `loghealth.Response`:
 
 ```jsonc
 {
   "state": "Healthy",              // node rollup: Healthy | Unhealthy
-  "reason": "observed_write_success",
-  "node_id": "...",
+  "reason": "observed_read_write_success",
+  "node_id": "...",                // from metrics.NodeID
   "filter_bucket_name": "",        // echoes the filter when one was applied, else ""
   "filter_root_path": "",
   "timestamp_ms": 0,
@@ -229,59 +316,86 @@ and each log carries its own triple.
 }
 ```
 
-- HTTP status: `200` when node `state == Healthy`, `503` when `Unhealthy` (so a load
-  balancer / probe can act on status code alone). Logs are sorted by
-  `(bucket_name, root_path, log_id)` for stable output.
+- HTTP status: `200` when node `state == Healthy`, `503` when `Unhealthy`. Logs sorted
+  by `(bucket_name, root_path, log_id)` for stable output.
+
+### Public API of `loghealth`
+
+```go
+func New(stallAfter time.Duration) *Tracker
+
+// metrics.OpObserver
+func (t *Tracker) OnOpStart(op *metrics.Op) uint64
+func (t *Tracker) OnOpEnd(op *metrics.Op, handle uint64, elapsed time.Duration, status string)
+
+// Snapshot is pure & deterministic (nodeID and now injected) — used by tests.
+func (t *Tracker) Snapshot(bucketFilter, rootPathFilter, nodeID string, now time.Time) Response
+
+// Report is the production wrapper used by the admin callback: it fills nodeID from
+// metrics.NodeID and now from time.Now(), and maps state -> HTTP status.
+func (t *Tracker) Report(bucketFilter, rootPathFilter string) (Response, int)
+
+// Node rollup states.
+const StateHealthy = "Healthy"
+const StateUnhealthy = "Unhealthy"
+```
 
 ### Wiring
 
-- `Server` gains `logHealthTracker *LogHealthTracker`, constructed in
-  `NewServerWithConfig` with `NewLogHealthTracker(defaultLogHealthStallAfter)`.
-- `Server.GetLogHealth(ctx, bucketFilter, rootPathFilter) (LogHealthResponse, int)`
-  builds the snapshot and returns the response + HTTP status. Empty filter strings
-  mean "all tenants"; when both are non-empty the snapshot is narrowed to that
-  instance.
-- `LogHealthCallback func(ctx, bucketName, rootPath) (any, int)` — the handler passes
-  the parsed filter (empty strings when absent); signature unchanged from the draft.
-- `AdminCallbacks` gains one field `GetLogHealth management.LogHealthCallback`; the
-  cluster callback is removed.
-- `common/http/server.go` registers the route when the callback is set.
-- `cmd/main.go` wires `srv.GetLogHealth`.
-- `common/http/README.md` documents the new route alongside the other admin routes.
+- `common/metrics/op.go`: add `BucketName`, `RootPath` to `Op`; add
+  `WithInstance(bucketName, rootPath string) OpOption`.
+- `server/logstore.go`: add `metrics.WithInstance(bucketName, rootPath)` to the
+  `StartOp` calls for `logstore.add_entry` (~:197) and `logstore.get_batch_entries`
+  (~:300). No other logic changes.
+- `cmd/main.go`: `t := loghealth.New(defaultStallAfter)`;
+  `metrics.RegisterOpObserver(t)` (next to the existing `opReg` registration);
+  add `GetLogHealth: func(_ context.Context, b, r string) (any, int) { return t.Report(b, r) }`.
+- `common/http/server.go`: `AdminCallbacks` gains `GetLogHealth management.LogHealthCallback`;
+  register route when set. Remove the two RW callback fields.
+- `common/http/router.go`: one const `AdminLogHealthPath = "/admin/log-health"`;
+  remove the two RW consts.
+- `common/http/management/log_health_handler.go`: handler + `LogHealthCallback`.
+- **Revert** the `rw_health` draft's edits to `server/service.go` and
+  `server/service_test.go` (restore the upstream `AddEntry`/`GetBatchEntriesAdv` and
+  remove the `rwHealthTracker` field); delete `server/rw_health.go` and
+  `server/rw_health_test.go`.
+- `common/http/README.md`: document the route.
 
 ## Error handling
 
-- `nil` tracker → all record methods no-op; `GetLogHealth` falls back to an empty
-  tracker and reports `Healthy / no_observed_activity`.
-- Missing filter params → return all tenants (not an error). Non-GET → `405`.
-- Client-cancelled writes are deliberately not counted as failures.
+- `nil` tracker → all observer/record methods no-op; `Report` on a `nil` tracker (or
+  empty tracker) yields `Healthy / no_observed_activity`.
+- Missing/partial filter → return all tenants (not an error). Non-GET → `405`.
+- Non-`"success"` op status counts as a failure (see Signal source & semantics).
 
 ## Testing
 
-- **`server/log_health_test.go`** (table-driven, using a fixed injected `now`):
+- **`common/runtime/loghealth/tracker_test.go`** (table-driven, fixed injected `now`,
+  using the internal record methods + `Snapshot`):
   - Each direction-state rule: Healthy, Stalled (incl. high-QPS hung-write case where
     `lastAttempt` is recent but `lastSuccess` is stale), Failed, Idle.
   - Read direction never goes Stalled.
-  - Log overall state precedence `Stalled > Failed > Healthy > Idle`, including a
-    case where write=Healthy and read=Failed → overall Failed.
-  - Counters partition `tracked_logs` (mutually exclusive).
-  - Node rollup: ≥1 healthy → Healthy; some idle + no failures → Healthy (quiet node
-    not pulled out); all stalled/failed → Unhealthy; no logs → Healthy +
-    `no_observed_activity`.
+  - Overall precedence `Stalled > Failed > Healthy > Idle`, incl. write=Healthy +
+    read=Failed → Failed.
+  - Counters partition `tracked_logs`.
+  - Node rollup: ≥1 healthy → Healthy; some idle + no failures → Healthy; all
+    stalled/failed → Unhealthy; no logs → Healthy + `no_observed_activity`.
+  - Multi-tenant: unfiltered returns logs across multiple `(bucket, rootPath)` each
+    tagged with its triple; filter narrows to one instance.
   - `nil` tracker safety.
-  - Concurrency smoke test: many goroutines recording on the same/different logs
-    under `-race` to confirm the RLock + atomic model is data-race free.
-- **`server/log_health_test.go`** also: unfiltered snapshot returns logs across
-  multiple `(bucket, rootPath)` instances, each tagged with its own triple; filtered
-  snapshot narrows to one instance.
+  - Concurrency smoke test under `-race`.
+  - **Observer adapter:** drive via `metrics.StartOp(...WithInstance...)` + `op.End`
+    (with `metrics.ResetObservers()` guard) and assert the resulting state, proving
+    `OnOpStart`/`OnOpEnd` map op-type + status correctly.
+- **`common/metrics/op_test.go`:** `WithInstance` sets `BucketName`/`RootPath`.
 - **`common/http/management/log_health_handler_test.go`:** no-filter returns all,
-  filter narrows, 405 non-GET, 200 vs 503 by node state, JSON shape (per-log triple
-  present).
-- **`server/service_test.go`:** adjust existing tests to the renamed
-  symbols/endpoint; drop cluster-health expectations.
+  filter narrows, lone param ignored, 405 non-GET, 200 vs 503 by node state, JSON
+  shape (per-log triple present).
 
 ## Migration / cleanup
 
-The earlier `rw_health` draft (working-tree changes, not yet committed) is
-superseded: rename the two files, rename the surviving symbols, and delete the entire
-cluster/quorum/peer/`PendingWrites`-map code path.
+The earlier `rw_health` draft (working-tree changes, not yet committed) is superseded:
+revert its `server/service.go` + `server/service_test.go` edits, delete
+`server/rw_health.go` + `server/rw_health_test.go`, and implement the observer-based
+design above. Net effect on data-path business code: **zero** (only two label-only
+args added to existing `StartOp` calls).

--- a/docs/superpowers/specs/2026-06-01-log-health-design.md
+++ b/docs/superpowers/specs/2026-06-01-log-health-design.md
@@ -1,0 +1,266 @@
+# Log Health — Lightweight Per-Log R/W Health Check
+
+- **Issue:** [zilliztech/woodpecker#131](https://github.com/zilliztech/woodpecker/issues/131)
+- **Date:** 2026-06-01
+- **Status:** Approved design, ready for implementation plan
+
+## Problem
+
+The existing `/healthz` probe only confirms the **process** is up and its role is
+registered. It does **not** verify that logs can actually be written to and read
+from the underlying storage. A node can pass `/healthz` while every write to
+storage hangs or fails.
+
+We want a second, **orthogonal** probe that answers: *"can this node still read and
+write its logs?"* — derived purely from the read/write activity the node already
+performs, with no injected probe traffic and no measurable cost on the hot path.
+
+## Goals
+
+- Per-log read/write health, observed from **real traffic** (no heartbeat/probe
+  messages injected — explicitly per the issue).
+- A single per-node HTTP endpoint that reports each tracked log's state plus a
+  node-level rollup.
+- Hot-path cost ≈ a shared `RLock` + a map lookup + one `atomic.Store`. No
+  allocation, no exclusive lock, no per-write bookkeeping.
+
+## Non-Goals
+
+- **No change to `/healthz`.** `log-health` does not feed into, gate, or modify the
+  existing liveness probe. A stalled log must never make `/healthz` fail —
+  otherwise a data-path issue would get escalated into a process restart by k8s.
+  The two probes stay fully independent (different package, route, types, data
+  source).
+- **No active/injected probe** (unlike Pulsar's topic `healthcheck`, which produces
+  and consumes a probe message). We only observe traffic that already happens.
+- **No idle storage fallback** (no `HeadBucket`). An idle log with no observed
+  activity reports `Healthy` — see Idle handling below. Active probing is a
+  possible future feature, out of scope here.
+- **No cluster-wide aggregation.** Each node answers only for itself; any caller
+  (monitor / load balancer / operator) aggregates across nodes. The previously
+  drafted `GetClusterRWHealth` / peer HTTP fan-out / memberlist parsing / quorum
+  logic is removed.
+
+## Relationship to `/healthz`
+
+| | `/healthz` (existing) | `/admin/log-health` (new) |
+|---|---|---|
+| Package | `common/http/health/` | `common/http/management/` |
+| Meaning | Process liveness — process up, role registered | Data-path health — real R/W path works, per log |
+| Data source | role indicators | `LogHealthTracker` atomic timestamps |
+| Response type | `health.HealthResponse` | `LogHealthResponse` |
+
+They are two orthogonal layers of liveness and share no code.
+
+## Naming
+
+Renamed from the earlier `rw_health` draft to `log_health` — the granularity is "per
+log", matching the granularity (not the mechanism) of Pulsar's per-topic health
+check.
+
+| Earlier draft | This design |
+|---|---|
+| `server/rw_health.go` | `server/log_health.go` |
+| `common/http/management/rw_health_handler.go` | `common/http/management/log_health_handler.go` |
+| `RWHealthTracker` | `LogHealthTracker` |
+| `ServerRWHealthResponse` | `LogHealthResponse` |
+| `RWLogHealthSnapshot` | `LogHealthSnapshot` |
+| `RWHealthStateHealthy` / `…Unhealthy` | `LogHealthStateHealthy` / `…Unhealthy` |
+| route `/admin/server-rw-health` | `/admin/log-health` |
+| `ClusterRWHealthResponse`, `GetClusterRWHealth`, `fetchPeerRWHealth`, `rwHealthPeer`, quorum aggregation | **deleted** |
+
+## Architecture
+
+### Components
+
+1. **`LogHealthTracker`** (`server/log_health.go`) — owns the in-memory state, the
+   record methods called from the hot path, and snapshot/classification logic.
+2. **Hot-path instrumentation** — calls into the tracker from `Server.AddEntry`
+   (write) and `Server.GetBatchEntriesAdv` (read).
+3. **HTTP handler** (`common/http/management/log_health_handler.go`) — validates
+   `bucket_name` / `root_path` query params and serializes the response.
+4. **Wiring** — `Server.GetLogHealth` callback, registered at route
+   `/admin/log-health` in `common/http/server.go`, exposed from `cmd/main.go`.
+
+### Data model — lock-free hot path
+
+```go
+type logInstanceKey struct{ bucketName, rootPath string }
+
+type logHealth struct {
+    writeAttemptMS atomic.Int64 // set when AddEntry starts (writes can hang in-flight)
+    writeSuccessMS atomic.Int64
+    writeFailureMS atomic.Int64
+    readSuccessMS  atomic.Int64 // reads are synchronous — no attempt timestamp
+    readFailureMS  atomic.Int64
+    failureReason  atomic.Pointer[string] // last failure reason, optional/diagnostic
+}
+
+type LogHealthTracker struct {
+    mu         sync.RWMutex // guards map STRUCTURE only
+    stallAfter time.Duration
+    logs       map[logInstanceKey]map[int64]*logHealth
+}
+```
+
+**Hot path:** `RLock` (shared) → map lookup → `atomic.Store` on the relevant field →
+`RUnlock`. The first write/read ever seen for a `(bucket, rootPath, logID)` takes the
+write lock once to create the `*logHealth`; every subsequent record is shared-lock +
+atomic only. No allocation per write, no exclusive lock per write, no per-write ID.
+
+### Record methods
+
+- `RecordWriteAttempt(bucket, rootPath, logID, now)` — store `writeAttemptMS`.
+- `RecordWriteSuccess(bucket, rootPath, logID, now)` — store `writeSuccessMS`.
+- `RecordWriteFailure(bucket, rootPath, logID, now, reason)` — store `writeFailureMS`
+  + `failureReason`.
+- `RecordReadSuccess(bucket, rootPath, logID, now)` — store `readSuccessMS`.
+- `RecordReadFailure(bucket, rootPath, logID, now, reason)` — store `readFailureMS`
+  + `failureReason`.
+
+All methods are no-ops when the tracker is `nil`.
+
+### Instrumentation points
+
+- **Write — `Server.AddEntry`:**
+  - `RecordWriteAttempt` at entry start.
+  - `RecordWriteSuccess` when the entry is synced.
+  - `RecordWriteFailure` on buffer error / result error.
+  - **Context cancel / deadline exceeded → no-op** (client gave up; not a storage
+    fault). Simpler than the old "abandoned" path because there is no map entry to
+    clean up.
+- **Read — `Server.GetBatchEntriesAdv`:**
+  - `RecordReadFailure` if the call returns `err`, else `RecordReadSuccess`.
+  - Reads are synchronous, so they have no attempt timestamp and never reach the
+    `Stalled` state — only `Healthy` / `Failed` / `Idle`.
+
+### Per-log classification (snapshot time)
+
+`stallAfter` defaults to 10 minutes. Each direction (read, write) is first classified
+independently from its timestamps into a raw direction-state, exposed as
+`write_state` / `read_state` for transparency. The log's single overall `state` is
+then derived from both directions (see "Log overall state" below).
+
+For a direction with `lastSuccess`, `lastFailure`, and (write only) `lastAttempt`:
+
+| Direction state | Rule |
+|---|---|
+| **Healthy** | `now - lastSuccess ≤ stallAfter` (succeeded recently) |
+| **Stalled** (write only) | `now - lastSuccess > stallAfter` **AND** `lastAttempt > lastSuccess` **AND** `lastAttempt > lastFailure` — work is flowing in but nothing completes (catches hung writes even under high QPS, because the rule keys off the age of the last *success*, not the last attempt) |
+| **Failed** | `lastFailure > lastSuccess` **AND** `now - lastFailure ≤ stallAfter` (recent terminal failures) |
+| **Idle** | no observed activity, or success & failure both stale (older than `stallAfter`) and not Stalled. Idle is informational — the last terminal outcome is still visible via the `last_*_ms` timestamps in the response, so an operator can read "last known status" directly. |
+
+### Log overall state
+
+A single enum per log, computed from the two direction-states with worst-wins
+precedence `Stalled > Failed > Healthy > Idle`:
+
+- `Stalled` if the write direction is Stalled.
+- else `Failed` if either direction is Failed.
+- else `Healthy` if either direction is Healthy.
+- else `Idle` (no recent activity in either direction).
+
+The four counters (`healthy_logs` / `failed_logs` / `stalled_logs` / `idle_logs`) are
+mutually exclusive and partition `tracked_logs` by this overall state.
+
+### Node-level rollup
+
+The node decision deliberately keys off **active evidence**, so a merely quiet node is
+never pulled out of rotation:
+
+- Node `state = Unhealthy` **iff** `tracked_logs > 0` **AND** every tracked log is
+  `Stalled` or `Failed` (zero Healthy, zero Idle — there is current, active evidence
+  the data path is broken across all logs).
+- Otherwise `state = Healthy`: ≥ 1 Healthy log, **or** all/some logs Idle (a quiet
+  node is healthy), **or** no tracked logs at all (reason `no_observed_activity`).
+
+This matches the issue's "at least one successfully reading/writing log = Healthy;
+multiple logs stalled simultaneously = Unhealthy", and resolves the idle case
+conservatively (idle alone never forces Unhealthy).
+
+### HTTP endpoint
+
+`GET /admin/log-health?bucket_name=<bucket>&root_path=<root>`
+
+- 400 if `bucket_name` or `root_path` is missing (accepts snake/camel/lower variants,
+  as the existing handler does).
+- 405 on non-GET.
+- Body `LogHealthResponse`:
+
+```jsonc
+{
+  "state": "Healthy",              // node rollup: Healthy | Unhealthy
+  "reason": "observed_write_success",
+  "node_id": "...",
+  "bucket_name": "...",
+  "root_path": "...",
+  "timestamp_ms": 0,
+  "stall_after_ms": 600000,
+  "tracked_logs": 1,
+  "healthy_logs": 1,
+  "failed_logs": 0,
+  "stalled_logs": 0,
+  "idle_logs": 0,
+  "logs": [
+    {
+      "log_id": 1,
+      "state": "Healthy",          // worst of write_state / read_state
+      "write_state": "Healthy",
+      "read_state": "Idle",
+      "last_write_success_ms": 0,
+      "last_write_failure_ms": 0,
+      "last_read_success_ms": 0,
+      "last_read_failure_ms": 0,
+      "last_failure_reason": ""
+    }
+  ]
+}
+```
+
+- HTTP status: `200` when node `state == Healthy`, `503` when `Unhealthy` (so a load
+  balancer / probe can act on status code alone). Logs are sorted by `log_id`.
+
+### Wiring
+
+- `Server` gains `logHealthTracker *LogHealthTracker`, constructed in
+  `NewServerWithConfig` with `NewLogHealthTracker(defaultLogHealthStallAfter)`.
+- `Server.GetLogHealth(ctx, bucket, rootPath) (LogHealthResponse, int)` builds the
+  snapshot and returns the response + HTTP status.
+- `AdminCallbacks` gains one field `GetLogHealth management.LogHealthCallback`; the
+  cluster callback is removed.
+- `common/http/server.go` registers the route when the callback is set.
+- `cmd/main.go` wires `srv.GetLogHealth`.
+- `common/http/README.md` documents the new route alongside the other admin routes.
+
+## Error handling
+
+- `nil` tracker → all record methods no-op; `GetLogHealth` falls back to an empty
+  tracker and reports `Healthy / no_observed_activity`.
+- Missing query params → `400`. Non-GET → `405`.
+- Client-cancelled writes are deliberately not counted as failures.
+
+## Testing
+
+- **`server/log_health_test.go`** (table-driven, using a fixed injected `now`):
+  - Each direction-state rule: Healthy, Stalled (incl. high-QPS hung-write case where
+    `lastAttempt` is recent but `lastSuccess` is stale), Failed, Idle.
+  - Read direction never goes Stalled.
+  - Log overall state precedence `Stalled > Failed > Healthy > Idle`, including a
+    case where write=Healthy and read=Failed → overall Failed.
+  - Counters partition `tracked_logs` (mutually exclusive).
+  - Node rollup: ≥1 healthy → Healthy; some idle + no failures → Healthy (quiet node
+    not pulled out); all stalled/failed → Unhealthy; no logs → Healthy +
+    `no_observed_activity`.
+  - `nil` tracker safety.
+  - Concurrency smoke test: many goroutines recording on the same/different logs
+    under `-race` to confirm the RLock + atomic model is data-race free.
+- **`common/http/management/log_health_handler_test.go`:** 400 missing params, 405
+  non-GET, 200 vs 503 by node state, JSON shape.
+- **`server/service_test.go`:** adjust existing tests to the renamed
+  symbols/endpoint; drop cluster-health expectations.
+
+## Migration / cleanup
+
+The earlier `rw_health` draft (working-tree changes, not yet committed) is
+superseded: rename the two files, rename the surviving symbols, and delete the entire
+cluster/quorum/peer/`PendingWrites`-map code path.

--- a/docs/superpowers/specs/2026-06-01-log-health-design.md
+++ b/docs/superpowers/specs/2026-06-01-log-health-design.md
@@ -77,8 +77,8 @@ check.
    record methods called from the hot path, and snapshot/classification logic.
 2. **Hot-path instrumentation** — calls into the tracker from `Server.AddEntry`
    (write) and `Server.GetBatchEntriesAdv` (read).
-3. **HTTP handler** (`common/http/management/log_health_handler.go`) — validates
-   `bucket_name` / `root_path` query params and serializes the response.
+3. **HTTP handler** (`common/http/management/log_health_handler.go`) — parses the
+   optional `bucket_name` / `root_path` filter and serializes the response.
 4. **Wiring** — `Server.GetLogHealth` callback, registered at route
    `/admin/log-health` in `common/http/server.go`, exposed from `cmd/main.go`.
 
@@ -165,8 +165,9 @@ mutually exclusive and partition `tracked_logs` by this overall state.
 
 ### Node-level rollup
 
-The node decision deliberately keys off **active evidence**, so a merely quiet node is
-never pulled out of rotation:
+The rollup spans **all logs in scope** (all tenants when unfiltered, or the one
+filtered instance). It deliberately keys off **active evidence**, so a merely quiet
+node is never pulled out of rotation:
 
 - Node `state = Unhealthy` **iff** `tracked_logs > 0` **AND** every tracked log is
   `Stalled` or `Failed` (zero Healthy, zero Idle — there is current, active evidence
@@ -180,10 +181,19 @@ conservatively (idle alone never forces Unhealthy).
 
 ### HTTP endpoint
 
-`GET /admin/log-health?bucket_name=<bucket>&root_path=<root>`
+**Node-level scope.** Woodpecker is multi-tenant: a node serves many
+`(bucket_name, root_path)` instances at once, and a log is uniquely identified by the
+triple `(bucket_name, root_path, log_id)` (there is no `logName` at the logstore
+layer). So one probe call returns **every** log the node tracks, across all tenants,
+and each log carries its own triple.
 
-- 400 if `bucket_name` or `root_path` is missing (accepts snake/camel/lower variants,
-  as the existing handler does).
+`GET /admin/log-health[?bucket_name=<bucket>&root_path=<root>]`
+
+- `bucket_name` / `root_path` are **optional filters** (accepts snake/camel/lower
+  variants). When both are supplied, the response is narrowed to that one instance;
+  when omitted, all tracked logs across all tenants are returned. Supplying only one
+  of the two is treated as "no filter" (or 400 — see open detail below); default is
+  to ignore a lone param and return everything.
 - 405 on non-GET.
 - Body `LogHealthResponse`:
 
@@ -192,19 +202,21 @@ conservatively (idle alone never forces Unhealthy).
   "state": "Healthy",              // node rollup: Healthy | Unhealthy
   "reason": "observed_write_success",
   "node_id": "...",
-  "bucket_name": "...",
-  "root_path": "...",
+  "filter_bucket_name": "",        // echoes the filter when one was applied, else ""
+  "filter_root_path": "",
   "timestamp_ms": 0,
   "stall_after_ms": 600000,
-  "tracked_logs": 1,
+  "tracked_logs": 2,
   "healthy_logs": 1,
   "failed_logs": 0,
   "stalled_logs": 0,
-  "idle_logs": 0,
+  "idle_logs": 1,
   "logs": [
     {
+      "bucket_name": "tenant-a-bucket",   // the unique triple, per log
+      "root_path": "tenant-a/root",
       "log_id": 1,
-      "state": "Healthy",          // worst of write_state / read_state
+      "state": "Healthy",          // overall, see "Log overall state"
       "write_state": "Healthy",
       "read_state": "Idle",
       "last_write_success_ms": 0,
@@ -218,14 +230,19 @@ conservatively (idle alone never forces Unhealthy).
 ```
 
 - HTTP status: `200` when node `state == Healthy`, `503` when `Unhealthy` (so a load
-  balancer / probe can act on status code alone). Logs are sorted by `log_id`.
+  balancer / probe can act on status code alone). Logs are sorted by
+  `(bucket_name, root_path, log_id)` for stable output.
 
 ### Wiring
 
 - `Server` gains `logHealthTracker *LogHealthTracker`, constructed in
   `NewServerWithConfig` with `NewLogHealthTracker(defaultLogHealthStallAfter)`.
-- `Server.GetLogHealth(ctx, bucket, rootPath) (LogHealthResponse, int)` builds the
-  snapshot and returns the response + HTTP status.
+- `Server.GetLogHealth(ctx, bucketFilter, rootPathFilter) (LogHealthResponse, int)`
+  builds the snapshot and returns the response + HTTP status. Empty filter strings
+  mean "all tenants"; when both are non-empty the snapshot is narrowed to that
+  instance.
+- `LogHealthCallback func(ctx, bucketName, rootPath) (any, int)` — the handler passes
+  the parsed filter (empty strings when absent); signature unchanged from the draft.
 - `AdminCallbacks` gains one field `GetLogHealth management.LogHealthCallback`; the
   cluster callback is removed.
 - `common/http/server.go` registers the route when the callback is set.
@@ -236,7 +253,7 @@ conservatively (idle alone never forces Unhealthy).
 
 - `nil` tracker → all record methods no-op; `GetLogHealth` falls back to an empty
   tracker and reports `Healthy / no_observed_activity`.
-- Missing query params → `400`. Non-GET → `405`.
+- Missing filter params → return all tenants (not an error). Non-GET → `405`.
 - Client-cancelled writes are deliberately not counted as failures.
 
 ## Testing
@@ -254,8 +271,12 @@ conservatively (idle alone never forces Unhealthy).
   - `nil` tracker safety.
   - Concurrency smoke test: many goroutines recording on the same/different logs
     under `-race` to confirm the RLock + atomic model is data-race free.
-- **`common/http/management/log_health_handler_test.go`:** 400 missing params, 405
-  non-GET, 200 vs 503 by node state, JSON shape.
+- **`server/log_health_test.go`** also: unfiltered snapshot returns logs across
+  multiple `(bucket, rootPath)` instances, each tagged with its own triple; filtered
+  snapshot narrows to one instance.
+- **`common/http/management/log_health_handler_test.go`:** no-filter returns all,
+  filter narrows, 405 non-GET, 200 vs 503 by node state, JSON shape (per-log triple
+  present).
 - **`server/service_test.go`:** adjust existing tests to the renamed
   symbols/endpoint; drop cluster-health expectations.
 

--- a/docs/superpowers/specs/2026-06-01-log-health-design.md
+++ b/docs/superpowers/specs/2026-06-01-log-health-design.md
@@ -120,8 +120,15 @@ calls — see Wiring).
   makes `add_entry` itself error. This is the deliberate trade-off of choosing the
   logstore layer over `file.flush`.
 - **Read** = `logstore.get_batch_entries` op `End(status)`.
-- **Success vs failure** = `status == "success"` (the literal logstore uses) →
-  success; any other status → failure.
+- **Success vs failure** = `status == "success"` → success; any other status →
+  failure. **Exception (read only):** reaching the end of the log
+  (`werr.ErrFileReaderEndOfFile` / `werr.ErrEntryNotFound`) is a routine, healthy read
+  outcome, not a fault. `logstore.go` tags these with a distinct status
+  `"end_of_file"`, and the tracker treats `"end_of_file"` as a **read success**.
+  Without this, a node merely tailing a caught-up log would accumulate fake read
+  failures and falsely report Unhealthy/503. (This also relabels the existing
+  `WpLogStoreOperationsTotal` metric for those reads from `error` → `end_of_file`,
+  which is more accurate.)
 - **Client cancel:** because `add_entry`'s op ends at buffering (it does not span the
   client's sync-wait), client cancellation during the sync-wait is naturally not
   observed as a write failure. A `get_batch_entries` cancelled mid-call ends with a

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -194,7 +194,7 @@ func (l *logStore) AddEntry(ctx context.Context, bucketName string, rootPath str
 	defer sp.End()
 	logIdStr := strconv.FormatInt(logId, 10)
 	ns := bucketName + "/" + rootPath
-	op := metrics.StartOp("logstore.add_entry", nil, nil, metrics.WithLogSegment(logId, entry.SegId))
+	op := metrics.StartOp("logstore.add_entry", nil, nil, metrics.WithInstance(bucketName, rootPath), metrics.WithLogSegment(logId, entry.SegId))
 	status := "success"
 	defer func() {
 		op.End(status)
@@ -297,7 +297,7 @@ func (l *logStore) GetBatchEntriesAdv(ctx context.Context, bucketName string, ro
 	defer sp.End()
 	logIdStr := strconv.FormatInt(logId, 10)
 	ns := bucketName + "/" + rootPath
-	op := metrics.StartOp("logstore.get_batch_entries", nil, nil, metrics.WithLogSegment(logId, segmentId))
+	op := metrics.StartOp("logstore.get_batch_entries", nil, nil, metrics.WithInstance(bucketName, rootPath), metrics.WithLogSegment(logId, segmentId))
 	status := "success"
 	defer func() {
 		op.End(status)

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -314,8 +314,11 @@ func (l *logStore) GetBatchEntriesAdv(ctx context.Context, bucketName string, ro
 	}
 	batchData, err := segmentProcessor.ReadBatchEntriesAdv(ctx, fromEntryId, maxEntries, lastReadState)
 	if err != nil {
-		status = "error"
-		if !werr.ErrEntryNotFound.Is(err) && !werr.ErrFileReaderEndOfFile.Is(err) {
+		if werr.ErrEntryNotFound.Is(err) || werr.ErrFileReaderEndOfFile.Is(err) {
+			// Reaching the end of the log is a routine, healthy read outcome, not a failure.
+			status = "end_of_file"
+		} else {
+			status = "error"
 			logger.Ctx(ctx).Warn("get batch entries failed", zap.Int64("logId", logId), zap.Int64("segId", segmentId), zap.Int64("fromEntryId", fromEntryId), zap.Int64("maxEntries", maxEntries), zap.Error(err))
 		}
 		return nil, err


### PR DESCRIPTION
## Summary

Adds a lightweight, node-wide, multi-tenant **per-log read/write health** probe at `GET /admin/log-health`, addressing #131. Unlike `/healthz` (process liveness), this answers *"can this node actually read and write its logs?"* — derived **passively** from real traffic, with no injected probe messages.

- **Reuses existing instrumentation, zero data-path intrusion.** A new `loghealth.Tracker` implements `metrics.OpObserver` and is registered once in `cmd/main.go` (mirroring `opReg`). It observes the `logstore.add_entry` (write) and `logstore.get_batch_entries` (read) ops that the logstore already emits. No manual instrumentation in `service.go`.
- **Lock-free hot path.** Per-`(bucket, rootPath, logID)` state is a handful of `atomic.Int64` timestamps updated under a shared `RLock` — no allocation, no exclusive lock per op.
- **Multi-tenant.** `metrics.Op` gained `BucketName`/`RootPath` (via `WithInstance`), so each log is identified by its `(bucket, rootPath, logID)` triple. One probe call returns all tenants; `?bucket_name=&root_path=` narrows to one instance.
- **Classification.** Each log is Healthy / Stalled / Failed / Idle (write keys off last-success age to catch hung writes even under high QPS; reads never "stall"). Node rollup returns `503` only when **every** tracked log is Stalled/Failed — a quiet/idle node stays Healthy and is never pulled from rotation.
- **End-of-log reads are healthy.** EOF / entry-not-found tail reads are tagged `end_of_file` and counted as read successes, so a caught-up node never falsely reports 503.
- Orthogonal to `/healthz` — a stalled log never affects the liveness probe.

## Test Plan

- [x] `go build ./...` clean
- [x] `go vet ./common/... ./server/... ./cmd/...` clean
- [x] `go test -race ./common/metrics/... ./common/runtime/loghealth/... ./common/http/...` pass
- [x] `go test ./server/...` pass
- [ ] Manual: hit `GET /admin/log-health` on a running node; confirm tenants/logs appear and 200/503 toggles with write/read outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)