### PR TITLE
fix(ci): apply ci-passed label when path-filtered checks are skipped

### DIFF
--- a/.github/workflows/code-checker.yaml
+++ b/.github/workflows/code-checker.yaml
@@ -65,6 +65,8 @@ jobs:
           for check in "${REQUIRED_CHECKS[@]}"; do
             [ "$check" = "$SELF" ] && continue
             bucket=$(echo "$CHECKS" | jq -r --arg n "$check" '.[] | select(.name == $n) | .bucket' | head -1)
+            # Skip checks not triggered for this PR (filtered out by `paths`); only block on checks that actually ran.
+            [ -z "$bucket" ] && continue
             if [ "$bucket" != "pass" ]; then
               ALL_PASSED=false
               break
@@ -115,6 +117,8 @@ jobs:
           for check in "${REQUIRED_CHECKS[@]}"; do
             [ "$check" = "$SELF" ] && continue
             bucket=$(echo "$CHECKS" | jq -r --arg n "$check" '.[] | select(.name == $n) | .bucket' | head -1)
+            # Skip checks not triggered for this PR (filtered out by `paths`); only block on checks that actually ran.
+            [ -z "$bucket" ] && continue
             if [ "$bucket" != "pass" ]; then
               ALL_PASSED=false
               break

--- a/.github/workflows/integration-test-chaos.yaml
+++ b/.github/workflows/integration-test-chaos.yaml
@@ -111,6 +111,8 @@ jobs:
           for check in "${REQUIRED_CHECKS[@]}"; do
             [ "$check" = "$SELF" ] && continue
             bucket=$(echo "$CHECKS" | jq -r --arg n "$check" '.[] | select(.name == $n) | .bucket' | head -1)
+            # Skip checks not triggered for this PR (filtered out by `paths`); only block on checks that actually ran.
+            [ -z "$bucket" ] && continue
             if [ "$bucket" != "pass" ]; then
               ALL_PASSED=false
               break

--- a/.github/workflows/integration-test-components.yaml
+++ b/.github/workflows/integration-test-components.yaml
@@ -103,6 +103,8 @@ jobs:
           for check in "${REQUIRED_CHECKS[@]}"; do
             [ "$check" = "$SELF" ] && continue
             bucket=$(echo "$CHECKS" | jq -r --arg n "$check" '.[] | select(.name == $n) | .bucket' | head -1)
+            # Skip checks not triggered for this PR (filtered out by `paths`); only block on checks that actually ran.
+            [ -z "$bucket" ] && continue
             if [ "$bucket" != "pass" ]; then
               ALL_PASSED=false
               break

--- a/.github/workflows/integration-test-e2e-local.yaml
+++ b/.github/workflows/integration-test-e2e-local.yaml
@@ -104,6 +104,8 @@ jobs:
           for check in "${REQUIRED_CHECKS[@]}"; do
             [ "$check" = "$SELF" ] && continue
             bucket=$(echo "$CHECKS" | jq -r --arg n "$check" '.[] | select(.name == $n) | .bucket' | head -1)
+            # Skip checks not triggered for this PR (filtered out by `paths`); only block on checks that actually ran.
+            [ -z "$bucket" ] && continue
             if [ "$bucket" != "pass" ]; then
               ALL_PASSED=false
               break

--- a/.github/workflows/integration-test-e2e-objectstorage.yaml
+++ b/.github/workflows/integration-test-e2e-objectstorage.yaml
@@ -104,6 +104,8 @@ jobs:
           for check in "${REQUIRED_CHECKS[@]}"; do
             [ "$check" = "$SELF" ] && continue
             bucket=$(echo "$CHECKS" | jq -r --arg n "$check" '.[] | select(.name == $n) | .bucket' | head -1)
+            # Skip checks not triggered for this PR (filtered out by `paths`); only block on checks that actually ran.
+            [ -z "$bucket" ] && continue
             if [ "$bucket" != "pass" ]; then
               ALL_PASSED=false
               break

--- a/.github/workflows/integration-test-e2e-service.yaml
+++ b/.github/workflows/integration-test-e2e-service.yaml
@@ -132,6 +132,8 @@ jobs:
           for check in "${REQUIRED_CHECKS[@]}"; do
             [ "$check" = "$SELF" ] && continue
             bucket=$(echo "$CHECKS" | jq -r --arg n "$check" '.[] | select(.name == $n) | .bucket' | head -1)
+            # Skip checks not triggered for this PR (filtered out by `paths`); only block on checks that actually ran.
+            [ -z "$bucket" ] && continue
             if [ "$bucket" != "pass" ]; then
               ALL_PASSED=false
               break

--- a/.github/workflows/operator-test.yaml
+++ b/.github/workflows/operator-test.yaml
@@ -63,3 +63,28 @@ jobs:
         run: |
           PR=${{ github.event.pull_request.number }}
           gh pr comment $PR --body "❌ **Operator Test** failed. Comment \`/rerun-operator\` to rerun, or \`/rerun\` to rerun all failed checks."
+          gh pr edit $PR --remove-label "ci-passed" 2>/dev/null || true
+
+      - name: Add ci-passed label
+        if: success() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR=${{ github.event.pull_request.number }}
+          SELF="${{ github.workflow }}"
+          REQUIRED_CHECKS=("Lint" "Go Mod Tidy Check" "Unit Test" "E2E Local" "E2E Object Storage" "E2E Service" "Component Integration Test" "Chaos Test" "Operator Test")
+          CHECKS=$(gh pr checks $PR --json name,bucket 2>/dev/null || echo "[]")
+          ALL_PASSED=true
+          for check in "${REQUIRED_CHECKS[@]}"; do
+            [ "$check" = "$SELF" ] && continue
+            bucket=$(echo "$CHECKS" | jq -r --arg n "$check" '.[] | select(.name == $n) | .bucket' | head -1)
+            # Skip checks not triggered for this PR (filtered out by `paths`); only block on checks that actually ran.
+            [ -z "$bucket" ] && continue
+            if [ "$bucket" != "pass" ]; then
+              ALL_PASSED=false
+              break
+            fi
+          done
+          if [ "$ALL_PASSED" = true ]; then
+            gh pr edit $PR --add-label "ci-passed"
+          fi

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -75,6 +75,8 @@ jobs:
           for check in "${REQUIRED_CHECKS[@]}"; do
             [ "$check" = "$SELF" ] && continue
             bucket=$(echo "$CHECKS" | jq -r --arg n "$check" '.[] | select(.name == $n) | .bucket' | head -1)
+            # Skip checks not triggered for this PR (filtered out by `paths`); only block on checks that actually ran.
+            [ -z "$bucket" ] && continue
             if [ "$bucket" != "pass" ]; then
               ALL_PASSED=false
               break


### PR DESCRIPTION
Fixes #174

## What

When a PR's CI was fully green, the `ci-passed` label was sometimes not applied. Root cause: the label gate hardcodes all 9 checks as required, but each workflow has different `paths:` filters. Checks that aren't triggered for a PR (most commonly `Operator Test`, which only runs on `deployments/operator/**`) have an empty `bucket` in `gh pr checks`, which made `ALL_PASSED=false`, so the label was never added even though every check that actually ran was green.

See #174 for the full diagnosis and evidence (#168 labeled vs #167/#162 not labeled).

## Changes

- **All gating workflows**: skip checks whose `bucket` is empty (not triggered for this PR); only block on checks that actually ran. `pending` checks keep a non-empty value, so a still-running check still correctly waits — no premature labeling.

  ```bash
  bucket=$(echo "$CHECKS" | jq -r --arg n "$check" '.[] | select(.name == $n) | .bucket' | head -1)
  # Skip checks not triggered for this PR (filtered out by `paths`); only block on checks that actually ran.
  [ -z "$bucket" ] && continue
  if [ "$bucket" != "pass" ]; then
  ```

- **`operator-test.yaml`**: it previously had no labeling logic at all. Added the `Add ci-passed label` step (with the same guard) and made the failure path remove `ci-passed`, so operator-only PRs are handled consistently.

## Behavior after fix

- Normal Go PR (no operator changes) → `Operator Test` absent is skipped, label applied once everything that ran is green ✅
- Operator-only PR → `operator-test.yaml` now applies the label itself ✅
- Mixed PR (all 9 run, e.g. #168) → unchanged: still requires all green ✅

## Not addressed (out of scope)

The "each job polls all other checks, last one to finish labels" design still has a residual race when checks finish near-simultaneously (GitHub API propagation lag). Tracked as a known limitation in #174; a single `workflow_run`-triggered aggregator would be the robust long-term fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
