### PR TITLE
fix(test): de-flake TestMiniCluster_CustomAZRGPreservation

### DIFF
--- a/tests/integration/mini_cluster_test.go
+++ b/tests/integration/mini_cluster_test.go
@@ -942,16 +942,31 @@ func TestMiniCluster_CustomAZRGPreservation(t *testing.T) {
 	t.Logf("Restarting node 1...")
 	_, err = cluster.RestartNode(t, 1, cluster.GetSeedList())
 	assert.NoError(t, err)
-	time.Sleep(3 * time.Second)
 
-	// Verify the restarted node has preserved AZ/RG via discovery
-	updatedServers := discovery.GetAllServers()
-	assert.Equal(t, 3, len(updatedServers), "Should discover all 3 nodes after restart")
-
+	// Wait for the client to rediscover all 3 nodes (including the restarted
+	// node1) with node1's AZ/RG re-propagated via gossip. The async seed-join
+	// reconcile loop runs on a backoff of up to 10s, so a fixed sleep is racy
+	// (a 2-node snapshot also makes node1's AZ/RG read as "" from a missing map
+	// key). Poll until membership has actually converged.
 	restartedMeta := make(map[string][2]string)
-	for _, srv := range updatedServers {
-		restartedMeta[srv.NodeId] = [2]string{srv.Az, srv.ResourceGroup}
-		t.Logf("After restart: %s -> AZ=%s, RG=%s", srv.NodeId, srv.Az, srv.ResourceGroup)
+	require.Eventually(t, func() bool {
+		updatedServers := discovery.GetAllServers()
+		if len(updatedServers) != 3 {
+			return false
+		}
+		m := make(map[string][2]string)
+		for _, srv := range updatedServers {
+			m[srv.NodeId] = [2]string{srv.Az, srv.ResourceGroup}
+		}
+		if m["node1"][0] != "us-west-2" || m["node1"][1] != "rg-standard" {
+			return false
+		}
+		restartedMeta = m
+		return true
+	}, 30*time.Second, 500*time.Millisecond, "Client should rediscover all 3 nodes with node1's AZ/RG preserved after restart")
+
+	for nodeID, meta := range restartedMeta {
+		t.Logf("After restart: %s -> AZ=%s, RG=%s", nodeID, meta[0], meta[1])
 	}
 
 	// Verify AZ/RG preserved after restart


### PR DESCRIPTION
## What

De-flakes `TestMiniCluster_CustomAZRGPreservation` in `tests/integration`.

Closes #178

## Why it was flaky

After leaving + restarting node1, the test waited a fixed `time.Sleep(3 * time.Second)` and then asserted (one-shot) that the client's discovery saw all 3 nodes with node1's AZ/RG preserved.

Re-joining the memberlist cluster after a restart is asynchronous: `monitorAndJoinSeeds` (`server/service.go`) reconciles on a backoff of up to `maxBackoff = 10 * time.Second` (CI logs show `nextCheck=10s`). So 3s is frequently not enough for the restarted node + gossip to propagate back to the client. When only 2 nodes are discovered, node1's AZ/RG also read as `""` — not because metadata was lost, but because `restartedMeta["node1"]` is a missing-map-key zero value.

Observed failure (CI on PR #177's component-test job):

```
mini_cluster_test.go:949: Should discover all 3 nodes after restart  expected 3, actual 2
mini_cluster_test.go:958: node1 AZ should be preserved after restart  expected "us-west-2", actual ""
mini_cluster_test.go:959: node1 RG should be preserved after restart  expected "rg-standard", actual ""
```

The pre-restart assertions (3 nodes + correct AZ/RG) pass, and node0/node2 stay correct after restart — only the just-restarted node1 is briefly absent. This is a convergence-timing race, not a regression in the AZ/RG-preservation feature.

## Fix (test-only)

Replace the fixed sleep + one-shot assertions with `require.Eventually(...)` (30s timeout, 500ms poll) that waits until all 3 nodes are present **and** node1's AZ/RG have re-propagated. This matches the convention already used by sibling tests in this file (e.g. `TestMiniCluster_Join` / `TestMiniCluster_Leave`).

## Verification

- `go test ./tests/integration/ -run '^TestMiniCluster_CustomAZRGPreservation$' -count=8` → `ok` (against local etcd + MinIO)
- `go vet ./tests/integration/` clean
