### PR TITLE
fix(test): de-flake TestStagedFileWriter_Close_ErrorCleansUpResources

### DIFF
--- a/server/storage/stagedstorage/writer_impl_test.go
+++ b/server/storage/stagedstorage/writer_impl_test.go
@@ -2566,6 +2566,14 @@ func TestStagedFileWriter_Close_ErrorCleansUpResources(t *testing.T) {
 	writer.runCancel()
 	time.Sleep(100 * time.Millisecond)
 
+	// Block the flush-queue processor from (re)starting during Close. Otherwise
+	// awaitAllFlushTasks can win the race where its select takes the buffered
+	// "send termination signal" branch, a processor consumes that signal and
+	// flips allUploadingTaskDone to true, and awaitAllFlushTasks returns nil --
+	// making this test flaky. With no processor to consume the signal, the
+	// cancelled ctx/runCtx deterministically drive awaitAllFlushTasks to error.
+	writer.flushTasksQueueProcessing.Store(true)
+
 	// Close with an already-cancelled context so awaitAllFlushTasks returns error immediately
 	cancelledCtx, cancel := context.WithCancel(context.Background())
 	cancel()


### PR DESCRIPTION
## What

Fixes the flaky unit test `TestStagedFileWriter_Close_ErrorCleansUpResources` in `server/storage/stagedstorage`.

Closes #176

## Why it was flaky

The test forces `awaitAllFlushTasks` to fail (cancel `runCtx` + pass an already-cancelled `ctx` to `Close`) and asserts `Close` returns an error. But `awaitAllFlushTasks`' `select` has three simultaneously-ready branches:

```go
select {
case f.flushTaskChan <- &blockFlushTask{entries: nil, ...}: // buffered chan (cap >= 300) -> always ready
    ...
case <-ctx.Done():      return ctx.Err()
case <-f.runCtx.Done(): return werr.ErrFileWriterAlreadyClosed
}
```

Go selects a ready case at random. When the **send** branch wins, the flush-queue processor consumes the termination signal and sets `allUploadingTaskDone = true`; the following loop then returns `nil` via `if allUploadingTaskDone { return nil }`, so `Close` returns `nil` and the assertion fails (`An error is expected but got nil`).

## Fix (test-only)

Since this test writes no data, `sync()` is a no-op and the **only** thing that would start a flush-queue processor is `awaitAllFlushTasks` itself. Setting `flushTasksQueueProcessing = true` before `Close` makes that `CompareAndSwap(false, true)` fail, so no processor starts, the termination signal is never consumed, `allUploadingTaskDone` stays `false`, and the cancelled `ctx`/`runCtx` deterministically drive `awaitAllFlushTasks` to return an error.

**Production code is unchanged** — `Close()`'s error propagation and `defer` cleanup were already correct; only the test's failure-injection was non-deterministic.

## Verification

| Check | Result |
|---|---|
| Before fix, `-count=200 -failfast` | reproduces `--- FAIL` |
| After fix, `-count=2000` | `ok` |
| After fix, `-race -count=50` | `ok`, no data race |
| Full `stagedstorage` package | `ok` |
