### PR TITLE
enhance: add maxIntervalForService for Woodpecker service mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ woodpecker:
     segmentSyncPolicy:
       maxInterval: 200 # Maximum interval between two sync operations in milliseconds
       maxIntervalForLocalStorage: 10 # Maximum interval between sync operations for local storage backend, in milliseconds
+      maxIntervalForService: 1 # Maximum interval between sync operations for service mode, in milliseconds (service mode also syncs on service-side events)
       maxEntries: 10000 # Maximum entries number of write buffer
       maxBytes: 256000000 # Maximum size of write buffer in bytes
       maxFlushRetries: 5 # Maximum number of retries for sync operations

--- a/cmd/external/user_config.go
+++ b/cmd/external/user_config.go
@@ -314,6 +314,9 @@ func mergeWoodpeckerConfig(dst, src *config.WoodpeckerConfig) {
 	if src.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage.Milliseconds() > 0 {
 		dst.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage = src.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage
 	}
+	if src.Logstore.SegmentSyncPolicy.MaxIntervalForService.Milliseconds() > 0 {
+		dst.Logstore.SegmentSyncPolicy.MaxIntervalForService = src.Logstore.SegmentSyncPolicy.MaxIntervalForService
+	}
 	if src.Logstore.SegmentSyncPolicy.MaxEntries > 0 {
 		dst.Logstore.SegmentSyncPolicy.MaxEntries = src.Logstore.SegmentSyncPolicy.MaxEntries
 	}

--- a/cmd/external/user_config_test.go
+++ b/cmd/external/user_config_test.go
@@ -309,6 +309,7 @@ woodpecker:
     segmentSyncPolicy:
       maxInterval: 500ms
       maxIntervalForLocalStorage: 5ms
+      maxIntervalForService: 3ms
       maxBytes: 128M
       retryInterval: 1s
       maxFlushSize: 2MB
@@ -346,6 +347,7 @@ etcd:
 	// Verify DurationMilliseconds parsing (default unit: milliseconds)
 	assert.Equal(t, 500, userConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxInterval.Milliseconds())
 	assert.Equal(t, 5, userConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage.Milliseconds())
+	assert.Equal(t, 3, userConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForService.Milliseconds())
 	assert.Equal(t, 1000, userConfig.Woodpecker.Logstore.SegmentSyncPolicy.RetryInterval.Milliseconds())
 	assert.Equal(t, 10000, userConfig.Minio.RequestTimeoutMs.Milliseconds())
 	assert.Equal(t, 5000, userConfig.Etcd.RequestTimeout.Milliseconds())

--- a/cmd/external/user_example.yaml
+++ b/cmd/external/user_example.yaml
@@ -234,6 +234,7 @@ woodpecker:
     segmentSyncPolicy:
       maxInterval: 200ms # Maximum interval between two sync operations, default is 200 milliseconds.
       maxIntervalForLocalStorage: 10ms # Maximum interval between two sync operations local storage backend, default is 10 milliseconds.
+      maxIntervalForService: 1ms # Maximum interval between two sync operations for service mode, default is 1 millisecond. Service mode also triggers sync via service-side events, so a small value minimizes durability latency.
       maxBytes: 256M # Maximum size of write buffer in bytes.
       maxEntries: 10000 # Maximum entries number of write buffer.
       maxFlushRetries: 5 # Maximum size of write buffer in bytes.

--- a/common/config/configuration.go
+++ b/common/config/configuration.go
@@ -159,6 +159,7 @@ type SegmentReadPolicyConfig struct {
 type SegmentSyncPolicyConfig struct {
 	MaxInterval                DurationMilliseconds `yaml:"maxInterval"`
 	MaxIntervalForLocalStorage DurationMilliseconds `yaml:"maxIntervalForLocalStorage"`
+	MaxIntervalForService      DurationMilliseconds `yaml:"maxIntervalForService"`
 	MaxEntries                 int                  `yaml:"maxEntries"`
 	MaxBytes                   ByteSize             `yaml:"maxBytes"`
 	MaxFlushRetries            int                  `yaml:"maxFlushRetries"`
@@ -653,6 +654,9 @@ func (c *Configuration) validateLogstoreConfig() error {
 	if logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage.Milliseconds() <= 0 {
 		return fmt.Errorf("segment sync policy max interval for local storage must be positive, got %d", logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage.Milliseconds())
 	}
+	if logstore.SegmentSyncPolicy.MaxIntervalForService.Milliseconds() <= 0 {
+		return fmt.Errorf("segment sync policy max interval for service must be positive, got %d", logstore.SegmentSyncPolicy.MaxIntervalForService.Milliseconds())
+	}
 	if logstore.SegmentSyncPolicy.MaxEntries <= 0 {
 		return fmt.Errorf("segment sync policy max entries must be positive, got %d", logstore.SegmentSyncPolicy.MaxEntries)
 	}
@@ -771,6 +775,7 @@ func getDefaultWoodpeckerConfig() WoodpeckerConfig {
 			SegmentSyncPolicy: SegmentSyncPolicyConfig{
 				MaxInterval:                DurationMilliseconds{Duration: Duration{duration: 1000 * 1000000}}, // 1000ms
 				MaxIntervalForLocalStorage: DurationMilliseconds{Duration: Duration{duration: 5 * 1000000}},    // 5ms
+				MaxIntervalForService:      DurationMilliseconds{Duration: Duration{duration: 1 * 1000000}},    // 1ms
 				MaxEntries:                 2000,
 				MaxBytes:                   ByteSize(100000000),
 				MaxFlushRetries:            3,

--- a/common/config/configuration_test.go
+++ b/common/config/configuration_test.go
@@ -62,6 +62,7 @@ func TestNewConfiguration(t *testing.T) {
 	assert.Equal(t, 2, config.Woodpecker.Client.Quorum.GetAckQuorumSize())
 	assert.Equal(t, 200, config.Woodpecker.Logstore.SegmentSyncPolicy.MaxInterval.Milliseconds())
 	assert.Equal(t, 10, config.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage.Milliseconds())
+	assert.Equal(t, 1, config.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForService.Milliseconds())
 	assert.Equal(t, 10000, config.Woodpecker.Logstore.SegmentSyncPolicy.MaxEntries)
 	assert.Equal(t, int64(256000000), config.Woodpecker.Logstore.SegmentSyncPolicy.MaxBytes.Int64())
 	assert.Equal(t, 5, config.Woodpecker.Logstore.SegmentSyncPolicy.MaxFlushRetries)
@@ -158,6 +159,7 @@ func TestNewConfiguration(t *testing.T) {
 	assert.Equal(t, 2, defaultConfig.Woodpecker.Client.Quorum.GetAckQuorumSize())
 	assert.Equal(t, 1000, defaultConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxInterval.Milliseconds())
 	assert.Equal(t, 5, defaultConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage.Milliseconds())
+	assert.Equal(t, 1, defaultConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForService.Milliseconds())
 	assert.Equal(t, 2000, defaultConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxEntries)
 	assert.Equal(t, int64(100000000), defaultConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxBytes.Int64())
 	assert.Equal(t, 3, defaultConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxFlushRetries)
@@ -446,6 +448,7 @@ func TestQuorumConfigValidation(t *testing.T) {
 						SegmentSyncPolicy: SegmentSyncPolicyConfig{
 							MaxInterval:                NewDurationMillisecondsFromInt(1000),
 							MaxIntervalForLocalStorage: NewDurationMillisecondsFromInt(5),
+							MaxIntervalForService:      NewDurationMillisecondsFromInt(1),
 							MaxEntries:                 2000,
 							MaxBytes:                   NewByteSize(100000000),
 							MaxFlushRetries:            3,
@@ -671,6 +674,12 @@ func TestValidateLogstoreConfig_Errors(t *testing.T) {
 		cfg := newValidCfg()
 		cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage = NewDurationMillisecondsFromInt(0)
 		assert.ErrorContains(t, cfg.Validate(), "max interval for local storage must be positive")
+	})
+
+	t.Run("SyncPolicy MaxIntervalForService<=0", func(t *testing.T) {
+		cfg := newValidCfg()
+		cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForService = NewDurationMillisecondsFromInt(0)
+		assert.ErrorContains(t, cfg.Validate(), "max interval for service must be positive")
 	})
 
 	t.Run("SyncPolicy MaxEntries<=0", func(t *testing.T) {
@@ -1001,6 +1010,7 @@ func TestCustomPlacementConfiguration(t *testing.T) {
 				SegmentSyncPolicy: SegmentSyncPolicyConfig{
 					MaxInterval:                NewDurationMillisecondsFromInt(1000),
 					MaxIntervalForLocalStorage: NewDurationMillisecondsFromInt(5),
+					MaxIntervalForService:      NewDurationMillisecondsFromInt(1),
 					MaxEntries:                 2000,
 					MaxBytes:                   NewByteSize(100000000),
 					MaxFlushRetries:            3,

--- a/config/woodpecker.yaml
+++ b/config/woodpecker.yaml
@@ -87,6 +87,7 @@ woodpecker:
     segmentSyncPolicy:
       maxInterval: 200 # Maximum interval between two sync operations in milliseconds
       maxIntervalForLocalStorage: 10 # Maximum interval between sync operations for local storage backend, in milliseconds
+      maxIntervalForService: 1 # Maximum interval between sync operations for service mode, in milliseconds. Service mode also triggers sync via service-side events, so a small value (e.g. 1ms) minimizes durability latency
       maxEntries: 10000 # Maximum entries number of write buffer
       maxBytes: 256000000 # Maximum size of write buffer in bytes
       maxFlushRetries: 5 # Maximum number of retries for sync operations

--- a/server/storage/disk/writer_impl_test.go
+++ b/server/storage/disk/writer_impl_test.go
@@ -51,6 +51,23 @@ func TestNewLocalFileWriter(t *testing.T) {
 	assert.False(t, writer.fenced.Load())
 }
 
+// TestLocalFileWriter_UsesMaxIntervalForLocalStorage verifies that local storage
+// mode drives its sync ticker from MaxIntervalForLocalStorage and is independent
+// of MaxIntervalForService (issue #172).
+func TestLocalFileWriter_UsesMaxIntervalForLocalStorage(t *testing.T) {
+	dir := getTempDir(t)
+	cfg, _ := config.NewConfiguration()
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage = config.NewDurationMillisecondsFromInt(13)
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForService = config.NewDurationMillisecondsFromInt(99)
+
+	writer, err := NewLocalFileWriter(context.Background(), dir, 1, 0, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, writer)
+	defer writer.Close(context.Background())
+
+	assert.Equal(t, 13, writer.maxIntervalMs)
+}
+
 func TestNewLocalFileWriterWithMode_RecoveryMode(t *testing.T) {
 	dir := getTempDir(t)
 	cfg, _ := config.NewConfiguration()

--- a/server/storage/stagedstorage/writer_impl.go
+++ b/server/storage/stagedstorage/writer_impl.go
@@ -139,7 +139,7 @@ func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath st
 	maxBufferEntries := cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxEntries
 	maxBytes := cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxBytes.Int64()
 	flushQueueSize := max(int(maxBytes/blockSize), 300)
-	maxInterval := cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage.Milliseconds()
+	maxInterval := cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForService.Milliseconds()
 	syncScheduler := DefaultSyncScheduler()
 	if len(schedulers) > 0 && schedulers[0] != nil {
 		syncScheduler = schedulers[0]
@@ -188,7 +188,7 @@ func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath st
 		writtenBytes:        0,
 		maxFlushSize:        blockSize,
 		maxBufferEntries:    int64(maxBufferEntries),                    // Default max entries per buffer
-		maxIntervalMs:       maxInterval,                                // 10ms default sync interval for more responsive syncing
+		maxIntervalMs:       maxInterval,                                // service-mode sync interval (maxIntervalForService, 1ms default); event-driven sync also triggers flushes
 		flushTaskChan:       make(chan *blockFlushTask, flushQueueSize), // Increased buffer size to reduce blocking
 		syncScheduler:       syncScheduler,
 		runCtx:              runCtx,

--- a/server/storage/stagedstorage/writer_impl_test.go
+++ b/server/storage/stagedstorage/writer_impl_test.go
@@ -48,6 +48,24 @@ func newTestConfig(t *testing.T) *config.Configuration {
 	return cfg
 }
 
+// TestStagedFileWriter_UsesMaxIntervalForService verifies that service mode
+// (staged storage) drives its sync ticker from MaxIntervalForService and is
+// independent of MaxIntervalForLocalStorage (issue #172).
+func TestStagedFileWriter_UsesMaxIntervalForService(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForService = config.NewDurationMillisecondsFromInt(7)
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage = config.NewDurationMillisecondsFromInt(123)
+	scheduler := NewSyncScheduler(1)
+	defer scheduler.Close()
+
+	writer, err := NewStagedFileWriter(context.Background(), "test-bucket", "test-root", dir, 1, 0, nil, cfg, scheduler)
+	require.NoError(t, err)
+	defer writer.Close(context.Background())
+
+	assert.Equal(t, 7, writer.maxIntervalMs)
+}
+
 // --- NewStagedFileWriter ---
 
 func TestNewStagedFileWriter(t *testing.T) {
@@ -356,7 +374,7 @@ func TestStagedFileWriter_Sync(t *testing.T) {
 func TestStagedFileWriter_ScheduledSyncFlushesBufferedEntry(t *testing.T) {
 	dir := t.TempDir()
 	cfg := newTestConfig(t)
-	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage = config.NewDurationMillisecondsFromInt(10)
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForService = config.NewDurationMillisecondsFromInt(10)
 	scheduler := NewSyncScheduler(1)
 	defer scheduler.Close()
 
@@ -380,7 +398,7 @@ func TestStagedFileWriter_ScheduledSyncFlushesBufferedEntry(t *testing.T) {
 func TestStagedFileWriter_ScheduledSyncWaitsForMissingFirstEntry(t *testing.T) {
 	dir := t.TempDir()
 	cfg := newTestConfig(t)
-	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage = config.NewDurationMillisecondsFromInt(10)
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForService = config.NewDurationMillisecondsFromInt(10)
 	scheduler := NewSyncScheduler(1)
 	defer scheduler.Close()
 
@@ -425,7 +443,7 @@ func TestStagedFileWriter_ScheduledSyncWaitsForMissingFirstEntry(t *testing.T) {
 func TestStagedFileWriter_ScheduledSyncReschedulesWhenJobAlreadySubmitted(t *testing.T) {
 	dir := t.TempDir()
 	cfg := newTestConfig(t)
-	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForLocalStorage = config.NewDurationMillisecondsFromInt(10)
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxIntervalForService = config.NewDurationMillisecondsFromInt(10)
 	scheduler := NewSyncScheduler(1)
 	defer scheduler.Close()
 


### PR DESCRIPTION
## What

Closes #172.

Service mode (staged storage) previously borrowed `maxIntervalForLocalStorage` for its periodic sync interval, even though it also triggers sync via service-side events and can therefore use a much more aggressive interval. Sharing one knob between the single-writer local append/sync model and the event-driven service model made them impossible to tune independently.

This PR introduces a dedicated `maxIntervalForService` configuration.

## Changes

- **New config field** `SegmentSyncPolicy.maxIntervalForService` (`common/config/configuration.go`), default **1ms**, with positive-value validation.
- **Service mode** (`server/storage/stagedstorage/writer_impl.go`) now reads `maxIntervalForService`.
- **Local storage mode** (`server/storage/disk/writer_impl.go`) continues to use `maxIntervalForLocalStorage` — unchanged.
- **Backward compatible**: defaults are applied before the YAML overlay (`NewConfiguration`), so existing deployments that omit the new field keep working.
- **Docs/examples** updated: `config/woodpecker.yaml`, `cmd/external/user_example.yaml`, `README.md`, plus the external user-config merge in `cmd/external/user_config.go`.

## Acceptance criteria

- [x] Add `maxIntervalForService` configuration
- [x] Service mode uses `maxIntervalForService`
- [x] Local storage mode continues to use `maxIntervalForLocalStorage`
- [x] Existing deployments remain backward compatible
- [x] Configuration documentation is updated
- [x] Add tests covering both configuration paths

## Tests

- `common/config`: default value (1ms), YAML load, and `MaxIntervalForService<=0` validation.
- `cmd/external`: user-config YAML override of the new field.
- `server/storage/stagedstorage`: service writer reads `maxIntervalForService` (distinct from `maxIntervalForLocalStorage`).
- `server/storage/disk`: local writer reads `maxIntervalForLocalStorage` (distinct from `maxIntervalForService`).

All four packages build and pass (`go build ./...`, `go vet`, `go test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)