### PR TITLE
test(chaos-mesh): add Chaos Mesh network-jitter nightly suite (#152)

### DIFF
--- a/.github/workflows/nightly-chaos-mesh.yaml
+++ b/.github/workflows/nightly-chaos-mesh.yaml
@@ -1,0 +1,32 @@
+name: Chaos Mesh Test
+on:
+  workflow_call:
+  workflow_dispatch:        # manual only; deliberately NO pull_request trigger -> never PR-gating
+concurrency:
+  group: nightly-chaos-mesh-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  Chaos-Mesh-Test:
+    name: Chaos Mesh Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: "1.25", cache: true }
+      - name: Install minikube, helm
+        run: |
+          curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          sudo install minikube /usr/local/bin/
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          kubectl version --client
+      - name: Run network-chaos suite
+        run: ./tests/chaos_mesh/run_network_chaos.sh
+      - name: Upload chaos artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chaos-mesh-artifacts
+          path: tests/chaos_mesh/artifacts/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -58,3 +58,8 @@ jobs:
     name: Chaos Test
     uses: ./.github/workflows/integration-test-chaos.yaml
     secrets: inherit
+
+  chaos-mesh-test:
+    name: Chaos Mesh Test
+    uses: ./.github/workflows/nightly-chaos-mesh.yaml
+    secrets: inherit

--- a/deployments/operator/test/lib.sh
+++ b/deployments/operator/test/lib.sh
@@ -1,0 +1,329 @@
+#!/bin/bash
+# Licensed to the LF AI & Data foundation under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Shared Woodpecker operator bring-up library. Source me; do not execute.
+: "${CLUSTER_NAME:=wp-operator-smoke}"
+: "${CR_NAME:=my-woodpecker}"
+: "${NAMESPACE:=default}"
+: "${REPLICAS:=3}"
+: "${OPERATOR_IMG:=woodpecker-operator:smoke}"
+: "${WP_IMG:=zilliztech/woodpecker:v0.1.26}"
+: "${MK_CPUS:=4}"            # chaos overrides -> 6
+: "${MK_MEMORY:=4096}"      # chaos overrides -> 8192
+: "${MK_RUNTIME:=}"         # chaos overrides -> containerd ; empty = minikube default
+: "${CLIENT_POD:=wp-client-test}"
+
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPERATOR_DIR="$(cd "$_LIB_DIR/.." && pwd)"
+PROJECT_ROOT="$(cd "$OPERATOR_DIR/../.." && pwd)"
+
+log()  { echo -e "\033[0;32m[$(date +'%H:%M:%S')]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[$(date +'%H:%M:%S')] WARN:\033[0m $*"; }
+fail() { echo -e "\033[0;31m[$(date +'%H:%M:%S')] FAIL:\033[0m $*"; exit 1; }
+
+wp_minikube_start() {
+    if minikube status -p "$CLUSTER_NAME" &>/dev/null; then log "cluster $CLUSTER_NAME up"; return 0; fi
+    local rt=""; [ -n "$MK_RUNTIME" ] && rt="--container-runtime=$MK_RUNTIME"
+    minikube start -p "$CLUSTER_NAME" --cpus="$MK_CPUS" --memory="$MK_MEMORY" --driver=docker $rt
+    kubectl config use-context "$CLUSTER_NAME"
+}
+
+wp_deploy_operator() {
+    log "=== Step 2: Building and deploying operator ==="
+    cd "$OPERATOR_DIR"
+    make docker-build IMG="$OPERATOR_IMG"
+    minikube -p "$CLUSTER_NAME" image load "$OPERATOR_IMG"
+    make deploy IMG="$OPERATOR_IMG"
+
+    log "Waiting for operator pod..."
+    kubectl wait --for=condition=Available deployment -l control-plane=controller-manager \
+        -n woodpecker-operator-system --timeout=120s
+    log "Step 2 done: operator running"
+    kubectl get pods -n woodpecker-operator-system
+}
+
+wp_build_wp_image() {
+    log "=== Step 3: Building Woodpecker server image ==="
+    cd "$PROJECT_ROOT"
+    make docker 2>/dev/null || docker build -t woodpecker:latest -f build/docker/ubuntu22.04/Dockerfile .
+    docker tag woodpecker:latest "$WP_IMG" 2>/dev/null || true
+    minikube -p "$CLUSTER_NAME" image load "$WP_IMG"
+    # Pre-load busybox for init container
+    docker pull busybox:1.36 2>/dev/null || true
+    minikube -p "$CLUSTER_NAME" image load busybox:1.36
+    log "Step 3 done: Woodpecker + busybox images loaded"
+}
+
+wp_deploy_deps() {
+    log "=== Step 4: Deploying etcd and MinIO ==="
+
+    # Skip if already running
+    if kubectl get pod/etcd pod/minio &>/dev/null; then
+        log "etcd and MinIO already running, skipping"
+        return 0
+    fi
+
+    kubectl apply -f - <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd
+  labels: { app: etcd }
+spec:
+  containers:
+    - name: etcd
+      image: quay.io/coreos/etcd:v3.5.18
+      command: ["etcd", "--listen-client-urls=http://0.0.0.0:2379",
+                "--advertise-client-urls=http://etcd.default.svc:2379"]
+      ports: [{ containerPort: 2379 }]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+spec:
+  selector: { app: etcd }
+  ports: [{ port: 2379, targetPort: 2379 }]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: minio
+  labels: { app: minio }
+spec:
+  containers:
+    - name: minio
+      image: minio/minio:RELEASE.2024-06-13T22-53-53Z
+      command: ["minio", "server", "/data"]
+      env:
+        - { name: MINIO_ROOT_USER, value: minioadmin }
+        - { name: MINIO_ROOT_PASSWORD, value: minioadmin }
+      ports: [{ containerPort: 9000 }]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  selector: { app: minio }
+  ports: [{ port: 9000, targetPort: 9000 }]
+EOF
+
+    kubectl wait --for=condition=Ready pod/etcd pod/minio --timeout=120s
+    log "Step 4 done: etcd and MinIO ready"
+}
+
+wp_create_cr() {
+    log "=== Step 5: Creating WoodpeckerCluster ($REPLICAS replicas) ==="
+
+    # Generate seeds
+    SEEDS_YAML=""
+    for i in $(seq 0 $((REPLICAS - 1))); do
+        SEEDS_YAML="$SEEDS_YAML
+                - ${CR_NAME}-server-${i}.${CR_NAME}-server-headless.${NAMESPACE}.svc:18080"
+    done
+
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-wp-config
+data:
+  woodpecker.yaml: |
+    woodpecker:
+      meta:
+        type: etcd
+      client:
+        quorum:
+          replicaCount: $REPLICAS
+          quorumBufferPools:
+            - name: default-region-pool
+              seeds:${SEEDS_YAML}
+      storage:
+        type: service
+        rootPath: /woodpecker/data
+      logstore:
+        segmentSyncPolicy:
+          syncInterval: 1000
+          syncMaxBytes: 4194304
+        retentionPolicy:
+          ttl: 10
+    log:
+      level: info
+      format: json
+      stdout: true
+    etcd:
+      endpoints: ["etcd.${NAMESPACE}.svc:2379"]
+      rootPath: by-dev
+    minio:
+      address: minio.${NAMESPACE}.svc
+      port: 9000
+      accessKeyID: minioadmin
+      secretAccessKey: minioadmin
+      bucketName: woodpecker
+      rootPath: files
+      createBucket: true
+---
+apiVersion: woodpecker.zilliz.io/v1alpha1
+kind: WoodpeckerCluster
+metadata:
+  name: ${CR_NAME}
+spec:
+  image: ${WP_IMG}
+  imagePullPolicy: Never
+  replicas: ${REPLICAS}
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  storageSize: 2Gi
+  configRef:
+    name: my-wp-config
+EOF
+
+    log "Waiting for StatefulSet to appear..."
+    TIMEOUT=60
+    while [ $TIMEOUT -gt 0 ]; do
+        if kubectl get statefulset "${CR_NAME}-server" &>/dev/null; then break; fi
+        sleep 3; TIMEOUT=$((TIMEOUT - 3))
+    done
+
+    kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance="$CR_NAME" --timeout=300s
+    log "Step 5 done: WoodpeckerCluster running ($REPLICAS replicas)"
+    kubectl get woodpeckerclusters
+    kubectl get pods -l app.kubernetes.io/instance="$CR_NAME"
+}
+
+wp_wait_healthy() {
+    log "=== Step 6: Verifying gossip cluster health ==="
+
+    # Check each node's memberlist via admin API
+    log "Checking gossip memberlist on each node..."
+    TIMEOUT=120
+    ALL_READY=false
+
+    while [ $TIMEOUT -gt 0 ] && [ "$ALL_READY" = false ]; do
+        ALL_READY=true
+        for i in $(seq 0 $((REPLICAS - 1))); do
+            POD="${CR_NAME}-server-${i}"
+            HOST="${POD}.${CR_NAME}-server-headless.${NAMESPACE}.svc"
+
+            # Check healthz
+            HEALTH=$(kubectl exec "$POD" -- curl -s -o /dev/null -w "%{http_code}" "http://localhost:9091/healthz" 2>/dev/null || echo "000")
+            if [ "$HEALTH" != "200" ]; then
+                ALL_READY=false
+                continue
+            fi
+
+            # Check node status - state should be "active"
+            NODE_STATUS=$(kubectl exec "$POD" -- curl -s "http://localhost:9091/admin/node/status" 2>/dev/null || echo "{}")
+            IS_ACTIVE=$(echo "$NODE_STATUS" | tr -d '\n' | grep -c '"state":"active"' 2>/dev/null || echo "0")
+
+            if [ "$IS_ACTIVE" -lt 1 ]; then
+                ALL_READY=false
+            fi
+        done
+
+        if [ "$ALL_READY" = false ]; then
+            log "  Gossip not fully formed yet (waiting...)  timeout=$TIMEOUT"
+            sleep 5
+            TIMEOUT=$((TIMEOUT - 5))
+        fi
+    done
+
+    if [ "$ALL_READY" = false ]; then
+        warn "Gossip cluster may not be fully formed after timeout. Dumping status..."
+        for i in $(seq 0 $((REPLICAS - 1))); do
+            POD="${CR_NAME}-server-${i}"
+            echo "--- $POD ---"
+            kubectl exec "$POD" -- curl -s "http://localhost:9091/admin/memberlist" 2>/dev/null || echo "  (unreachable)"
+            echo ""
+        done
+        fail "Gossip cluster not ready"
+    fi
+
+    log "All $REPLICAS nodes have joined the gossip cluster"
+
+    # Show memberlist from node-0 for verification
+    log "Memberlist from ${CR_NAME}-server-0:"
+    kubectl exec "${CR_NAME}-server-0" -- curl -s "http://localhost:9091/admin/memberlist" 2>/dev/null || true
+    echo ""
+
+    # Check node status
+    for i in $(seq 0 $((REPLICAS - 1))); do
+        POD="${CR_NAME}-server-${i}"
+        STATUS=$(kubectl exec "$POD" -- curl -s "http://localhost:9091/admin/node/status" 2>/dev/null || echo "{}")
+        log "  $POD: $STATUS"
+    done
+
+    log "Step 6 done: gossip cluster verified"
+}
+
+wp_launch_client_pod() {
+    kubectl get pod "$CLIENT_POD" &>/dev/null && return 0
+    docker pull golang:1.24 2>/dev/null || true; minikube -p "$CLUSTER_NAME" image load golang:1.24
+    kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${CLIENT_POD}
+  labels: { role: wp-client }
+spec:
+  containers:
+    - name: test
+      image: golang:1.24
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash","-c","sleep infinity"]
+      resources: { requests: { cpu: "500m", memory: "1Gi" } }
+  restartPolicy: Never
+EOF
+    kubectl wait --for=condition=Ready pod/"$CLIENT_POD" --timeout=300s
+}
+
+wp_write_client_config() {
+    local replicas="${1:-$REPLICAS}" seeds=""
+    for i in $(seq 0 $((replicas-1))); do
+        seeds="$seeds
+            - ${CR_NAME}-server-${i}.${CR_NAME}-server-headless.${NAMESPACE}.svc:18080"
+    done
+    kubectl exec "$CLIENT_POD" -- bash -c "cat > /tmp/test-config.yaml <<'CFGEOF'
+woodpecker:
+  meta: { type: etcd }
+  client:
+    segmentRollingPolicy: { maxSize: 1000 }
+    quorum:
+      replicaCount: ${replicas}
+      quorumBufferPools:
+        - name: default-region-pool
+          seeds:${seeds}
+  logstore: { retentionPolicy: { ttl: 10 } }
+  storage: { type: service, rootPath: /tmp/wp-test-data }
+log: { level: info, format: json, stdout: true }
+etcd: { endpoints: [ etcd.${NAMESPACE}.svc:2379 ], rootPath: by-dev }
+minio:
+  address: minio.${NAMESPACE}.svc
+  port: 9000
+  accessKeyID: minioadmin
+  secretAccessKey: minioadmin
+  bucketName: woodpecker
+  rootPath: files
+  createBucket: true
+CFGEOF"
+}

--- a/deployments/operator/test/lib.sh
+++ b/deployments/operator/test/lib.sh
@@ -41,9 +41,14 @@ wp_minikube_start() {
         log "Cluster '$CLUSTER_NAME' already running, skipping"
         return 0
     fi
-    local rt_args=()
-    [ -n "$MK_RUNTIME" ] && rt_args=("--container-runtime=$MK_RUNTIME")
-    minikube start -p "$CLUSTER_NAME" --cpus="$MK_CPUS" --memory="$MK_MEMORY" --driver=docker "${rt_args[@]}"
+    # NOTE: explicit if/else rather than a bash array — expanding an empty array under `set -u`
+    # ("${arr[@]}") throws "unbound variable" on macOS's bash 3.2, which both this suite and
+    # smoke-test.sh run under. $MK_RUNTIME is a controlled value with no spaces.
+    if [ -n "$MK_RUNTIME" ]; then
+        minikube start -p "$CLUSTER_NAME" --cpus="$MK_CPUS" --memory="$MK_MEMORY" --driver=docker --container-runtime="$MK_RUNTIME"
+    else
+        minikube start -p "$CLUSTER_NAME" --cpus="$MK_CPUS" --memory="$MK_MEMORY" --driver=docker
+    fi
     kubectl config use-context "$CLUSTER_NAME" # pin context (chaos suite creates multiple minikube profiles)
     kubectl cluster-info
     log "Step 1 done: minikube running"

--- a/deployments/operator/test/lib.sh
+++ b/deployments/operator/test/lib.sh
@@ -36,10 +36,16 @@ warn() { echo -e "\033[1;33m[$(date +'%H:%M:%S')] WARN:\033[0m $*"; }
 fail() { echo -e "\033[0;31m[$(date +'%H:%M:%S')] FAIL:\033[0m $*"; exit 1; }
 
 wp_minikube_start() {
-    if minikube status -p "$CLUSTER_NAME" &>/dev/null; then log "cluster $CLUSTER_NAME up"; return 0; fi
+    log "=== Step 1: Starting minikube cluster '$CLUSTER_NAME' ==="
+    if minikube status -p "$CLUSTER_NAME" &>/dev/null; then
+        log "Cluster '$CLUSTER_NAME' already running, skipping"
+        return 0
+    fi
     local rt=""; [ -n "$MK_RUNTIME" ] && rt="--container-runtime=$MK_RUNTIME"
     minikube start -p "$CLUSTER_NAME" --cpus="$MK_CPUS" --memory="$MK_MEMORY" --driver=docker $rt
     kubectl config use-context "$CLUSTER_NAME"
+    kubectl cluster-info
+    log "Step 1 done: minikube running"
 }
 
 wp_deploy_operator() {
@@ -297,9 +303,11 @@ EOF
     kubectl wait --for=condition=Ready pod/"$CLIENT_POD" --timeout=300s
 }
 
-wp_write_client_config() {
-    local replicas="${1:-$REPLICAS}" seeds=""
-    for i in $(seq 0 $((replicas-1))); do
+wp_write_client_config() {     # $1 = seed replica count ; $2 (optional) = replicaCount override
+    local seed_replicas="${1:-$REPLICAS}"
+    local replica_count="${2:-$seed_replicas}"
+    local seeds=""
+    for i in $(seq 0 $((seed_replicas-1))); do
         seeds="$seeds
             - ${CR_NAME}-server-${i}.${CR_NAME}-server-headless.${NAMESPACE}.svc:18080"
     done
@@ -309,7 +317,7 @@ woodpecker:
   client:
     segmentRollingPolicy: { maxSize: 1000 }
     quorum:
-      replicaCount: ${replicas}
+      replicaCount: ${replica_count}
       quorumBufferPools:
         - name: default-region-pool
           seeds:${seeds}

--- a/deployments/operator/test/lib.sh
+++ b/deployments/operator/test/lib.sh
@@ -41,9 +41,10 @@ wp_minikube_start() {
         log "Cluster '$CLUSTER_NAME' already running, skipping"
         return 0
     fi
-    local rt=""; [ -n "$MK_RUNTIME" ] && rt="--container-runtime=$MK_RUNTIME"
-    minikube start -p "$CLUSTER_NAME" --cpus="$MK_CPUS" --memory="$MK_MEMORY" --driver=docker $rt
-    kubectl config use-context "$CLUSTER_NAME"
+    local rt_args=()
+    [ -n "$MK_RUNTIME" ] && rt_args=("--container-runtime=$MK_RUNTIME")
+    minikube start -p "$CLUSTER_NAME" --cpus="$MK_CPUS" --memory="$MK_MEMORY" --driver=docker "${rt_args[@]}"
+    kubectl config use-context "$CLUSTER_NAME" # pin context (chaos suite creates multiple minikube profiles)
     kubectl cluster-info
     log "Step 1 done: minikube running"
 }
@@ -137,7 +138,8 @@ wp_create_cr() {
     log "=== Step 5: Creating WoodpeckerCluster ($REPLICAS replicas) ==="
 
     # Generate seeds
-    SEEDS_YAML=""
+    local SEEDS_YAML=""
+    local i
     for i in $(seq 0 $((REPLICAS - 1))); do
         SEEDS_YAML="$SEEDS_YAML
                 - ${CR_NAME}-server-${i}.${CR_NAME}-server-headless.${NAMESPACE}.svc:18080"
@@ -205,7 +207,7 @@ spec:
 EOF
 
     log "Waiting for StatefulSet to appear..."
-    TIMEOUT=60
+    local TIMEOUT=60
     while [ $TIMEOUT -gt 0 ]; do
         if kubectl get statefulset "${CR_NAME}-server" &>/dev/null; then break; fi
         sleep 3; TIMEOUT=$((TIMEOUT - 3))
@@ -222,14 +224,14 @@ wp_wait_healthy() {
 
     # Check each node's memberlist via admin API
     log "Checking gossip memberlist on each node..."
-    TIMEOUT=120
-    ALL_READY=false
+    local TIMEOUT=120
+    local ALL_READY=false
+    local i POD HEALTH NODE_STATUS IS_ACTIVE STATUS
 
     while [ $TIMEOUT -gt 0 ] && [ "$ALL_READY" = false ]; do
         ALL_READY=true
         for i in $(seq 0 $((REPLICAS - 1))); do
             POD="${CR_NAME}-server-${i}"
-            HOST="${POD}.${CR_NAME}-server-headless.${NAMESPACE}.svc"
 
             # Check healthz
             HEALTH=$(kubectl exec "$POD" -- curl -s -o /dev/null -w "%{http_code}" "http://localhost:9091/healthz" 2>/dev/null || echo "000")
@@ -313,18 +315,30 @@ wp_write_client_config() {     # $1 = seed replica count ; $2 (optional) = repli
     done
     kubectl exec "$CLIENT_POD" -- bash -c "cat > /tmp/test-config.yaml <<'CFGEOF'
 woodpecker:
-  meta: { type: etcd }
+  meta:
+    type: etcd
   client:
-    segmentRollingPolicy: { maxSize: 1000 }
+    segmentRollingPolicy:
+      maxSize: 1000
     quorum:
       replicaCount: ${replica_count}
       quorumBufferPools:
         - name: default-region-pool
           seeds:${seeds}
-  logstore: { retentionPolicy: { ttl: 10 } }
-  storage: { type: service, rootPath: /tmp/wp-test-data }
-log: { level: info, format: json, stdout: true }
-etcd: { endpoints: [ etcd.${NAMESPACE}.svc:2379 ], rootPath: by-dev }
+  logstore:
+    retentionPolicy:
+      ttl: 10
+  storage:
+    type: service
+    rootPath: /tmp/wp-test-data
+log:
+  level: info
+  format: json
+  stdout: true
+etcd:
+  endpoints:
+    - etcd.${NAMESPACE}.svc:2379
+  rootPath: by-dev
 minio:
   address: minio.${NAMESPACE}.svc
   port: 9000

--- a/deployments/operator/test/smoke-test.sh
+++ b/deployments/operator/test/smoke-test.sh
@@ -156,8 +156,8 @@ do_step8() {
     kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance="$CR_NAME" --timeout=300s
     kubectl get woodpeckerclusters
 
-    wp_write_client_config "$NEW_REPLICAS"
-    log "Test config updated with $NEW_REPLICAS seeds"
+    wp_write_client_config "$NEW_REPLICAS" "$REPLICAS"
+    log "Test config updated with $NEW_REPLICAS seeds (replicaCount=$REPLICAS)"
 
     log "Running E2E tests after scale-up..."
     kubectl exec -i "$CLIENT_POD" -- /bin/bash -c '

--- a/deployments/operator/test/smoke-test.sh
+++ b/deployments/operator/test/smoke-test.sh
@@ -25,27 +25,12 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-OPERATOR_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-PROJECT_ROOT="$(cd "$OPERATOR_DIR/../.." && pwd)"
+# Source shared bring-up library (defines log/warn/fail, OPERATOR_DIR, PROJECT_ROOT, wp_* functions)
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
 
-CLUSTER_NAME="wp-operator-smoke"
-OPERATOR_IMG="woodpecker-operator:smoke"
-WP_IMG="zilliztech/woodpecker:v0.1.26"
-NAMESPACE="default"
-CR_NAME="my-woodpecker"
-REPLICAS=3
+# smoke-test.sh keeps its own default knobs; intentionally does NOT set
+# MK_RUNTIME/MK_CPUS/MK_MEMORY so lib.sh defaults (4 CPU / 4096 MB / docker) apply.
 GIT_BRANCH="introduce_wp_operator"
-
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
-
-log()  { echo -e "${GREEN}[$(date +'%H:%M:%S')]${NC} $*"; }
-warn() { echo -e "${YELLOW}[$(date +'%H:%M:%S')] WARN:${NC} $*"; }
-fail() { echo -e "${RED}[$(date +'%H:%M:%S')] FAIL:${NC} $*"; exit 1; }
 
 usage() {
     cat <<EOF
@@ -103,265 +88,32 @@ do_clean() {
 # ============================================================
 # Step 1: Start minikube
 # ============================================================
-do_step1() {
-    log "=== Step 1: Starting minikube cluster '$CLUSTER_NAME' ==="
-    if minikube status -p "$CLUSTER_NAME" &>/dev/null; then
-        log "Cluster '$CLUSTER_NAME' already running, skipping"
-        return 0
-    fi
-    minikube start -p "$CLUSTER_NAME" --cpus=4 --memory=4096 --driver=docker
-    kubectl cluster-info
-    log "Step 1 done: minikube running"
-}
+do_step1() { wp_minikube_start; }
 
 # ============================================================
 # Step 2: Build and deploy operator
 # ============================================================
-do_step2() {
-    log "=== Step 2: Building and deploying operator ==="
-    cd "$OPERATOR_DIR"
-    make docker-build IMG="$OPERATOR_IMG"
-    minikube -p "$CLUSTER_NAME" image load "$OPERATOR_IMG"
-    make deploy IMG="$OPERATOR_IMG"
-
-    log "Waiting for operator pod..."
-    kubectl wait --for=condition=Available deployment -l control-plane=controller-manager \
-        -n woodpecker-operator-system --timeout=120s
-    log "Step 2 done: operator running"
-    kubectl get pods -n woodpecker-operator-system
-}
+do_step2() { wp_deploy_operator; }
 
 # ============================================================
 # Step 3: Build Woodpecker server image
 # ============================================================
-do_step3() {
-    log "=== Step 3: Building Woodpecker server image ==="
-    cd "$PROJECT_ROOT"
-    make docker 2>/dev/null || docker build -t woodpecker:latest -f build/docker/ubuntu22.04/Dockerfile .
-    docker tag woodpecker:latest "$WP_IMG" 2>/dev/null || true
-    minikube -p "$CLUSTER_NAME" image load "$WP_IMG"
-    # Pre-load busybox for init container
-    docker pull busybox:1.36 2>/dev/null || true
-    minikube -p "$CLUSTER_NAME" image load busybox:1.36
-    log "Step 3 done: Woodpecker + busybox images loaded"
-}
+do_step3() { wp_build_wp_image; }
 
 # ============================================================
 # Step 4: Deploy etcd and MinIO
 # ============================================================
-do_step4() {
-    log "=== Step 4: Deploying etcd and MinIO ==="
-
-    # Skip if already running
-    if kubectl get pod/etcd pod/minio &>/dev/null; then
-        log "etcd and MinIO already running, skipping"
-        return 0
-    fi
-
-    kubectl apply -f - <<'EOF'
-apiVersion: v1
-kind: Pod
-metadata:
-  name: etcd
-  labels: { app: etcd }
-spec:
-  containers:
-    - name: etcd
-      image: quay.io/coreos/etcd:v3.5.18
-      command: ["etcd", "--listen-client-urls=http://0.0.0.0:2379",
-                "--advertise-client-urls=http://etcd.default.svc:2379"]
-      ports: [{ containerPort: 2379 }]
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: etcd
-spec:
-  selector: { app: etcd }
-  ports: [{ port: 2379, targetPort: 2379 }]
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: minio
-  labels: { app: minio }
-spec:
-  containers:
-    - name: minio
-      image: minio/minio:RELEASE.2024-06-13T22-53-53Z
-      command: ["minio", "server", "/data"]
-      env:
-        - { name: MINIO_ROOT_USER, value: minioadmin }
-        - { name: MINIO_ROOT_PASSWORD, value: minioadmin }
-      ports: [{ containerPort: 9000 }]
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: minio
-spec:
-  selector: { app: minio }
-  ports: [{ port: 9000, targetPort: 9000 }]
-EOF
-
-    kubectl wait --for=condition=Ready pod/etcd pod/minio --timeout=120s
-    log "Step 4 done: etcd and MinIO ready"
-}
+do_step4() { wp_deploy_deps; }
 
 # ============================================================
 # Step 5: Create WoodpeckerCluster
 # ============================================================
-do_step5() {
-    log "=== Step 5: Creating WoodpeckerCluster ($REPLICAS replicas) ==="
-
-    # Generate seeds
-    SEEDS_YAML=""
-    for i in $(seq 0 $((REPLICAS - 1))); do
-        SEEDS_YAML="$SEEDS_YAML
-                - ${CR_NAME}-server-${i}.${CR_NAME}-server-headless.${NAMESPACE}.svc:18080"
-    done
-
-    kubectl apply -f - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: my-wp-config
-data:
-  woodpecker.yaml: |
-    woodpecker:
-      meta:
-        type: etcd
-      client:
-        quorum:
-          replicaCount: $REPLICAS
-          quorumBufferPools:
-            - name: default-region-pool
-              seeds:${SEEDS_YAML}
-      storage:
-        type: service
-        rootPath: /woodpecker/data
-      logstore:
-        segmentSyncPolicy:
-          syncInterval: 1000
-          syncMaxBytes: 4194304
-        retentionPolicy:
-          ttl: 10
-    log:
-      level: info
-      format: json
-      stdout: true
-    etcd:
-      endpoints: ["etcd.${NAMESPACE}.svc:2379"]
-      rootPath: by-dev
-    minio:
-      address: minio.${NAMESPACE}.svc
-      port: 9000
-      accessKeyID: minioadmin
-      secretAccessKey: minioadmin
-      bucketName: woodpecker
-      rootPath: files
-      createBucket: true
----
-apiVersion: woodpecker.zilliz.io/v1alpha1
-kind: WoodpeckerCluster
-metadata:
-  name: ${CR_NAME}
-spec:
-  image: ${WP_IMG}
-  imagePullPolicy: Never
-  replicas: ${REPLICAS}
-  resources:
-    requests:
-      cpu: "250m"
-      memory: "256Mi"
-    limits:
-      cpu: "500m"
-      memory: "512Mi"
-  storageSize: 2Gi
-  configRef:
-    name: my-wp-config
-EOF
-
-    log "Waiting for StatefulSet to appear..."
-    TIMEOUT=60
-    while [ $TIMEOUT -gt 0 ]; do
-        if kubectl get statefulset "${CR_NAME}-server" &>/dev/null; then break; fi
-        sleep 3; TIMEOUT=$((TIMEOUT - 3))
-    done
-
-    kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance="$CR_NAME" --timeout=300s
-    log "Step 5 done: WoodpeckerCluster running ($REPLICAS replicas)"
-    kubectl get woodpeckerclusters
-    kubectl get pods -l app.kubernetes.io/instance="$CR_NAME"
-}
+do_step5() { wp_create_cr; }
 
 # ============================================================
 # Step 6: Wait for gossip and verify cluster health
 # ============================================================
-do_step6() {
-    log "=== Step 6: Verifying gossip cluster health ==="
-
-    # Check each node's memberlist via admin API
-    log "Checking gossip memberlist on each node..."
-    TIMEOUT=120
-    ALL_READY=false
-
-    while [ $TIMEOUT -gt 0 ] && [ "$ALL_READY" = false ]; do
-        ALL_READY=true
-        for i in $(seq 0 $((REPLICAS - 1))); do
-            POD="${CR_NAME}-server-${i}"
-            HOST="${POD}.${CR_NAME}-server-headless.${NAMESPACE}.svc"
-
-            # Check healthz
-            HEALTH=$(kubectl exec "$POD" -- curl -s -o /dev/null -w "%{http_code}" "http://localhost:9091/healthz" 2>/dev/null || echo "000")
-            if [ "$HEALTH" != "200" ]; then
-                ALL_READY=false
-                continue
-            fi
-
-            # Check node status - state should be "active"
-            NODE_STATUS=$(kubectl exec "$POD" -- curl -s "http://localhost:9091/admin/node/status" 2>/dev/null || echo "{}")
-            IS_ACTIVE=$(echo "$NODE_STATUS" | tr -d '\n' | grep -c '"state":"active"' 2>/dev/null || echo "0")
-
-            if [ "$IS_ACTIVE" -lt 1 ]; then
-                ALL_READY=false
-            fi
-        done
-
-        if [ "$ALL_READY" = false ]; then
-            log "  Gossip not fully formed yet (waiting...)  timeout=$TIMEOUT"
-            sleep 5
-            TIMEOUT=$((TIMEOUT - 5))
-        fi
-    done
-
-    if [ "$ALL_READY" = false ]; then
-        warn "Gossip cluster may not be fully formed after timeout. Dumping status..."
-        for i in $(seq 0 $((REPLICAS - 1))); do
-            POD="${CR_NAME}-server-${i}"
-            echo "--- $POD ---"
-            kubectl exec "$POD" -- curl -s "http://localhost:9091/admin/memberlist" 2>/dev/null || echo "  (unreachable)"
-            echo ""
-        done
-        fail "Gossip cluster not ready"
-    fi
-
-    log "All $REPLICAS nodes have joined the gossip cluster"
-
-    # Show memberlist from node-0 for verification
-    log "Memberlist from ${CR_NAME}-server-0:"
-    kubectl exec "${CR_NAME}-server-0" -- curl -s "http://localhost:9091/admin/memberlist" 2>/dev/null || true
-    echo ""
-
-    # Check node status
-    for i in $(seq 0 $((REPLICAS - 1))); do
-        POD="${CR_NAME}-server-${i}"
-        STATUS=$(kubectl exec "$POD" -- curl -s "http://localhost:9091/admin/node/status" 2>/dev/null || echo "{}")
-        log "  $POD: $STATUS"
-    done
-
-    log "Step 6 done: gossip cluster verified"
-}
+do_step6() { wp_wait_healthy; }
 
 # ============================================================
 # Step 7: Launch test pod and run E2E tests
@@ -369,74 +121,11 @@ do_step6() {
 do_step7() {
     log "=== Step 7: Running E2E tests ==="
 
-    # Create test pod if not exists
-    if ! kubectl get pod wp-client-test &>/dev/null; then
-        docker pull golang:1.24 2>/dev/null || true
-        minikube -p "$CLUSTER_NAME" image load golang:1.24
-
-        kubectl apply -f - <<'EOF'
-apiVersion: v1
-kind: Pod
-metadata:
-  name: wp-client-test
-spec:
-  containers:
-    - name: test
-      image: golang:1.24
-      imagePullPolicy: IfNotPresent
-      command: ["/bin/bash", "-c", "sleep infinity"]
-      resources:
-        requests: { cpu: "500m", memory: "1Gi" }
-  restartPolicy: Never
-EOF
-        kubectl wait --for=condition=Ready pod/wp-client-test --timeout=300s
-    fi
-
-    # Generate test config
-    SEEDS_YAML=""
-    for i in $(seq 0 $((REPLICAS - 1))); do
-        SEEDS_YAML="$SEEDS_YAML
-            - ${CR_NAME}-server-${i}.${CR_NAME}-server-headless.${NAMESPACE}.svc:18080"
-    done
-
-    kubectl exec wp-client-test -- bash -c "cat > /tmp/test-config.yaml << 'CFGEOF'
-woodpecker:
-  meta:
-    type: etcd
-  client:
-    segmentRollingPolicy:
-      maxSize: 1000
-    quorum:
-      replicaCount: $REPLICAS
-      quorumBufferPools:
-        - name: default-region-pool
-          seeds:${SEEDS_YAML}
-  logstore:
-    retentionPolicy:
-      ttl: 10
-  storage:
-    type: service
-    rootPath: /tmp/wp-test-data
-log:
-  level: info
-  format: json
-  stdout: true
-etcd:
-  endpoints:
-    - etcd.${NAMESPACE}.svc:2379
-  rootPath: by-dev
-minio:
-  address: minio.${NAMESPACE}.svc
-  port: 9000
-  accessKeyID: minioadmin
-  secretAccessKey: minioadmin
-  bucketName: woodpecker
-  rootPath: files
-  createBucket: true
-CFGEOF"
+    wp_launch_client_pod
+    wp_write_client_config "$REPLICAS"
 
     # Clone code if not already done
-    kubectl exec -i wp-client-test -- /bin/bash -c "
+    kubectl exec -i "$CLIENT_POD" -- /bin/bash -c "
         if [ ! -d /root/woodpecker ]; then
             git clone -b $GIT_BRANCH --depth 1 https://github.com/zilliztech/woodpecker.git /root/woodpecker
         fi
@@ -444,7 +133,7 @@ CFGEOF"
 
     # Run tests
     log "Running E2E tests..."
-    kubectl exec -i wp-client-test -- /bin/bash -c '
+    kubectl exec -i "$CLIENT_POD" -- /bin/bash -c '
 set -e
 cd /root/woodpecker/tests/e2e_operator
 go test -v -count=1 -timeout 10m -config-file /tmp/test-config.yaml .
@@ -467,52 +156,11 @@ do_step8() {
     kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance="$CR_NAME" --timeout=300s
     kubectl get woodpeckerclusters
 
-    # Regenerate test config with all seeds (including new node)
-    SEEDS_YAML=""
-    for i in $(seq 0 $((NEW_REPLICAS - 1))); do
-        SEEDS_YAML="$SEEDS_YAML
-            - ${CR_NAME}-server-${i}.${CR_NAME}-server-headless.${NAMESPACE}.svc:18080"
-    done
-
-    kubectl exec wp-client-test -- bash -c "cat > /tmp/test-config.yaml << 'CFGEOF'
-woodpecker:
-  meta:
-    type: etcd
-  client:
-    segmentRollingPolicy:
-      maxSize: 1000
-    quorum:
-      replicaCount: $REPLICAS
-      quorumBufferPools:
-        - name: default-region-pool
-          seeds:${SEEDS_YAML}
-  logstore:
-    retentionPolicy:
-      ttl: 10
-  storage:
-    type: service
-    rootPath: /tmp/wp-test-data
-log:
-  level: info
-  format: json
-  stdout: true
-etcd:
-  endpoints:
-    - etcd.${NAMESPACE}.svc:2379
-  rootPath: by-dev
-minio:
-  address: minio.${NAMESPACE}.svc
-  port: 9000
-  accessKeyID: minioadmin
-  secretAccessKey: minioadmin
-  bucketName: woodpecker
-  rootPath: files
-  createBucket: true
-CFGEOF"
+    wp_write_client_config "$NEW_REPLICAS"
     log "Test config updated with $NEW_REPLICAS seeds"
 
     log "Running E2E tests after scale-up..."
-    kubectl exec -i wp-client-test -- /bin/bash -c '
+    kubectl exec -i "$CLIENT_POD" -- /bin/bash -c '
 set -e
 cd /root/woodpecker/tests/e2e_operator
 go test -v -count=1 -timeout 10m -run TestOperatorE2E_WriteAndRead -config-file /tmp/test-config.yaml .
@@ -532,12 +180,12 @@ do_step9() {
     log "=== Step 9: Scale down $CURRENT_REPLICAS → $FINAL_REPLICAS (decommission ${DECOMMISSION_NODE}) ==="
 
     # Sync latest test code to the pod (in case local changes haven't been pushed)
-    kubectl cp "$PROJECT_ROOT/tests/e2e_operator/main_test.go" wp-client-test:/root/woodpecker/tests/e2e_operator/main_test.go 2>/dev/null || true
+    kubectl cp "$PROJECT_ROOT/tests/e2e_operator/main_test.go" "$CLIENT_POD":/root/woodpecker/tests/e2e_operator/main_test.go 2>/dev/null || true
 
     # Phase 1: Run decommission test inside the test pod
     # Test will: decommission the node → write data → truncate → wait safe_to_terminate
     log "Running decommission test inside test pod..."
-    kubectl exec -i wp-client-test -- /bin/bash -c "
+    kubectl exec -i "$CLIENT_POD" -- /bin/bash -c "
 set -e
 cd /root/woodpecker/tests/e2e_operator
 go test -v -count=1 -timeout 5m \
@@ -562,50 +210,10 @@ go test -v -count=1 -timeout 5m \
     kubectl get pods -l app.kubernetes.io/instance="$CR_NAME"
 
     # Phase 3: Final write/read test on reduced cluster
-    SEEDS_YAML=""
-    for i in $(seq 0 $((FINAL_REPLICAS - 1))); do
-        SEEDS_YAML="$SEEDS_YAML
-            - ${CR_NAME}-server-${i}.${CR_NAME}-server-headless.${NAMESPACE}.svc:18080"
-    done
-
-    kubectl exec wp-client-test -- bash -c "cat > /tmp/test-config.yaml << 'CFGEOF'
-woodpecker:
-  meta:
-    type: etcd
-  client:
-    segmentRollingPolicy:
-      maxSize: 1000
-    quorum:
-      replicaCount: $FINAL_REPLICAS
-      quorumBufferPools:
-        - name: default-region-pool
-          seeds:${SEEDS_YAML}
-  logstore:
-    retentionPolicy:
-      ttl: 10
-  storage:
-    type: service
-    rootPath: /tmp/wp-test-data
-log:
-  level: info
-  format: json
-  stdout: true
-etcd:
-  endpoints:
-    - etcd.${NAMESPACE}.svc:2379
-  rootPath: by-dev
-minio:
-  address: minio.${NAMESPACE}.svc
-  port: 9000
-  accessKeyID: minioadmin
-  secretAccessKey: minioadmin
-  bucketName: woodpecker
-  rootPath: files
-  createBucket: true
-CFGEOF"
+    wp_write_client_config "$FINAL_REPLICAS"
 
     log "Running final write/read test on $FINAL_REPLICAS-node cluster..."
-    kubectl exec -i wp-client-test -- /bin/bash -c '
+    kubectl exec -i "$CLIENT_POD" -- /bin/bash -c '
 set -e
 cd /root/woodpecker/tests/e2e_operator
 go test -v -count=1 -timeout 10m -run TestOperatorE2E_WriteAndRead -config-file /tmp/test-config.yaml .
@@ -627,9 +235,9 @@ do_all() {
     do_step8
     do_step9
     echo ""
-    echo -e "${GREEN}========================================${NC}"
-    echo -e "${GREEN} ALL SMOKE TESTS PASSED${NC}"
-    echo -e "${GREEN}========================================${NC}"
+    echo -e "\033[0;32m========================================\033[0m"
+    echo -e "\033[0;32m ALL SMOKE TESTS PASSED\033[0m"
+    echo -e "\033[0;32m========================================\033[0m"
 }
 
 # ============================================================

--- a/deployments/operator/test/smoke-test.sh
+++ b/deployments/operator/test/smoke-test.sh
@@ -75,7 +75,7 @@ do_clean() {
     kubectl delete statefulset "${CR_NAME}-server" 2>/dev/null || true
     kubectl delete configmap my-wp-config 2>/dev/null || true
     kubectl delete pvc -l app.kubernetes.io/instance="$CR_NAME" 2>/dev/null || true
-    kubectl delete pod wp-client-test --force --grace-period=0 2>/dev/null || true
+    kubectl delete pod "$CLIENT_POD" --force --grace-period=0 2>/dev/null || true
     kubectl delete pod/etcd svc/etcd pod/minio svc/minio 2>/dev/null || true
 
     cd "$OPERATOR_DIR"

--- a/docs/superpowers/plans/2026-06-04-chaos-mesh-network-jitter.md
+++ b/docs/superpowers/plans/2026-06-04-chaos-mesh-network-jitter.md
@@ -1,0 +1,1105 @@
+# Chaos Mesh Network-Jitter Nightly Test — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a nightly-only Chaos Mesh suite that injects network jitter (delay+jitter / loss / partition-blip) on Woodpecker's server↔MinIO, server↔etcd, and client↔server links and asserts that the system only degrades gracefully (transient errors recover) — never loses acked data, hangs, corrupts, crashes, or storms retries.
+
+**Architecture:** Reuse the operator's minikube bring-up (`deployments/operator/test/smoke-test.sh`, refactored into a sourceable `lib.sh`), install Chaos Mesh, then a host-driven orchestrator (`tests/chaos_mesh/run_network_chaos.sh`) runs each scenario through phases `warmup → inject → under-chaos → remove → recovery → verify`. An in-pod Go program (`tests/chaos_mesh/workload/`) drives concurrent writers/readers, persists every acked `(logId, segmentId, entryId, payloadHash)` to a JSONL file, and asserts invariants I1–I7. The whole thing runs nightly only, never gating PRs.
+
+**Tech Stack:** Bash, minikube (docker driver + containerd runtime), Helm, Chaos Mesh `NetworkChaos` CRD, Go (`go test`-driven workload using the `github.com/zilliztech/woodpecker` client), GitHub Actions.
+
+**Source spec:** `docs/superpowers/specs/2026-06-04-chaos-mesh-network-jitter-design.md`
+
+---
+
+## Corrections to the spec (verified against the codebase)
+
+Where these conflict with the spec, **these win** (they were verified file-by-file during research):
+
+1. **Ports:** workload RPC = gRPC `:18080`; admin/healthz/node-status = `:9091` (`tests/e2e_operator/main_test.go:52-54`, `smoke-test.sh:399`). `NetworkChaos` is link-scoped, not port-scoped. **Consequence:** the I6 no-crash / health probes must run **from the host via `kubectl`**, because the client pod is itself under client↔server chaos.
+2. **Real server pod labels:** `app.kubernetes.io/instance: my-woodpecker` **AND** `app.kubernetes.io/component: server` (`deployments/operator/internal/controller/labels.go:23-31`). Not `app: server`. etcd/minio use bare `app: etcd` / `app: minio` (`smoke-test.sh` step4).
+3. **Client API (verified):** `LogWriter.WriteAsync(ctx, *log.WriteMessage) <-chan *log.WriteResult` (`woodpecker/log/log_writer.go:238`); `WriteResult{LogMessageId *LogMessageId; Err error}` (`:676`); `LogMessageId{SegmentId, EntryId int64}` (`woodpecker/log/log_message.go:29`); `LogReader.ReadNext(ctx) (*LogMessage, error)` with `LogMessage{Id *LogMessageId; Payload []byte; Properties map[string]string}` (`:71`); `log.EarliestLogMessageID()` (`:56`); `logHandle.GetId() int64` (`woodpecker/log/log_handle.go:46`). Client = `woodpecker.NewClient(ctx, cfg, etcdCli, true)` + `etcd.GetRemoteEtcdClient(cfg.Etcd.GetEndpoints())`. **No app-level CRC field** → I3 uses an app-computed `payloadHash` stored as a message Property and recomputed on read-back.
+4. **Error helpers:** `werr.IsRetryableErr` (`common/werr/errors.go:309`), `werr.IsTransportError` (`common/werr/utils.go:160`). `IsRetryableErr` returns **false** for non-Woodpecker errors (raw `context.DeadlineExceeded`, gRPC status). I5 ("permanent error") therefore means **a Woodpecker-typed, non-retryable error only** — raw ctx-deadline is an I4 (liveness budget) signal, not I5.
+5. **In-pod code delivery:** `smoke-test.sh:439-441` `git clone`s a **stale GitHub branch** for the Go test code. We must instead ship **current local source** (tarball + `kubectl cp` + extract), so the test exercises code under review.
+6. **Server image:** built from current source by `make docker`, tagged `zilliztech/woodpecker:v0.1.26`, `minikube image load`ed (`smoke-test.sh:34,140-142`). Keep the tag; the CR references it.
+7. **No minikube/helm GitHub Action in the repo** — install inline in the nightly job.
+8. **minikube runtime:** `smoke-test.sh:112` uses the default runtime; we need `--container-runtime=containerd` (+ 8 GiB / 6 CPU). Parameterize so smoke-test keeps its defaults.
+
+**Plan refinements over the raw research (decided here):**
+
+- **A. I2 soundness:** concurrency is **N logs × 1 writer each** (not multiple writers per log). With one writer per log, read-back `(segmentId, entryId)` is unambiguously monotonic, so the ordering check can't false-positive. Breadth comes from many logs.
+- **B. Source delivery:** `tar --exclude=.git` of the current working tree → `kubectl cp` → extract in-pod → `go test` in-pod (pod has `golang:1.24`). Robust, current, correct platform.
+- **C. Client pod labeled `role: wp-client`** in `wp_launch_client_pod`; the client↔server manifests select it by `labelSelectors: {role: wp-client}` (avoids the `fieldSelectors` portability gamble).
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `deployments/operator/test/lib.sh` | Create | Sourceable bring-up functions (minikube/operator/deps/CR/health/client-pod), parameterized by env vars. |
+| `deployments/operator/test/smoke-test.sh` | Modify | Thin wrappers that source `lib.sh`; preserve current defaults. |
+| `tests/chaos_mesh/README.md` | Create | How to run, prerequisites, scenario + invariant tables, "nightly-only." |
+| `tests/chaos_mesh/manifests/*.yaml` | Create (7) | One `NetworkChaos` per scenario N1–N7, verified selectors, no `duration`. |
+| `tests/chaos_mesh/workload/record.go` | Create | Acked-record JSONL persistence (append/load), concurrency-safe. |
+| `tests/chaos_mesh/workload/classify.go` | Create | `payloadHash`, `isWoodpeckerPermanent` (I5 predicate). |
+| `tests/chaos_mesh/workload/record_test.go` | Create | Unit tests for record round-trip. |
+| `tests/chaos_mesh/workload/classify_test.go` | Create | Unit tests for the I5 predicate + hash determinism. |
+| `tests/chaos_mesh/workload/main_test.go` | Create | Flags, client bring-up, `TestNetworkChaosWorkload` dispatcher, load+verify phases, I1–I7. |
+| `tests/chaos_mesh/run_network_chaos.sh` | Create | Host orchestrator: bring-up + chaos-mesh install + smoke-check + scenario loop + artifacts + cleanup. |
+| `.github/workflows/nightly-chaos-mesh.yaml` | Create | Reusable (`workflow_call`+`workflow_dispatch`) nightly job; no PR trigger, no ci-passed step. |
+| `.github/workflows/nightly.yaml` | Modify | Add one job that calls the new workflow. |
+
+---
+
+## Task 1: Refactor reusable bring-up into `lib.sh`
+
+**Files:**
+- Create: `deployments/operator/test/lib.sh`
+- Modify: `deployments/operator/test/smoke-test.sh`
+
+- [ ] **Step 1: Create `lib.sh` with parameterized bring-up functions**
+
+Extract the bodies of `do_step1`–`do_step7` (pod-create part), `do_step?` config heredoc from the current `smoke-test.sh` into functions. Add the resource/runtime knobs.
+
+```bash
+#!/bin/bash
+# Shared Woodpecker operator bring-up library. Source me; do not execute.
+# Consumers set these before sourcing (defaults preserve smoke-test.sh behavior):
+: "${CLUSTER_NAME:=wp-operator-smoke}"
+: "${CR_NAME:=my-woodpecker}"
+: "${NAMESPACE:=default}"
+: "${REPLICAS:=3}"
+: "${OPERATOR_IMG:=woodpecker-operator:smoke}"
+: "${WP_IMG:=zilliztech/woodpecker:v0.1.26}"
+: "${MK_CPUS:=4}"            # chaos overrides -> 6
+: "${MK_MEMORY:=4096}"      # chaos overrides -> 8192
+: "${MK_RUNTIME:=}"         # chaos overrides -> containerd ; empty = minikube default
+: "${CLIENT_POD:=wp-client-test}"
+
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OPERATOR_DIR="$(cd "$_LIB_DIR/.." && pwd)"
+PROJECT_ROOT="$(cd "$OPERATOR_DIR/../.." && pwd)"
+
+log()  { echo -e "\033[0;32m[$(date +'%H:%M:%S')]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[$(date +'%H:%M:%S')] WARN:\033[0m $*"; }
+fail() { echo -e "\033[0;31m[$(date +'%H:%M:%S')] FAIL:\033[0m $*"; exit 1; }
+
+wp_minikube_start() {
+  if minikube status -p "$CLUSTER_NAME" &>/dev/null; then log "cluster $CLUSTER_NAME up"; return 0; fi
+  local rt=""; [ -n "$MK_RUNTIME" ] && rt="--container-runtime=$MK_RUNTIME"
+  minikube start -p "$CLUSTER_NAME" --cpus="$MK_CPUS" --memory="$MK_MEMORY" --driver=docker $rt
+  kubectl config use-context "$CLUSTER_NAME"
+}
+wp_deploy_operator() {  # body of current do_step2
+  cd "$OPERATOR_DIR"
+  make docker-build IMG="$OPERATOR_IMG"
+  minikube -p "$CLUSTER_NAME" image load "$OPERATOR_IMG"
+  make deploy IMG="$OPERATOR_IMG"
+  kubectl wait --for=condition=Available deployment -l control-plane=controller-manager \
+    -n woodpecker-operator-system --timeout=120s
+}
+wp_build_wp_image() {   # body of current do_step3
+  cd "$PROJECT_ROOT"
+  make docker 2>/dev/null || docker build -t woodpecker:latest -f build/docker/ubuntu22.04/Dockerfile .
+  docker tag woodpecker:latest "$WP_IMG" 2>/dev/null || true
+  minikube -p "$CLUSTER_NAME" image load "$WP_IMG"
+  docker pull busybox:1.36 2>/dev/null || true; minikube -p "$CLUSTER_NAME" image load busybox:1.36
+}
+wp_deploy_deps()  { :; }   # paste current do_step4 etcd+minio apply + wait verbatim
+wp_create_cr()    { :; }   # paste current do_step5 ConfigMap+CR apply + wait verbatim (uses $REPLICAS)
+wp_wait_healthy() { :; }   # paste current do_step6 gossip/health loop verbatim (curl :9091)
+wp_launch_client_pod() {   # pod-create part of current do_step7, PLUS a role label (refinement C)
+  kubectl get pod "$CLIENT_POD" &>/dev/null && return 0
+  docker pull golang:1.24 2>/dev/null || true; minikube -p "$CLUSTER_NAME" image load golang:1.24
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${CLIENT_POD}
+  labels: { role: wp-client }
+spec:
+  containers:
+    - name: test
+      image: golang:1.24
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash","-c","sleep infinity"]
+      resources: { requests: { cpu: "500m", memory: "1Gi" } }
+  restartPolicy: Never
+EOF
+  kubectl wait --for=condition=Ready pod/"$CLIENT_POD" --timeout=300s
+}
+wp_write_client_config() {  # heredoc from current do_step7; param $1 = replicas
+  local replicas="${1:-$REPLICAS}" seeds=""
+  for i in $(seq 0 $((replicas-1))); do
+    seeds="$seeds
+            - ${CR_NAME}-server-${i}.${CR_NAME}-server-headless.${NAMESPACE}.svc:18080"
+  done
+  kubectl exec "$CLIENT_POD" -- bash -c "cat > /tmp/test-config.yaml <<'CFGEOF'
+woodpecker:
+  meta: { type: etcd }
+  client:
+    segmentRollingPolicy: { maxSize: 1000 }
+    quorum:
+      replicaCount: ${replicas}
+      quorumBufferPools:
+        - name: default-region-pool
+          seeds:${seeds}
+  logstore: { retentionPolicy: { ttl: 10 } }
+  storage: { type: service, rootPath: /tmp/wp-test-data }
+log: { level: info, format: json, stdout: true }
+etcd: { endpoints: [ etcd.${NAMESPACE}.svc:2379 ], rootPath: by-dev }
+minio:
+  address: minio.${NAMESPACE}.svc
+  port: 9000
+  accessKeyID: minioadmin
+  secretAccessKey: minioadmin
+  bucketName: woodpecker
+  rootPath: files
+  createBucket: true
+CFGEOF"
+}
+```
+
+> When pasting the `:;` placeholder bodies, copy the **exact** blocks from the current `smoke-test.sh` (`do_step4` lines ~152-209, `do_step5` ~214-296, `do_step6` ~301-364). Do not paraphrase — they are known-good.
+
+- [ ] **Step 2: Refactor `smoke-test.sh` to source `lib.sh`**
+
+Replace the `do_step1`..`do_step7` bodies with wrappers, keeping smoke-test's existing defaults (no chaos knobs set, so `MK_RUNTIME` stays empty and resources stay 4/4096):
+
+```bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib.sh"
+do_step1() { wp_minikube_start; }
+do_step2() { wp_deploy_operator; }
+do_step3() { wp_build_wp_image; }
+do_step4() { wp_deploy_deps; }
+do_step5() { wp_create_cr; }
+do_step6() { wp_wait_healthy; }
+# do_step7..do_step9 keep their existing test-running logic, but call
+# wp_launch_client_pod + wp_write_client_config for the pod/config setup.
+```
+
+- [ ] **Step 3: Verify syntax + bring-up parity**
+
+Run: `bash -n deployments/operator/test/lib.sh && bash -n deployments/operator/test/smoke-test.sh`
+Expected: no output (syntax OK).
+
+Run (requires minikube/docker): `cd deployments/operator/test && ./smoke-test.sh step1 && ./smoke-test.sh step6 && kubectl get pods -l app.kubernetes.io/instance=my-woodpecker`
+Expected: 3 server pods `Running`. Then `./smoke-test.sh clean`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deployments/operator/test/lib.sh deployments/operator/test/smoke-test.sh
+git commit -m "test(operator): extract reusable bring-up into lib.sh
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Scaffold `tests/chaos_mesh/` + README
+
+**Files:**
+- Create: `tests/chaos_mesh/README.md`, `tests/chaos_mesh/manifests/.gitkeep`, `tests/chaos_mesh/workload/.gitkeep`
+
+- [ ] **Step 1: Create the directory tree and README**
+
+```bash
+mkdir -p tests/chaos_mesh/manifests tests/chaos_mesh/workload
+touch tests/chaos_mesh/manifests/.gitkeep tests/chaos_mesh/workload/.gitkeep
+```
+
+README contents: a short intro, prerequisites (`minikube, docker, kubectl, helm, go`), `./run_network_chaos.sh` usage, the N1–N7 scenario table and I1–I7 invariant table copied from the spec, and a bold note: **"Nightly only — never a PR-gating check."** The Go workload is part of the root module `github.com/zilliztech/woodpecker` (no new `go.mod`).
+
+- [ ] **Step 2: Verify + commit**
+
+Run: `ls -R tests/chaos_mesh`
+Expected: shows `README.md`, `manifests/`, `workload/`.
+
+```bash
+git add tests/chaos_mesh
+git commit -m "test(chaos-mesh): scaffold tests/chaos_mesh layout
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: NetworkChaos manifests (N1–N7)
+
+**Files:**
+- Create: `tests/chaos_mesh/manifests/{server-minio-delay,server-minio-loss,server-minio-blip,server-etcd-delay,server-etcd-blip,client-server-delay,client-server-loss}.yaml`
+
+- [ ] **Step 1: Write all seven manifests**
+
+Selectors use verified labels (Correction #2 + refinement C). `duration` omitted (orchestrator owns lifetime).
+
+`server-minio-delay.yaml`:
+```yaml
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata: { name: server-minio-delay, namespace: default }
+spec:
+  action: delay
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors: { app.kubernetes.io/instance: my-woodpecker, app.kubernetes.io/component: server }
+  direction: to
+  target:
+    mode: all
+    selector: { namespaces: [default], labelSelectors: { app: minio } }
+  delay: { latency: "300ms", jitter: "100ms", correlation: "50" }
+```
+
+`server-minio-loss.yaml`: identical to N1 but:
+```yaml
+  action: loss
+  loss: { loss: "10", correlation: "25" }
+```
+(remove the `delay:` block)
+
+`server-minio-blip.yaml`:
+```yaml
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata: { name: server-minio-blip, namespace: default }
+spec:
+  action: partition
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors: { app.kubernetes.io/instance: my-woodpecker, app.kubernetes.io/component: server }
+  direction: both
+  target:
+    mode: all
+    selector: { namespaces: [default], labelSelectors: { app: minio } }
+```
+
+`server-etcd-delay.yaml`: copy N1, change `metadata.name: server-etcd-delay` and `target...labelSelectors: { app: etcd }`.
+
+`server-etcd-blip.yaml`: copy N3, change `metadata.name: server-etcd-blip` and `target...labelSelectors: { app: etcd }`.
+
+`client-server-delay.yaml` (selects the client pod by its `role` label — refinement C):
+```yaml
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata: { name: client-server-delay, namespace: default }
+spec:
+  action: delay
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors: { role: wp-client }
+  direction: to
+  target:
+    mode: all
+    selector:
+      namespaces: [default]
+      labelSelectors: { app.kubernetes.io/instance: my-woodpecker, app.kubernetes.io/component: server }
+  delay: { latency: "300ms", jitter: "100ms", correlation: "50" }
+```
+
+`client-server-loss.yaml`: copy N6, change `metadata.name: client-server-loss`, replace `delay:` with:
+```yaml
+  action: loss
+  loss: { loss: "10", correlation: "25" }
+```
+
+- [ ] **Step 2: Verify YAML + commit**
+
+Run:
+```bash
+for f in tests/chaos_mesh/manifests/*.yaml; do
+  python3 -c "import yaml,sys; list(yaml.safe_load_all(open(sys.argv[1])))" "$f" && echo "OK $f"
+done
+```
+Expected: `OK` for all seven. (Server-side CRD validation `kubectl apply --dry-run=server` happens later in Task 12 once Chaos Mesh is installed.)
+
+```bash
+git add tests/chaos_mesh/manifests
+git commit -m "test(chaos-mesh): add NetworkChaos manifests N1-N7
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Workload — record persistence (TDD)
+
+**Files:**
+- Create: `tests/chaos_mesh/workload/record.go`
+- Test: `tests/chaos_mesh/workload/record_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package workload
+
+import ("os"; "path/filepath"; "testing"; "github.com/stretchr/testify/require")
+
+func TestRecorderRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "acked.jsonl")
+	r, err := openRecorder(path, true)
+	require.NoError(t, err)
+	in := []AckRecord{
+		{LogName: "chaos-n152-0", LogId: 1, SegmentId: 0, EntryId: 0, PayloadHash: "aa", Seq: 1},
+		{LogName: "chaos-n152-0", LogId: 1, SegmentId: 0, EntryId: 1, PayloadHash: "bb", Seq: 2},
+	}
+	for _, rec := range in { require.NoError(t, r.append(rec)) }
+	require.NoError(t, r.close())
+	out, err := loadRecords(path)
+	require.NoError(t, err)
+	require.Equal(t, in, out)
+	_ = os.Remove(path)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd tests/chaos_mesh/workload && go test -run TestRecorderRoundTrip .`
+Expected: FAIL — `undefined: openRecorder/AckRecord/loadRecords`.
+
+- [ ] **Step 3: Implement `record.go`**
+
+```go
+package workload
+
+import ("bufio"; "encoding/json"; "os"; "sync")
+
+// AckRecord is the persisted unit of truth for I1/I2/I3 read-back.
+type AckRecord struct {
+	LogName     string `json:"log"`
+	LogId       int64  `json:"logId"`
+	SegmentId   int64  `json:"seg"`
+	EntryId     int64  `json:"entry"`
+	PayloadHash string `json:"hash"`
+	Seq         int64  `json:"seq"`
+}
+
+type recorder struct {
+	mu sync.Mutex
+	f  *os.File
+}
+
+func openRecorder(path string, truncate bool) (*recorder, error) {
+	flags := os.O_CREATE | os.O_WRONLY | os.O_APPEND
+	if truncate { flags = os.O_CREATE | os.O_WRONLY | os.O_TRUNC }
+	f, err := os.OpenFile(path, flags, 0o644)
+	if err != nil { return nil, err }
+	return &recorder{f: f}, nil
+}
+
+func (r *recorder) append(rec AckRecord) error {
+	b, err := json.Marshal(rec)
+	if err != nil { return err }
+	r.mu.Lock(); defer r.mu.Unlock()
+	_, err = r.f.Write(append(b, '\n'))
+	return err
+}
+
+func (r *recorder) close() error { return r.f.Close() }
+
+func loadRecords(path string) ([]AckRecord, error) {
+	f, err := os.Open(path)
+	if err != nil { return nil, err }
+	defer f.Close()
+	var out []AckRecord
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 0, 1024*1024), 8*1024*1024)
+	for s.Scan() {
+		line := s.Bytes()
+		if len(line) == 0 { continue }
+		var rec AckRecord
+		if err := json.Unmarshal(line, &rec); err != nil { return nil, err }
+		out = append(out, rec)
+	}
+	return out, s.Err()
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd tests/chaos_mesh/workload && go test -run TestRecorderRoundTrip .`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/chaos_mesh/workload/record.go tests/chaos_mesh/workload/record_test.go
+git commit -m "test(chaos-mesh): acked-record JSONL persistence
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Workload — hash + I5 classifier (TDD)
+
+**Files:**
+- Create: `tests/chaos_mesh/workload/classify.go`
+- Test: `tests/chaos_mesh/workload/classify_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package workload
+
+import ("context"; "errors"; "testing"; "github.com/stretchr/testify/require")
+
+func TestPayloadHashDeterministic(t *testing.T) {
+	require.Equal(t, payloadHash([]byte("abc")), payloadHash([]byte("abc")))
+	require.NotEqual(t, payloadHash([]byte("abc")), payloadHash([]byte("abd")))
+}
+
+func TestIsWoodpeckerPermanent_TransientAndNil(t *testing.T) {
+	require.False(t, isWoodpeckerPermanent(nil))
+	require.False(t, isWoodpeckerPermanent(context.DeadlineExceeded))
+	require.False(t, isWoodpeckerPermanent(context.Canceled))
+	require.False(t, isWoodpeckerPermanent(errors.New("some random non-wp error")))
+}
+```
+> The Woodpecker-typed permanent/retryable cases are exercised live in Task 12 (constructing real `werr` errors here would couple the unit test to internal constructors). These cases pin the critical "raw ctx / nil / unknown error is NOT charged as I5" behavior, which is the subtle part.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd tests/chaos_mesh/workload && go test -run 'TestPayloadHash|TestIsWoodpeckerPermanent' .`
+Expected: FAIL — `undefined: payloadHash/isWoodpeckerPermanent`.
+
+- [ ] **Step 3: Implement `classify.go`**
+
+```go
+package workload
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+
+	"github.com/zilliztech/woodpecker/common/werr"
+)
+
+func payloadHash(b []byte) string { h := sha256.Sum256(b); return hex.EncodeToString(h[:]) }
+
+// isWoodpeckerPermanent reports true ONLY for a Woodpecker-typed, non-retryable error.
+// Raw context deadline / cancellation / transport errors are transient (owned by the
+// client's own retry budget) and must NOT be charged as I5 violations (Correction #4).
+func isWoodpeckerPermanent(err error) bool {
+	if err == nil { return false }
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) { return false }
+	if werr.IsTransportError(err) { return false }
+	// A retryable Woodpecker error is acceptable degradation, not a permanent failure.
+	if werr.IsRetryableErr(err) { return false }
+	// Permanent iff it is a Woodpecker-typed error that is NOT retryable.
+	var wpErr interface{ IsRetryable() bool }
+	if errors.As(err, &wpErr) { return !wpErr.IsRetryable() }
+	return false // unknown / non-WP error: not our I5 target
+}
+```
+> **At execution time, confirm** the `interface{ IsRetryable() bool }` assertion matches the real `*werr.woodpeckerError` method (research cited `errors.go:309` for `IsRetryableErr`; verify the method name with `go doc github.com/zilliztech/woodpecker/common/werr` — if the method differs, adjust the interface and re-run the test). The test in Step 1 does not depend on this branch.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd tests/chaos_mesh/workload && go test -run 'TestPayloadHash|TestIsWoodpeckerPermanent' .`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/chaos_mesh/workload/classify.go tests/chaos_mesh/workload/classify_test.go
+git commit -m "test(chaos-mesh): payload hash + I5 permanent-error classifier
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Workload — flags + client bring-up
+
+**Files:**
+- Create: `tests/chaos_mesh/workload/main_test.go`
+
+- [ ] **Step 1: Write flags + `newClient` + an empty dispatcher**
+
+```go
+package workload
+
+import (
+	"context"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/etcd"
+	"github.com/zilliztech/woodpecker/woodpecker"
+)
+
+var (
+	configFile = flag.String("config-file", "/tmp/test-config.yaml", "woodpecker config path")
+	phase      = flag.String("phase", "warmup", "warmup|under-chaos|recovery|verify")
+	recordFile = flag.String("record-file", "/tmp/wp-chaos-acked.jsonl", "acked records JSONL")
+	numLogs    = flag.Int("logs", 8, "number of concurrent logs (1 writer each — refinement A)")
+	windowSecs = flag.Int("window", 45, "load-phase duration seconds")
+	logPrefix  = flag.String("log-prefix", "chaos-n152", "stable log name prefix across phases")
+)
+
+func newClient(ctx context.Context, t *testing.T) (woodpecker.Client, func()) {
+	cfg, err := config.NewConfiguration(*configFile)
+	require.NoError(t, err)
+	etcdCli, err := etcd.GetRemoteEtcdClient(cfg.Etcd.GetEndpoints())
+	require.NoError(t, err)
+	cli, err := woodpecker.NewClient(ctx, cfg, etcdCli, true)
+	require.NoError(t, err)
+	return cli, func() { _ = cli.Close(ctx); _ = etcdCli.Close() }
+}
+
+func TestNetworkChaosWorkload(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+	cli, closeFn := newClient(ctx, t)
+	defer closeFn()
+	switch *phase {
+	case "warmup":
+		runLoadPhase(ctx, t, cli, true)
+	case "under-chaos", "recovery":
+		runLoadPhase(ctx, t, cli, false)
+	case "verify":
+		runVerifyPhase(ctx, t, cli)
+	default:
+		t.Fatalf("unknown phase %q", *phase)
+	}
+}
+```
+
+- [ ] **Step 2: Verify it compiles (functions defined in Tasks 7-8)**
+
+This step intentionally won't build until Tasks 7–8 add `runLoadPhase`/`runVerifyPhase`. Confirm only that imports resolve:
+Run: `cd tests/chaos_mesh/workload && go vet ./... 2>&1 | head`
+Expected: errors are limited to `undefined: runLoadPhase` / `undefined: runVerifyPhase` (no import/type errors). If an import path or `NewClient`/`NewConfiguration`/`GetRemoteEtcdClient` signature is wrong, fix it now against `go doc`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/chaos_mesh/workload/main_test.go
+git commit -m "test(chaos-mesh): workload flags + client bring-up + phase dispatcher
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Workload — load phase (warmup/under-chaos/recovery) + I4/I5/I7
+
+**Files:**
+- Modify: `tests/chaos_mesh/workload/main_test.go`
+
+- [ ] **Step 1: Add `runLoadPhase`**
+
+One writer per log (refinement A) + one tail reader per log. Per-op 30s bound (I4). I5 via `isWoodpeckerPermanent`. I7 via `ok > 0`.
+
+```go
+import (  // add to the existing import block
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/zilliztech/woodpecker/woodpecker/log"
+)
+
+type metrics struct{ ok, errRetryable, errPermanent int64 }
+
+func runLoadPhase(ctx context.Context, t *testing.T, cli woodpecker.Client, truncate bool) {
+	rec, err := openRecorder(*recordFile, truncate)
+	require.NoError(t, err)
+	defer rec.close()
+
+	var m metrics
+	deadline := time.Now().Add(time.Duration(*windowSecs) * time.Second)
+
+	type lh struct {
+		name   string
+		id     int64
+		handle log.LogHandle
+		writer log.LogWriter
+		seq    int64
+	}
+	logs := make([]*lh, *numLogs)
+	for i := range logs {
+		name := fmt.Sprintf("%s-%d", *logPrefix, i)
+		_ = cli.CreateLog(ctx, name) // idempotent across phases
+		h, err := cli.OpenLog(ctx, name)
+		require.NoError(t, err)
+		w, err := h.OpenLogWriter(ctx)
+		require.NoError(t, err)
+		logs[i] = &lh{name: name, id: h.GetId(), handle: h, writer: w}
+	}
+
+	var wg sync.WaitGroup
+	// ---- one WRITER per log (refinement A: unambiguous ordering) ----
+	for _, L := range logs {
+		wg.Add(1)
+		go func(L *lh) {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				seq := atomic.AddInt64(&L.seq, 1)
+				payload := []byte(fmt.Sprintf("%s|%d|%d", L.name, time.Now().UnixNano(), seq))
+				ph := payloadHash(payload)
+				opCtx, opCancel := context.WithTimeout(ctx, 30*time.Second) // I4 bound
+				res := <-L.writer.WriteAsync(opCtx, &log.WriteMessage{
+					Payload:    payload,
+					Properties: map[string]string{"hash": ph},
+				})
+				opCancel()
+				if res.Err != nil {
+					if isWoodpeckerPermanent(res.Err) {
+						atomic.AddInt64(&m.errPermanent, 1)
+						t.Errorf("I5 VIOLATION (write): permanent error under transient fault: %v", res.Err)
+					} else {
+						atomic.AddInt64(&m.errRetryable, 1) // acceptable degradation
+					}
+					continue
+				}
+				atomic.AddInt64(&m.ok, 1)
+				_ = rec.append(AckRecord{
+					LogName: L.name, LogId: L.id,
+					SegmentId: res.LogMessageId.SegmentId, EntryId: res.LogMessageId.EntryId,
+					PayloadHash: ph, Seq: seq,
+				})
+			}
+		}(L)
+	}
+	// ---- one tail READER per log (liveness / no-hang) ----
+	for _, L := range logs {
+		wg.Add(1)
+		go func(L *lh) {
+			defer wg.Done()
+			earliest := log.EarliestLogMessageID()
+			r, err := L.handle.OpenLogReader(ctx, &earliest, "chaos-tail-"+L.name)
+			if err != nil { return }
+			defer r.Close(ctx)
+			for time.Now().Before(deadline) {
+				rCtx, rCancel := context.WithTimeout(ctx, 30*time.Second)
+				_, err := r.ReadNext(rCtx)
+				rCancel()
+				if err != nil && isWoodpeckerPermanent(err) {
+					t.Errorf("I5 VIOLATION (read): permanent error under transient fault: %v", err)
+				}
+			}
+		}(L)
+	}
+	wg.Wait()
+	for _, L := range logs { _ = L.writer.Close(ctx) }
+
+	require.Greater(t, m.ok, int64(0),
+		"I7 VIOLATION: zero successful writes in phase %s (no forward progress)", *phase)
+	t.Logf("phase=%s ok=%d retryableErr=%d permanentErr=%d",
+		*phase, m.ok, m.errRetryable, m.errPermanent)
+}
+```
+> I4 note: each op has a 30s bound → a stuck op returns `DeadlineExceeded` (definitive), never hangs; `wg.Wait()` returning within the `go test -timeout` is itself the no-deadlock witness. At execution time, confirm `OpenLogReader(ctx, *LogMessageId, name)` and `OpenLogWriter(ctx)` signatures against `go doc` (research cited them; adjust if needed).
+
+- [ ] **Step 2: Verify build/vet**
+
+Run: `cd tests/chaos_mesh/workload && go vet ./... 2>&1 | head`
+Expected: only `undefined: runVerifyPhase` remains.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/chaos_mesh/workload/main_test.go
+git commit -m "test(chaos-mesh): load phase + I4/I5/I7 assertions
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Workload — verify phase + I1/I2/I3
+
+**Files:**
+- Modify: `tests/chaos_mesh/workload/main_test.go`
+
+- [ ] **Step 1: Add `runVerifyPhase`**
+
+```go
+import ("sort") // add to import block
+
+func runVerifyPhase(ctx context.Context, t *testing.T, cli woodpecker.Client) {
+	recs, err := loadRecords(*recordFile)
+	require.NoError(t, err)
+	require.Greater(t, len(recs), 0, "no acked records to verify")
+
+	byLog := map[string][]AckRecord{}
+	for _, r := range recs { byLog[r.LogName] = append(byLog[r.LogName], r) }
+
+	for name, want := range byLog {
+		sort.Slice(want, func(i, j int) bool { return want[i].Seq < want[j].Seq })
+		h, err := cli.OpenLog(ctx, name)
+		require.NoError(t, err)
+		earliest := log.EarliestLogMessageID()
+		r, err := h.OpenLogReader(ctx, &earliest, "verify-"+name)
+		require.NoError(t, err)
+
+		ackedHash := map[[2]int64]string{}
+		for _, w := range want { ackedHash[[2]int64{w.SegmentId, w.EntryId}] = w.PayloadHash }
+
+		seen := map[[2]int64]bool{}
+		var lastSeg, lastEntry int64 = -1, -1
+		rctx, rcancel := context.WithTimeout(ctx, 5*time.Minute)
+		for len(seen) < len(ackedHash) {
+			msg, err := r.ReadNext(rctx)
+			require.NoError(t, err, "I1/I4 read-back failed for %s (%d/%d)", name, len(seen), len(ackedHash))
+			k := [2]int64{msg.Id.SegmentId, msg.Id.EntryId}
+			// I2 ordering: strictly increasing (seg,entry) in read order (one writer per log).
+			if msg.Id.SegmentId == lastSeg {
+				require.Greater(t, msg.Id.EntryId, lastEntry, "I2 VIOLATION: non-increasing entryId in %s", name)
+			} else if lastSeg >= 0 {
+				require.Greater(t, msg.Id.SegmentId, lastSeg, "I2 VIOLATION: non-increasing segmentId in %s", name)
+			}
+			lastSeg, lastEntry = msg.Id.SegmentId, msg.Id.EntryId
+			if wantHash, ok := ackedHash[k]; ok {
+				require.Equal(t, wantHash, payloadHash(msg.Payload),
+					"I3 VIOLATION: payload hash mismatch %s seg=%d entry=%d", name, k[0], k[1])
+				require.Equal(t, wantHash, msg.Properties["hash"],
+					"I3 VIOLATION: property hash mismatch %s", name)
+				seen[k] = true
+			}
+		}
+		rcancel()
+		require.Equal(t, len(ackedHash), len(seen),
+			"I1 VIOLATION: %d acked entries missing in %s", len(ackedHash)-len(seen), name)
+		_ = r.Close(ctx)
+		t.Logf("VERIFY %s: %d acked entries durable, ordered, hash-matched", name, len(seen))
+	}
+}
+```
+
+- [ ] **Step 2: Verify full build + unit tests**
+
+Run: `cd tests/chaos_mesh/workload && go build ./... && go vet ./... && go test -run 'TestRecorder|TestPayloadHash|TestIsWoodpeckerPermanent' .`
+Expected: build clean; the three unit tests PASS. (The `TestNetworkChaosWorkload` integration test needs a cluster — exercised in Task 12.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/chaos_mesh/workload/main_test.go
+git commit -m "test(chaos-mesh): verify phase + I1/I2/I3 read-back assertions
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Orchestrator — bring-up + Chaos Mesh install + injection smoke-check
+
+**Files:**
+- Create: `tests/chaos_mesh/run_network_chaos.sh`
+
+- [ ] **Step 1: Write the orchestrator top half**
+
+```bash
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Chaos knobs (override lib.sh defaults) — spec Layer 1 + Correction #8.
+export CLUSTER_NAME="wp-chaos"
+export CR_NAME="my-woodpecker"
+export NAMESPACE="default"
+export REPLICAS=3
+export MK_CPUS="${MK_CPUS:-6}" MK_MEMORY="${MK_MEMORY:-8192}" MK_RUNTIME="${MK_RUNTIME:-containerd}"
+export WP_IMG="zilliztech/woodpecker:v0.1.26"
+export CLIENT_POD="wp-client-test"
+
+source "$PROJECT_ROOT/deployments/operator/test/lib.sh"
+
+WORKLOAD_IN_POD=/root/woodpecker/tests/chaos_mesh/workload
+RECORD_FILE=/tmp/wp-chaos-acked.jsonl
+
+bringup() {
+  wp_minikube_start; wp_deploy_operator; wp_build_wp_image
+  wp_deploy_deps; wp_create_cr; wp_wait_healthy
+  wp_launch_client_pod; wp_write_client_config "$REPLICAS"
+}
+
+install_chaos_mesh() {
+  helm repo add chaos-mesh https://charts.chaos-mesh.org 2>/dev/null || true
+  helm repo update
+  helm install chaos-mesh chaos-mesh/chaos-mesh -n chaos-mesh --create-namespace \
+    --set chaosDaemon.runtime=containerd \
+    --set chaosDaemon.socketPath=/run/containerd/containerd.sock \
+    --wait --timeout 5m
+  kubectl -n chaos-mesh rollout status daemonset/chaos-daemon --timeout=180s
+}
+
+# Deliver CURRENT source into the pod (Correction #5 / refinement B), then it's ready for `go test`.
+push_workload() {
+  local tgz=/tmp/wp-src.tgz
+  tar --exclude='./.git' --exclude='./tests/chaos_mesh/artifacts' -czf "$tgz" -C "$PROJECT_ROOT" .
+  kubectl exec "$CLIENT_POD" -- mkdir -p /root/woodpecker
+  kubectl cp "$tgz" "$CLIENT_POD:/tmp/wp-src.tgz"
+  kubectl exec "$CLIENT_POD" -- bash -c "tar -xzf /tmp/wp-src.tgz -C /root/woodpecker"
+  kubectl exec "$CLIENT_POD" -- bash -c "cd $WORKLOAD_IN_POD && go build ./..." \
+    || fail "in-pod go build failed (module/source delivery problem)"
+}
+
+# Spec Layer 2 / Risk #1: prove injection is NOT a silent no-op before trusting any result.
+injection_smoke_check() {
+  local ip; ip=$(kubectl get pod ${CR_NAME}-server-0 -o jsonpath='{.status.podIP}')
+  local probe="S=\$(date +%s%N); (exec 3<>/dev/tcp/$ip/18080) 2>/dev/null; echo \$(( (\$(date +%s%N)-S)/1000000 ))"
+  local before; before=$(kubectl exec "$CLIENT_POD" -- bash -c "$probe")
+  kubectl apply -f "$SCRIPT_DIR/manifests/client-server-delay.yaml"
+  kubectl wait --for=condition=AllInjected networkchaos/client-server-delay -n "$NAMESPACE" --timeout=60s \
+    || { kubectl describe networkchaos client-server-delay -n "$NAMESPACE"; fail "chaos never reached AllInjected"; }
+  local after; after=$(kubectl exec "$CLIENT_POD" -- bash -c "$probe")
+  kubectl delete -f "$SCRIPT_DIR/manifests/client-server-delay.yaml" --ignore-not-found
+  log "smoke-check connect ms: before=$before after=$after"
+  if [ "$after" -lt $(( before + 200 )) ]; then
+    kubectl logs -n chaos-mesh -l app.kubernetes.io/component=chaos-daemon --tail=200 || true
+    fail "INJECTION SMOKE-CHECK FAILED (before=${before}ms after=${after}ms) — likely runtime/socket mismatch; chaos is a silent no-op. Aborting before false-green."
+  fi
+  log "Injection smoke-check PASSED (${before}ms -> ${after}ms)"
+}
+```
+
+- [ ] **Step 2: Verify syntax**
+
+Run: `bash -n tests/chaos_mesh/run_network_chaos.sh`
+Expected: no output.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/chaos_mesh/run_network_chaos.sh
+git commit -m "test(chaos-mesh): orchestrator bring-up + chaos-mesh install + injection smoke-check
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Orchestrator — scenario loop + blips + I6 + artifacts + cleanup
+
+**Files:**
+- Modify: `tests/chaos_mesh/run_network_chaos.sh`
+
+- [ ] **Step 1: Append the run/verify machinery + `main`**
+
+```bash
+run_phase() {  # $1 = phase
+  kubectl exec -i "$CLIENT_POD" -- /bin/bash -c "
+    set -e; cd $WORKLOAD_IN_POD
+    go test -v -count=1 -timeout 16m -run TestNetworkChaosWorkload \
+      -config-file /tmp/test-config.yaml -phase $1 -record-file $RECORD_FILE ."
+}
+
+restart_sum() {  # I6: total server container restarts (host-side; client pod is itself under chaos)
+  kubectl get pod -l app.kubernetes.io/instance=${CR_NAME},app.kubernetes.io/component=server \
+    -o jsonpath='{range .items[*]}{.status.containerStatuses[0].restartCount}{"+"}{end}0' | bc
+}
+
+collect_artifacts() {  # mirror integration-test-chaos.yaml log collection
+  local scen="$1" out="$SCRIPT_DIR/artifacts/$1"; mkdir -p "$out"
+  for i in $(seq 0 $((REPLICAS-1))); do kubectl logs "${CR_NAME}-server-$i" >"$out/server-$i.log" 2>&1 || true; done
+  kubectl get networkchaos -A -o yaml            >"$out/networkchaos.yaml" 2>&1 || true
+  kubectl get events -A --sort-by=.lastTimestamp >"$out/events.txt" 2>&1 || true
+  kubectl get pods -o wide                        >"$out/pods.txt" 2>&1 || true
+  kubectl logs etcd  >"$out/etcd.log"  2>&1 || true
+  kubectl logs minio >"$out/minio.log" 2>&1 || true
+  kubectl cp "$CLIENT_POD:$RECORD_FILE" "$out/acked.jsonl" 2>/dev/null || true
+  echo "restarts: $(restart_sum)" >"$out/restartcounts.txt"
+}
+
+run_steady() {  # $1 = manifest basename
+  local m="$SCRIPT_DIR/manifests/$1.yaml" rc0; rc0=$(restart_sum)
+  run_phase warmup
+  kubectl apply -f "$m"
+  kubectl wait --for=condition=AllInjected "networkchaos/$1" -n "$NAMESPACE" --timeout=60s
+  run_phase under-chaos || { collect_artifacts "$1"; kubectl delete -f "$m" --ignore-not-found; return 1; }
+  kubectl delete -f "$m" --ignore-not-found
+  run_phase recovery || { collect_artifacts "$1"; return 1; }
+  run_phase verify   || { collect_artifacts "$1"; return 1; }
+  [ "$(restart_sum)" -eq "$rc0" ] || { collect_artifacts "$1"; fail "I6 VIOLATION: server restarted during $1"; }
+  log "SCENARIO $1 PASSED"
+}
+
+run_blip() {  # $1 = manifest basename (N3/N5)
+  local m="$SCRIPT_DIR/manifests/$1.yaml" rc0; rc0=$(restart_sum)
+  run_phase warmup
+  ( run_phase under-chaos ) & local wl=$!
+  for _ in $(seq 1 6); do kubectl apply -f "$m"; sleep 5; kubectl delete -f "$m" --ignore-not-found; sleep 5; done
+  wait "$wl" || { collect_artifacts "$1"; return 1; }
+  run_phase recovery && run_phase verify || { collect_artifacts "$1"; return 1; }
+  [ "$(restart_sum)" -eq "$rc0" ] || { collect_artifacts "$1"; fail "I6 VIOLATION: server restarted during $1"; }
+  log "SCENARIO $1 PASSED"
+}
+
+main() {
+  bringup; install_chaos_mesh; injection_smoke_check; push_workload
+  local rc=0
+  for s in server-minio-delay server-minio-loss server-etcd-delay client-server-delay client-server-loss; do
+    run_steady "$s" || rc=1
+  done
+  for s in server-minio-blip server-etcd-blip; do run_blip "$s" || rc=1; done
+  [ "$rc" -eq 0 ] && log "ALL SCENARIOS PASSED" || warn "SOME SCENARIOS FAILED (see artifacts/)"
+  exit $rc
+}
+
+trap 'rc=$?; [ -n "${KEEP:-}" ] || { helm uninstall chaos-mesh -n chaos-mesh 2>/dev/null || true; minikube delete -p "$CLUSTER_NAME" 2>/dev/null || true; }; exit $rc' EXIT
+main "$@"
+```
+> The blip window is `6×(5s+5s)=60s`; pass `-window 60` to the under-chaos `go test` for blips if needed (tune in Task 12). `KEEP=1 ./run_network_chaos.sh` leaves the cluster up for inspection.
+
+- [ ] **Step 2: Verify syntax + commit**
+
+Run: `bash -n tests/chaos_mesh/run_network_chaos.sh`
+Expected: no output.
+
+```bash
+git add tests/chaos_mesh/run_network_chaos.sh
+git commit -m "test(chaos-mesh): scenario loop, blip loops, I6 check, artifacts, cleanup trap
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Nightly-only CI workflow
+
+**Files:**
+- Create: `.github/workflows/nightly-chaos-mesh.yaml`
+- Modify: `.github/workflows/nightly.yaml`
+
+- [ ] **Step 1: Create the reusable workflow (no PR trigger, no ci-passed step)**
+
+```yaml
+name: Chaos Mesh Test
+on:
+  workflow_call:
+  workflow_dispatch:        # manual only; deliberately NO pull_request trigger -> never PR-gating
+concurrency:
+  group: nightly-chaos-mesh-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  Chaos-Mesh-Test:
+    name: Chaos Mesh Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: "1.25", cache: true }
+      - name: Install minikube, helm
+        run: |
+          curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          sudo install minikube /usr/local/bin/
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          kubectl version --client
+      - name: Run network-chaos suite
+        run: ./tests/chaos_mesh/run_network_chaos.sh
+      - name: Upload chaos artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chaos-mesh-artifacts
+          path: tests/chaos_mesh/artifacts/
+          retention-days: 7
+          if-no-files-found: ignore
+```
+
+- [ ] **Step 2: Add a job to `nightly.yaml`**
+
+Append (matching the existing `uses:` job style in that file):
+```yaml
+  chaos-mesh-test:
+    name: Chaos Mesh Test
+    uses: ./.github/workflows/nightly-chaos-mesh.yaml
+    secrets: inherit
+```
+
+- [ ] **Step 3: Verify non-gating + lint**
+
+Run: `grep -R "REQUIRED_CHECKS" .github/workflows/ | grep -i mesh`
+Expected: **no output** (the new check is absent from every gating array).
+
+Run: `grep -rn "pull_request" .github/workflows/nightly-chaos-mesh.yaml`
+Expected: **no output** (no PR trigger).
+
+Run (if available): `actionlint .github/workflows/nightly-chaos-mesh.yaml .github/workflows/nightly.yaml`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/nightly-chaos-mesh.yaml .github/workflows/nightly.yaml
+git commit -m "ci(nightly): add nightly-only Chaos Mesh network-jitter job (#152)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Run on minikube and hunt bugs (acceptance §5)
+
+**Files:** none — live execution + triage.
+
+- [ ] **Step 1: Full run**
+
+Run: `tests/chaos_mesh/run_network_chaos.sh 2>&1 | tee /tmp/chaos-run.log`
+Expected: `Injection smoke-check PASSED`, each scenario reaches `AllInjected`, each `verify` logs `VERIFY ... durable, ordered, hash-matched`, final `ALL SCENARIOS PASSED`.
+
+- [ ] **Step 2: Confirm the gate actually fired**
+
+Run: `grep -E "Injection smoke-check PASSED|AllInjected|VERIFY .* durable|I[0-9] VIOLATION" /tmp/chaos-run.log`
+Expected: a smoke-check PASS line, 7 `AllInjected`, ≥1 `VERIFY` per scenario, and ideally zero `VIOLATION`.
+
+- [ ] **Step 3: Validate I2 assumption without chaos (Risk #4)**
+
+Before trusting I2, run `warmup` then `verify` with **no** chaos (`KEEP=1`, then exec the two phases manually). If I2 fails even without chaos, the global `(seg,entry)` read order isn't monotonic under this config — drop `-logs` interaction or keep the single-writer-per-log design (already chosen) and, if still failing, weaken I2 to per-`Seq` subsequence. Document the outcome in the README.
+
+- [ ] **Step 4: Triage any failure → acceptable vs bug**
+
+```
+I1/I2/I3 fail -> durability/ordering/corruption BUG (file issue w/ acked.jsonl + offending (seg,entry))
+I4 fail       -> hang/deadlock BUG (capture goroutine dump: kubectl exec wp-client-test -- kill -QUIT <pid>)
+I5 fail       -> transient fault became permanent WP error BUG (error string in server-*.log)
+I6 fail       -> crash/OOM BUG (server-*.log tail + kubectl describe pod)
+I7 fail       -> retry storm / no progress BUG (ok==0 with high retryableErr)
+elevated retryableErr/latency but ok>0 and verify PASS -> ACCEPTABLE degradation (the expected result)
+```
+
+- [ ] **Step 5: Gauge flakiness, then record outcome**
+
+Re-run once. Then append a short "Run results" section to `tests/chaos_mesh/README.md` (date, pass/fail per scenario, any bug candidates) and commit.
+
+```bash
+git add tests/chaos_mesh/README.md
+git commit -m "test(chaos-mesh): record first network-jitter run results (#152)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Remaining unknowns / risks (carry into execution)
+
+1. **GitHub `ubuntu-latest` resourcing.** `--cpus=6 --memory=8192` + chaos-daemon + 3 servers + etcd/minio + workload may OOM the runner. Fallback: `--cpus=4 --memory=8192`, or trim nightly to N1/N4/N6 with the full set weekly. The smoke-check still surfaces silent no-ops early.
+2. **`werr` permanent-error method name.** Task 5 asserts `interface{ IsRetryable() bool }`; verify against `go doc .../common/werr` and adjust if the method differs.
+3. **Client API signature drift.** Tasks 6–8 use researched signatures (`WriteAsync`, `ReadNext`, `OpenLogReader(ctx,*LogMessageId,name)`, `OpenLogWriter(ctx)`); confirm with `go build` and fix imports/args if needed.
+4. **I2 across segments under load** — see Task 12 Step 3. Single-writer-per-log (chosen) is the safe design; fall back to per-`Seq` subsequence if needed.
+5. **30s per-op bound vs internal budgets** (append callback ~30s, retry budget ~21.8s). May clip an op that would have succeeded; raise after observing p99 in Task 12.
+6. **Single-pod etcd/minio** means N3/N5 blips are full dependency outages, not multi-AZ jitter — larger blast radius than prod (spec non-goal). Interpret accordingly.
+7. **`make docker` target / image path drift** — keep the `|| docker build -f build/docker/ubuntu22.04/Dockerfile` fallback already in `wp_build_wp_image`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Layer-1 bring-up → Task 1; Chaos Mesh install + smoke-check → Task 9; scenario matrix N1–N7 → Task 3; three phases + I1–I7 → Tasks 7–8 (+I6 host-side Task 10); deliverables/layout → Tasks 2–11; nightly-only wiring → Task 11; run-and-hunt → Task 12. All spec sections map to a task.
+- **Placeholders:** the `:;` bodies in `lib.sh` are explicit "paste exact block from smoke-test.sh lines X-Y" instructions, not vague TODOs. No "add error handling" / "TBD" remain.
+- **Type consistency:** `AckRecord`, `recorder`, `openRecorder/append/close/loadRecords`, `payloadHash`, `isWoodpeckerPermanent`, `runLoadPhase`, `runVerifyPhase`, `metrics` are defined once and referenced consistently across Tasks 4–8.

--- a/docs/superpowers/specs/2026-06-04-chaos-mesh-network-jitter-design.md
+++ b/docs/superpowers/specs/2026-06-04-chaos-mesh-network-jitter-design.md
@@ -1,0 +1,294 @@
+# Chaos Mesh — Network-Jitter Fault Injection (Nightly)
+
+- **Issue:** [zilliztech/woodpecker#152](https://github.com/zilliztech/woodpecker/issues/152)
+- **Date:** 2026-06-04
+- **Status:** Approved design, ready for implementation plan
+
+## Problem
+
+Woodpecker leans heavily on object storage (S3/MinIO) and on network stability for
+WAL write/read, segment completion, quorum replication, and metadata (etcd). In
+multi-AZ production, transient network degradation — latency spikes, jitter, packet
+loss, brief disconnects — routinely causes elevated write latency, amplified retries,
+LAC-progression delays, and temporary read unavailability.
+
+The existing chaos suite (`tests/docker/chaos/`) only exercises **hard** failures:
+node `kill`/`stop`/`restart`, full Docker-network **partition** (disconnect/connect),
+and MinIO/etcd **stop**. There is **no soft network degradation** anywhere in the
+repo — confirmed: no `tc`/netem, no toxiproxy, no latency/jitter/loss injection. The
+chaos matrix (`tests/docker/chaos/chaos_matrix.md`) lists "MinIO slow / high latency"
+(S4), "slow disk I/O" (D5), and "MinIO slow + server crash" (X5) as **P2 and
+unimplemented**.
+
+This is exactly the gap issue #152 targets. We want a test that injects **network
+jitter** across the key links and verifies the system behaves as expected under it:
+**occasional internal errors are acceptable as long as retries recover** — but data
+loss, permanent hangs, corruption, crashes, or retry storms are serious bugs.
+
+## Goals
+
+- Inject realistic **soft** network faults (latency + jitter, packet loss, transient
+  partition blips) on Woodpecker's key links using **Chaos Mesh `NetworkChaos`** on a
+  Kubernetes cluster.
+- Drive a **sustained concurrent read/write workload** during injection and assert a
+  fixed set of **invariants** (durability, ordering, CRC, liveness, bounded retry).
+- Distinguish **acceptable degradation** ("eventual success after retry") from
+  **serious bugs** (lost acked writes, permanent hang, corruption, crash, retry storm).
+- **Reuse the existing minikube operator bring-up** (`deployments/operator/test/smoke-test.sh`
+  steps 1–6) so the new work is "add chaos + add a chaos-aware verifier," not "build a
+  whole k8s e2e from scratch."
+- Run **nightly only** (hook into `nightly.yaml`), never as a PR-gating check.
+- Build the Woodpecker image **from current source**, so the test exercises the code
+  under review — not a released image.
+
+## Non-Goals
+
+- **Not a PR-CI check.** Chaos Mesh + minikube + sustained injection takes
+  ~25–40 min/run and is inherently non-deterministic; gating PRs on it would be
+  painful. Nightly cadence only.
+- **No Toxiproxy / `tc` path.** Issue #152 lists Toxiproxy (Docker) as an alternative;
+  we deliberately choose Chaos Mesh on k8s and do not build the Docker/Toxiproxy
+  variant in this work.
+- **No `server↔server` quorum/gossip link in v1.** Scoped to three links (below).
+  Quorum-replication jitter is a fast-follow, explicitly deferred.
+- **No physical multi-AZ topology.** Single-node minikube; `NetworkChaos` shapes per
+  pod network namespace, so injection correctness is unaffected, but AZ separation is
+  only logical, not physical.
+- **No new fault types beyond delay+jitter / loss / blip in v1.** `corrupt`, `reorder`,
+  `duplicate`, bandwidth throttle, asymmetric partition are deferred to the
+  "full-link + full-fault" follow-up.
+- **No change to production code** is *planned*. If the verifier surfaces a real bug,
+  fixing it is separate follow-up work, not part of this test harness.
+
+## Key Decisions (locked in)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Injection tool | **Chaos Mesh** (`NetworkChaos` CRD) | Purpose-built for delay+jitter+loss; closest to multi-AZ prod; user's explicit ask. |
+| Cluster | **minikube**, `--container-runtime=containerd` | The repo's only k8s deploy path (`smoke-test.sh`) is already minikube; we reuse steps 1–6. containerd is the most reliably-supported runtime for the Chaos Mesh `chaos-daemon`. |
+| Cadence | **Nightly only**, not PR CI | Slow + non-deterministic; hook into `nightly.yaml`. |
+| Scope (links) | **server↔MinIO, server↔etcd, client↔server** | Covers the object-storage focus of #152 plus the metadata and RPC paths; quorum link deferred. |
+| Scope (faults) | **delay+jitter, loss, partition blip** | The "jitter" surface #152 describes. |
+| Orchestration | **Host-driven phases + in-pod Go verifier** (Approach ①) | Reuse proven bring-up; keep the hard invariant-checking logic in Go; chaos stays declarative YAML; no in-pod RBAC / client-go dependency. |
+
+## Architecture
+
+### Layer 1 — Cluster bring-up (reuse)
+
+Reuse the bring-up from `deployments/operator/test/smoke-test.sh` (steps 1–6):
+
+1. `minikube start` (bumped to **8 GiB / 6 CPU**, `--container-runtime=containerd`).
+2. Build + deploy the operator (`make docker-build` / `make deploy`, image loaded via
+   `minikube image load`).
+3. Build the **Woodpecker server image from current source** and load it.
+4. Deploy `etcd` and `minio` pods/services.
+5. Create the `WoodpeckerCluster` CR (3 replicas) → operator creates the server
+   StatefulSet; gossip cluster forms.
+6. Verify all nodes healthy + gossip converged (admin API `/admin/node/status`).
+
+To avoid duplicating this logic, the reusable steps are refactored into a sourceable
+shared library (e.g. `deployments/operator/test/lib.sh`) parameterized by
+`CLUSTER_NAME` / `CR_NAME` / `REPLICAS`; both `smoke-test.sh` and the new chaos
+orchestrator source it. (Refactor-vs-invoke is a plan-time detail; the shared-lib
+refactor is preferred and stays narrowly scoped to the bring-up steps.)
+
+Known identifiers (from `smoke-test.sh`), used by the chaos selectors:
+
+| Component | Pod label | Service / port |
+|---|---|---|
+| Woodpecker servers | `app.kubernetes.io/instance: my-woodpecker` | `my-woodpecker-server-headless`, gRPC `18080`, admin/healthz `9091` |
+| etcd | `app: etcd` | `etcd:2379` |
+| MinIO | `app: minio` | `minio:9000` |
+| Client/workload | `wp-client-test` (pod name) | in-cluster, uses `*.svc` DNS seeds |
+
+### Layer 2 — Chaos Mesh install
+
+After bring-up, install Chaos Mesh via Helm into its own namespace, with the
+`chaos-daemon` pointed at the containerd socket:
+
+```
+helm install chaos-mesh chaos-mesh/chaos-mesh \
+  -n chaos-mesh --create-namespace \
+  --set chaosDaemon.runtime=containerd \
+  --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+```
+
+**Injection smoke-check before the full run:** apply one minimal `NetworkChaos`
+(e.g. delay on `client↔server`) and confirm from inside the client pod that observed
+latency actually rises, then remove it. This proves the daemon/runtime wiring works
+*before* we trust any pass/fail result. If injection is silently a no-op, every test
+"passes" — this guard prevents that false-green.
+
+### Layer 3 — Orchestration model (host-driven phases)
+
+The orchestrator (`run_network_chaos.sh`) owns the **timeline**; the in-pod Go
+program owns the **integrity logic**. For each scenario:
+
+```
+warmup (no chaos) → inject NetworkChaos → under-chaos window → remove chaos → recovery → verify
+```
+
+- The Go workload runs **inside** `wp-client-test` (it needs in-cluster `*.svc` DNS
+  for the quorum seeds), driven by `kubectl exec`.
+- Chaos is applied/removed from the **host** with `kubectl apply -f manifests/<scenario>.yaml`
+  / `kubectl delete`. No client-go, no in-pod RBAC.
+- The workload **persists every acked `(logId, entryId, payloadHash)`** to a file in
+  the pod so the `recovery`/`verify` phase can read it back even across separate
+  `go test` invocations.
+
+## Fault-injection scenario matrix (v1)
+
+Three links × fault types ≈ 7 scenarios. Each is one `NetworkChaos` manifest selected
+by pod label + `direction`/`target`.
+
+| # | Link | Fault | Key params | Stresses |
+|---|---|---|---|---|
+| N1 | server→MinIO | delay+jitter | `latency=300ms jitter=100ms correlation=50` | compaction/flush upload, read-from-object |
+| N2 | server→MinIO | loss | `loss=10% correlation=25` | upload retry, partial-progress handling |
+| N3 | server→MinIO | partition blip | `partition`, `duration=5s`, repeated | transient outage → compaction retry |
+| N4 | server→etcd | delay+jitter | `latency=300ms jitter=100ms` | segment completion, session lease, CAS retry |
+| N5 | server→etcd | partition blip | `partition`, `duration=5s` | metadata update retry, lease survival |
+| N6 | client→server | delay+jitter | `latency=300ms jitter=100ms` | append/read RPC retry |
+| N7 | client→server | loss | `loss=10%` | RPC retry, no spurious permanent error |
+
+Representative manifest (N1, server→MinIO delay+jitter):
+
+```yaml
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: server-minio-delay
+  namespace: default
+spec:
+  action: delay
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors:
+      app.kubernetes.io/instance: my-woodpecker   # server pods
+  direction: to
+  target:
+    mode: all
+    selector:
+      namespaces: [default]
+      labelSelectors:
+        app: minio
+  delay:
+    latency: "300ms"
+    jitter: "100ms"
+    correlation: "50"
+  # duration omitted → orchestrator controls lifetime via kubectl delete
+```
+
+`NetworkChaos` shapes traffic between the selected pods on the chosen `direction`; it
+is link-scoped (server↔minio), not port-scoped, which is sufficient because each
+target pod hosts exactly one relevant service.
+
+## Workload + Verifier (the core)
+
+A new Go program/test in `tests/chaos_mesh/workload/` drives the workload and runs the
+assertions (reusing `tests/e2e_operator`'s config-loading / client-creation helpers
+where useful). It is **chaos-aware via phases** but does not itself toggle chaos.
+
+### Phases
+
+1. **warmup** (no injection): N concurrent writers across M logs append continuously;
+   tail readers read concurrently. Record every acked `(logId, entryId, payloadHash)`.
+   Establish a healthy baseline (throughput, p50/p99 latency, error rate ≈ 0).
+2. **under-chaos** (injection active): keep writing/reading. Assert **every operation
+   eventually succeeds within a bounded retry/timeout budget**; no operation returns a
+   **non-retryable permanent error** for a purely transient network fault; no operation
+   hangs past the liveness bound. Elevated latency / raised retry counts / brief read
+   stalls are expected and recorded, not failed.
+3. **recovery** (injection removed): assert throughput/latency return toward baseline,
+   then **full read-back** of all acked entries from phases 1+2 and verify
+   durability / ordering / hash.
+
+### Invariants (asserted; any violation = serious bug)
+
+| # | Invariant | Check |
+|---|---|---|
+| I1 | Durability | every acked `(logId, entryId)` is readable post-test with matching `payloadHash` — **zero loss** |
+| I2 | Ordering | within a log, returned entryIds strictly increasing; read-back order matches write order |
+| I3 | CRC / integrity | app-level `payloadHash` matches on read-back (on top of Woodpecker's internal CRC) |
+| I4 | Liveness / no hang | every op completes (success or definitive error) within a bounded wall-clock; no permanent hang/deadlock |
+| I5 | No spurious permanent error | a transient network fault never surfaces as a non-retryable error to the client |
+| I6 | No crash | no server pod panic / OOM / crashloop — `restartCount` stays flat through the run |
+| I7 | Bounded retry / forward progress | injection-window throughput stays `> 0`; retries do not amplify into a storm |
+
+### "Acceptable" vs "serious bug" (maps to the user's expectation)
+
+- **Acceptable** ("偶发内部错误但重试能正常跑通"): raised error/retry rate, higher
+  latency, brief read unavailability — **as long as operations eventually succeed and
+  all invariants hold** (this is exactly phase-2's success condition).
+- **Serious bug**: any I1–I7 violation. The harness fails the scenario and dumps the
+  scene.
+
+### Failure artifacts
+
+On any violation, collect (mirroring the existing chaos CI's log-collection step):
+server logs (all replicas), `kubectl get networkchaos -o yaml` + chaos events, pod
+`restartCount`s, etcd/minio pod state, and the failing operation's record. Upload as a
+nightly artifact.
+
+## Deliverables & file layout
+
+```
+tests/chaos_mesh/
+├── README.md                       # how to run locally + scenario descriptions
+├── run_network_chaos.sh            # orchestrator: source bring-up lib + install chaos-mesh
+│                                   #   + injection smoke-check + scenario loop + artifact collection
+├── manifests/                      # one NetworkChaos per scenario (N1–N7)
+│   ├── server-minio-delay.yaml
+│   ├── server-minio-loss.yaml
+│   ├── server-minio-blip.yaml
+│   ├── server-etcd-delay.yaml
+│   ├── server-etcd-blip.yaml
+│   ├── client-server-delay.yaml
+│   └── client-server-loss.yaml
+└── workload/                       # Go workload + phase-based verifier (invariants I1–I7)
+
+deployments/operator/test/lib.sh    # (refactor) shared bring-up steps, sourced by
+                                    #   both smoke-test.sh and run_network_chaos.sh
+
+.github/workflows/nightly-chaos-mesh.yaml   # nightly-only job (or a new job in nightly.yaml)
+```
+
+## Nightly CI integration
+
+- A nightly job (new `nightly-chaos-mesh.yaml`, or a job added to `nightly.yaml`) on
+  `ubuntu-latest` that: sets up minikube (containerd) → runs `run_network_chaos.sh` →
+  uploads artifacts on failure.
+- **Not** added to the PR `REQUIRED_CHECKS` list; no `ci-passed` gating.
+- Generous `timeout-minutes` (e.g. 60) to absorb image build + 7 scenarios.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Chaos Mesh × minikube runtime/socket mismatch → injection silently no-ops | Use `--container-runtime=containerd` + matching `chaosDaemon.socketPath`; **injection smoke-check** (Layer 2) fails fast if injection isn't real. |
+| Single-node minikube ≠ physical multi-AZ | Accepted; `NetworkChaos` is per-pod-netns so injection is still correct. Documented as a non-goal. |
+| Runtime too long for nightly | ~25–40 min budget; scenarios are independent and can be trimmed/parallelized later; image build is the slow part and is cached. |
+| Resource pressure (workload + chaos-daemon + 3 servers + etcd/minio) | minikube bumped to 8 GiB / 6 CPU. |
+| Flakiness misread as a bug | Thresholds (latency/loss/timeout budgets) are explicit and tunable; phase-2 only fails on *invariant* violations, not on elevated-but-recovering metrics. |
+
+## Acceptance criteria
+
+1. `run_network_chaos.sh` brings up the cluster, installs Chaos Mesh, passes the
+   injection smoke-check, and runs scenarios N1–N7 end to end on a clean machine.
+2. Under each scenario, the verifier asserts invariants I1–I7 and reports per-scenario
+   pass/fail with metrics (error rate, retry counts, p50/p99 latency, throughput).
+3. On failure, scene artifacts are collected.
+4. A nightly workflow runs the suite and is **not** a PR-gating check.
+5. The harness has actually been **run locally** at least once and either confirms
+   "only transient errors, retries recover, all invariants hold" or surfaces concrete
+   bug candidates with reproductions.
+
+## Out of scope / future work
+
+- `server↔server` quorum-replication and gossip jitter.
+- Additional fault types: `corrupt`, `reorder`, `duplicate`, bandwidth throttle,
+  asymmetric/partial partition.
+- Chaos Mesh `Workflow`/`Schedule` CRDs for declarative multi-fault timelines.
+- A Toxiproxy/Docker variant for fast local/PR-CI smoke (the #152 alternative).
+- Physical multi-node minikube/kind for true topology separation.

--- a/tests/chaos_mesh/README.md
+++ b/tests/chaos_mesh/README.md
@@ -1,0 +1,108 @@
+# Chaos Mesh — Network-Jitter Fault Injection (Nightly)
+
+This suite injects **soft network faults** (latency+jitter, packet loss, transient partition blips) on Woodpecker's three key links — server↔MinIO, server↔etcd, and client↔server — using **Chaos Mesh `NetworkChaos`** on a minikube cluster. A phase-based Go workload runs concurrent reads and writes throughout each scenario while a verifier asserts a fixed set of invariants: acked writes are never lost, ordering is preserved, CRC matches on read-back, no server crashes, and retry counts stay bounded. Elevated latency and transient errors that recover are acceptable; any invariant violation (I1–I7) is a serious bug.
+
+**Nightly only — never a PR-gating check.**
+
+## Prerequisites
+
+- [minikube](https://minikube.sigs.k8s.io/) (with `--container-runtime=containerd` support)
+- docker
+- kubectl
+- helm
+- go 1.24+
+
+## How to Run
+
+```bash
+./tests/chaos_mesh/run_network_chaos.sh
+```
+
+Pass `KEEP=1` to leave the cluster running after the run for manual inspection:
+
+```bash
+KEEP=1 ./tests/chaos_mesh/run_network_chaos.sh
+```
+
+The orchestrator sources the shared cluster bring-up library at
+`deployments/operator/test/lib.sh` (minikube start, operator deploy, Woodpecker CR
+creation, gossip convergence check — reusing the same steps as `smoke-test.sh`), then
+installs Chaos Mesh via Helm:
+
+```bash
+helm install chaos-mesh chaos-mesh/chaos-mesh \
+  -n chaos-mesh --create-namespace \
+  --set chaosDaemon.runtime=containerd \
+  --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+```
+
+An injection smoke-check (a brief delay applied to the client→server link, latency
+measured from inside the pod, then removed) runs before the scenario loop to confirm
+`chaos-daemon` is actually shaping traffic — a silent no-op would otherwise make every
+test appear to pass.
+
+## Scenario Matrix (N1–N7)
+
+| # | Link | Fault | Key params | Stresses |
+|---|---|---|---|---|
+| N1 | server→MinIO | delay+jitter | `latency=300ms jitter=100ms correlation=50` | compaction/flush upload, read-from-object |
+| N2 | server→MinIO | loss | `loss=10% correlation=25` | upload retry, partial-progress handling |
+| N3 | server→MinIO | partition blip | `partition`, `duration=5s`, repeated | transient outage → compaction retry |
+| N4 | server→etcd | delay+jitter | `latency=300ms jitter=100ms` | segment completion, session lease, CAS retry |
+| N5 | server→etcd | partition blip | `partition`, `duration=5s` | metadata update retry, lease survival |
+| N6 | client→server | delay+jitter | `latency=300ms jitter=100ms` | append/read RPC retry |
+| N7 | client→server | loss | `loss=10%` | RPC retry, no spurious permanent error |
+
+Each scenario follows the phases: **warmup** (no chaos) → **inject** → **under-chaos window** → **remove chaos** → **recovery** → **verify**.
+
+## Invariants (I1–I7)
+
+Any violation is a serious bug; the harness fails the scenario and collects artifacts.
+
+| # | Invariant | Check |
+|---|---|---|
+| I1 | Durability | every acked `(logId, entryId)` is readable post-test with matching `payloadHash` — zero loss |
+| I2 | Ordering | within a log, returned entryIds strictly increasing; read-back order matches write order |
+| I3 | CRC / integrity | app-level `payloadHash` matches on read-back (on top of Woodpecker's internal CRC) |
+| I4 | Liveness / no hang | every op completes (success or definitive error) within a bounded wall-clock; no permanent hang/deadlock |
+| I5 | No spurious permanent error | a transient network fault never surfaces as a non-retryable error to the client |
+| I6 | No crash | no server pod panic / OOM / crashloop — `restartCount` stays flat through the run |
+| I7 | Bounded retry / forward progress | injection-window throughput stays > 0; retries do not amplify into a storm |
+
+Elevated latency, raised retry counts, and brief read stalls during the under-chaos
+window are **acceptable** — operations are expected to eventually succeed. Only I1–I7
+violations trigger a failure.
+
+## Layout
+
+```
+tests/chaos_mesh/
+├── README.md                 # this file
+├── run_network_chaos.sh      # orchestrator: source lib.sh, install Chaos Mesh,
+│                             #   smoke-check, run N1–N7, collect artifacts
+├── manifests/                # one NetworkChaos CR per scenario (N1–N7)
+│   ├── server-minio-delay.yaml
+│   ├── server-minio-loss.yaml
+│   ├── server-minio-blip.yaml
+│   ├── server-etcd-delay.yaml
+│   ├── server-etcd-blip.yaml
+│   ├── client-server-delay.yaml
+│   └── client-server-loss.yaml
+└── workload/                 # phase-based Go workload + verifier (invariants I1–I7)
+                              #   part of the root github.com/zilliztech/woodpecker
+                              #   module — no separate go.mod
+```
+
+`manifests/` and `workload/` are currently empty (`.gitkeep` placeholders); they will
+be populated by subsequent tasks.
+
+The workload binary runs **inside** the `wp-client-test` pod (it needs in-cluster DNS
+for the quorum seeds); chaos is applied and removed from the **host** via
+`kubectl apply/delete` — no client-go dependency, no in-pod RBAC.
+
+## Further Reading
+
+Detailed design and implementation plan live in:
+
+- `docs/superpowers/specs/2026-06-04-chaos-mesh-network-jitter-design.md`
+- `docs/superpowers/plans/` (implementation plan)

--- a/tests/chaos_mesh/README.md
+++ b/tests/chaos_mesh/README.md
@@ -6,7 +6,7 @@ This suite injects **soft network faults** (latency+jitter, packet loss, transie
 
 ## Prerequisites
 
-- [minikube](https://minikube.sigs.k8s.io/) (with `--container-runtime=containerd` support)
+- [minikube](https://minikube.sigs.k8s.io/) (docker driver; uses the docker runtime by default)
 - docker
 - kubectl
 - helm
@@ -30,11 +30,16 @@ creation, gossip convergence check — reusing the same steps as `smoke-test.sh`
 installs Chaos Mesh via Helm:
 
 ```bash
+# chaosDaemon.runtime/socketPath follow the minikube runtime (docker by default):
 helm install chaos-mesh chaos-mesh/chaos-mesh \
   -n chaos-mesh --create-namespace \
-  --set chaosDaemon.runtime=containerd \
-  --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+  --set chaosDaemon.runtime=docker \
+  --set chaosDaemon.socketPath=/var/run/docker.sock
 ```
+
+> The suite defaults to minikube's **docker** runtime. `--container-runtime=containerd`
+> makes minikube deploy a kindnet CNI whose image often can't be pulled on constrained
+> hosts (no pod networking); set `MK_RUNTIME=containerd` only where that image is reachable.
 
 An injection smoke-check (a brief delay applied to the client→server link, latency
 measured from inside the pod, then removed) runs before the scenario loop to confirm

--- a/tests/chaos_mesh/README.md
+++ b/tests/chaos_mesh/README.md
@@ -105,6 +105,46 @@ The workload binary runs **inside** the `wp-client-test` pod (it needs in-cluste
 for the quorum seeds); chaos is applied and removed from the **host** via
 `kubectl apply/delete` — no client-go dependency, no in-pod RBAC.
 
+## Run results — 2026-06-05 (local minikube, docker runtime, 3-node, ~6 GiB)
+
+### Realistic jitter — all 7 scenarios PASSED (exit 0)
+
+| Scenario | Fault | under-chaos `ok / retryable / permanent` | Verdict |
+|---|---|---|---|
+| server→MinIO delay | 300ms±100ms | 12464 / 0 / 0 | PASS — async upload path, no client impact |
+| server→MinIO loss | 10% | 4658 / 0 / 0 | PASS |
+| server→etcd delay | 300ms±100ms | 6412 / 0 / 0 | PASS — metadata async |
+| client→server delay | 300ms±100ms | 298 / 0 / 0 | PASS — ~20–40× slower, zero errors |
+| client→server loss | 10% | 6185 / 0 / 0 | PASS — TCP recovers |
+| server→MinIO blip | 5s partitions | 6683 / 0 / 0 | PASS — local-buffer ack |
+| server→etcd blip | 5s partitions | 6387 / 0 / 0 | PASS |
+
+Every scenario: zero client-visible errors, zero data loss, all acked entries durable/ordered/hash-matched,
+no server restarts. Under moderate jitter Woodpecker degrades only in latency/throughput (worst: the
+synchronous client↔server delay), because writes ack from the local staged buffer and MinIO/etcd work is async.
+
+### Stress (manual, ad-hoc NetworkChaos on the client→server link)
+
+| Fault | warmup ok | under-chaos `ok / retryable / permanent` | recovery ok | verify |
+|---|---|---|---|---|
+| delay 20s±14s (≈ total outage; per-packet × RPC round-trips ≫ 30s op timeout) | 6049 | 0 (I7 stall) | 1857 | all durable |
+| **loss 60%** | 3694 | **28 / 8 / 0** | 5678 | all durable |
+
+- **60% loss is the textbook target**: occasional transient errors (`retryable=8`) with continued progress
+  (`ok=28`), **zero permanent errors**, then full recovery (`ok=5678`) and **zero data loss** — i.e.
+  "occasional internal errors, retries recover."
+- **20s±14s delay** is effectively a total outage (per-packet delay compounds across RPC round-trips, far
+  exceeding the 30s op timeout) → zero progress *during* the fault, but **fail-safe** (no loss/corruption/hang)
+  and **full recovery** once cleared. The workload's I7 ("ok>0 during chaos") flags this — a **test-design
+  nuance**, not a Woodpecker bug: a sustained near-total outage legitimately makes zero progress. (Possible
+  refinement: have I7 distinguish "no progress that later recovers" from "no progress that never recovers".)
+
+### Conclusion (issue #152)
+
+No serious bugs. Under network jitter Woodpecker degrades gracefully (latency/throughput) with zero data loss;
+under harsh faults it fails safe and fully recovers, surfacing only transient/retryable errors (never spurious
+permanent ones). Acknowledged writes are never lost; ordering and CRC always hold.
+
 ## Further Reading
 
 Detailed design and implementation plan live in:

--- a/tests/chaos_mesh/manifests/client-server-delay.yaml
+++ b/tests/chaos_mesh/manifests/client-server-delay.yaml
@@ -1,0 +1,16 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata: { name: client-server-delay, namespace: default }
+spec:
+  action: delay
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors: { role: wp-client }
+  direction: to
+  target:
+    mode: all
+    selector:
+      namespaces: [default]
+      labelSelectors: { app.kubernetes.io/instance: my-woodpecker, app.kubernetes.io/component: server }
+  delay: { latency: "300ms", jitter: "100ms", correlation: "50" }

--- a/tests/chaos_mesh/manifests/client-server-loss.yaml
+++ b/tests/chaos_mesh/manifests/client-server-loss.yaml
@@ -1,0 +1,16 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata: { name: client-server-loss, namespace: default }
+spec:
+  action: loss
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors: { role: wp-client }
+  direction: to
+  target:
+    mode: all
+    selector:
+      namespaces: [default]
+      labelSelectors: { app.kubernetes.io/instance: my-woodpecker, app.kubernetes.io/component: server }
+  loss: { loss: "10", correlation: "25" }

--- a/tests/chaos_mesh/manifests/server-etcd-blip.yaml
+++ b/tests/chaos_mesh/manifests/server-etcd-blip.yaml
@@ -1,0 +1,13 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata: { name: server-etcd-blip, namespace: default }
+spec:
+  action: partition
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors: { app.kubernetes.io/instance: my-woodpecker, app.kubernetes.io/component: server }
+  direction: both
+  target:
+    mode: all
+    selector: { namespaces: [default], labelSelectors: { app: etcd } }

--- a/tests/chaos_mesh/manifests/server-etcd-delay.yaml
+++ b/tests/chaos_mesh/manifests/server-etcd-delay.yaml
@@ -1,0 +1,14 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata: { name: server-etcd-delay, namespace: default }
+spec:
+  action: delay
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors: { app.kubernetes.io/instance: my-woodpecker, app.kubernetes.io/component: server }
+  direction: to
+  target:
+    mode: all
+    selector: { namespaces: [default], labelSelectors: { app: etcd } }
+  delay: { latency: "300ms", jitter: "100ms", correlation: "50" }

--- a/tests/chaos_mesh/manifests/server-minio-blip.yaml
+++ b/tests/chaos_mesh/manifests/server-minio-blip.yaml
@@ -1,0 +1,13 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata: { name: server-minio-blip, namespace: default }
+spec:
+  action: partition
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors: { app.kubernetes.io/instance: my-woodpecker, app.kubernetes.io/component: server }
+  direction: both
+  target:
+    mode: all
+    selector: { namespaces: [default], labelSelectors: { app: minio } }

--- a/tests/chaos_mesh/manifests/server-minio-delay.yaml
+++ b/tests/chaos_mesh/manifests/server-minio-delay.yaml
@@ -1,0 +1,14 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata: { name: server-minio-delay, namespace: default }
+spec:
+  action: delay
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors: { app.kubernetes.io/instance: my-woodpecker, app.kubernetes.io/component: server }
+  direction: to
+  target:
+    mode: all
+    selector: { namespaces: [default], labelSelectors: { app: minio } }
+  delay: { latency: "300ms", jitter: "100ms", correlation: "50" }

--- a/tests/chaos_mesh/manifests/server-minio-loss.yaml
+++ b/tests/chaos_mesh/manifests/server-minio-loss.yaml
@@ -1,0 +1,14 @@
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+metadata: { name: server-minio-loss, namespace: default }
+spec:
+  action: loss
+  mode: all
+  selector:
+    namespaces: [default]
+    labelSelectors: { app.kubernetes.io/instance: my-woodpecker, app.kubernetes.io/component: server }
+  direction: to
+  target:
+    mode: all
+    selector: { namespaces: [default], labelSelectors: { app: minio } }
+  loss: { loss: "10", correlation: "25" }

--- a/tests/chaos_mesh/run_network_chaos.sh
+++ b/tests/chaos_mesh/run_network_chaos.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Chaos knobs (override lib.sh defaults) — spec Layer 1 + Correction #8.
+export CLUSTER_NAME="wp-chaos"
+export CR_NAME="my-woodpecker"
+export NAMESPACE="default"
+export REPLICAS=3
+export MK_CPUS="${MK_CPUS:-6}" MK_MEMORY="${MK_MEMORY:-8192}" MK_RUNTIME="${MK_RUNTIME:-containerd}"
+export WP_IMG="zilliztech/woodpecker:v0.1.26"
+export CLIENT_POD="wp-client-test"
+
+source "$PROJECT_ROOT/deployments/operator/test/lib.sh"
+
+WORKLOAD_IN_POD=/root/woodpecker/tests/chaos_mesh/workload
+RECORD_FILE=/tmp/wp-chaos-acked.jsonl
+
+bringup() {
+  wp_minikube_start; wp_deploy_operator; wp_build_wp_image
+  wp_deploy_deps; wp_create_cr; wp_wait_healthy
+  wp_launch_client_pod; wp_write_client_config "$REPLICAS"
+}
+
+install_chaos_mesh() {
+  helm repo add chaos-mesh https://charts.chaos-mesh.org 2>/dev/null || true
+  helm repo update
+  helm install chaos-mesh chaos-mesh/chaos-mesh -n chaos-mesh --create-namespace \
+    --set chaosDaemon.runtime=containerd \
+    --set chaosDaemon.socketPath=/run/containerd/containerd.sock \
+    --wait --timeout 5m
+  kubectl -n chaos-mesh rollout status daemonset/chaos-daemon --timeout=180s
+}
+
+# Deliver CURRENT source into the pod (Correction #5 / refinement B), then it's ready for `go test`.
+push_workload() {
+  local tgz=/tmp/wp-src.tgz
+  tar --exclude='./.git' --exclude='./tests/chaos_mesh/artifacts' -czf "$tgz" -C "$PROJECT_ROOT" .
+  kubectl exec "$CLIENT_POD" -- mkdir -p /root/woodpecker
+  kubectl cp "$tgz" "$CLIENT_POD:/tmp/wp-src.tgz"
+  kubectl exec "$CLIENT_POD" -- bash -c "tar -xzf /tmp/wp-src.tgz -C /root/woodpecker"
+  kubectl exec "$CLIENT_POD" -- bash -c "cd $WORKLOAD_IN_POD && go build ./..." \
+    || fail "in-pod go build failed (module/source delivery problem)"
+}
+
+# Spec Layer 2 / Risk #1: prove injection is NOT a silent no-op before trusting any result.
+injection_smoke_check() {
+  local ip; ip=$(kubectl get pod ${CR_NAME}-server-0 -o jsonpath='{.status.podIP}')
+  local probe="S=\$(date +%s%N); (exec 3<>/dev/tcp/$ip/18080) 2>/dev/null; echo \$(( (\$(date +%s%N)-S)/1000000 ))"
+  local before; before=$(kubectl exec "$CLIENT_POD" -- bash -c "$probe")
+  kubectl apply -f "$SCRIPT_DIR/manifests/client-server-delay.yaml"
+  kubectl wait --for=condition=AllInjected networkchaos/client-server-delay -n "$NAMESPACE" --timeout=60s \
+    || { kubectl describe networkchaos client-server-delay -n "$NAMESPACE"; fail "chaos never reached AllInjected"; }
+  local after; after=$(kubectl exec "$CLIENT_POD" -- bash -c "$probe")
+  kubectl delete -f "$SCRIPT_DIR/manifests/client-server-delay.yaml" --ignore-not-found
+  log "smoke-check connect ms: before=$before after=$after"
+  if [ "$after" -lt $(( before + 200 )) ]; then
+    kubectl logs -n chaos-mesh -l app.kubernetes.io/component=chaos-daemon --tail=200 || true
+    fail "INJECTION SMOKE-CHECK FAILED (before=${before}ms after=${after}ms) — likely runtime/socket mismatch; chaos is a silent no-op. Aborting before false-green."
+  fi
+  log "Injection smoke-check PASSED (${before}ms -> ${after}ms)"
+}
+
+run_phase() {  # $1 = phase
+  kubectl exec -i "$CLIENT_POD" -- /bin/bash -c "
+    set -e; cd $WORKLOAD_IN_POD
+    go test -v -count=1 -timeout 16m -run TestNetworkChaosWorkload \
+      -config-file /tmp/test-config.yaml -phase $1 -record-file $RECORD_FILE ."
+}
+
+restart_sum() {  # I6: total server container restarts (host-side; client pod is itself under chaos)
+  kubectl get pod -l app.kubernetes.io/instance=${CR_NAME},app.kubernetes.io/component=server \
+    -o jsonpath='{range .items[*]}{.status.containerStatuses[0].restartCount}{"+"}{end}0' | bc
+}
+
+collect_artifacts() {  # mirror integration-test-chaos.yaml log collection
+  local scen="$1" out="$SCRIPT_DIR/artifacts/$1"; mkdir -p "$out"
+  for i in $(seq 0 $((REPLICAS-1))); do kubectl logs "${CR_NAME}-server-$i" >"$out/server-$i.log" 2>&1 || true; done
+  kubectl get networkchaos -A -o yaml            >"$out/networkchaos.yaml" 2>&1 || true
+  kubectl get events -A --sort-by=.lastTimestamp >"$out/events.txt" 2>&1 || true
+  kubectl get pods -o wide                        >"$out/pods.txt" 2>&1 || true
+  kubectl logs etcd  >"$out/etcd.log"  2>&1 || true
+  kubectl logs minio >"$out/minio.log" 2>&1 || true
+  kubectl cp "$CLIENT_POD:$RECORD_FILE" "$out/acked.jsonl" 2>/dev/null || true
+  echo "restarts: $(restart_sum)" >"$out/restartcounts.txt"
+}
+
+run_steady() {  # $1 = manifest basename
+  local m="$SCRIPT_DIR/manifests/$1.yaml" rc0; rc0=$(restart_sum)
+  run_phase warmup
+  kubectl apply -f "$m"
+  kubectl wait --for=condition=AllInjected "networkchaos/$1" -n "$NAMESPACE" --timeout=60s
+  run_phase under-chaos || { collect_artifacts "$1"; kubectl delete -f "$m" --ignore-not-found; return 1; }
+  kubectl delete -f "$m" --ignore-not-found
+  run_phase recovery || { collect_artifacts "$1"; return 1; }
+  run_phase verify   || { collect_artifacts "$1"; return 1; }
+  [ "$(restart_sum)" -eq "$rc0" ] || { collect_artifacts "$1"; fail "I6 VIOLATION: server restarted during $1"; }
+  log "SCENARIO $1 PASSED"
+}
+
+run_blip() {  # $1 = manifest basename (N3/N5)
+  local m="$SCRIPT_DIR/manifests/$1.yaml" rc0; rc0=$(restart_sum)
+  run_phase warmup
+  ( run_phase under-chaos ) & local wl=$!
+  for _ in $(seq 1 6); do kubectl apply -f "$m"; sleep 5; kubectl delete -f "$m" --ignore-not-found; sleep 5; done
+  wait "$wl" || { collect_artifacts "$1"; return 1; }
+  run_phase recovery && run_phase verify || { collect_artifacts "$1"; return 1; }
+  [ "$(restart_sum)" -eq "$rc0" ] || { collect_artifacts "$1"; fail "I6 VIOLATION: server restarted during $1"; }
+  log "SCENARIO $1 PASSED"
+}
+
+main() {
+  bringup; install_chaos_mesh; injection_smoke_check; push_workload
+  local rc=0
+  for s in server-minio-delay server-minio-loss server-etcd-delay client-server-delay client-server-loss; do
+    run_steady "$s" || rc=1
+  done
+  for s in server-minio-blip server-etcd-blip; do run_blip "$s" || rc=1; done
+  [ "$rc" -eq 0 ] && log "ALL SCENARIOS PASSED" || warn "SOME SCENARIOS FAILED (see artifacts/)"
+  exit $rc
+}
+
+trap 'rc=$?; [ -n "${KEEP:-}" ] || { helm uninstall chaos-mesh -n chaos-mesh 2>/dev/null || true; minikube delete -p "$CLUSTER_NAME" 2>/dev/null || true; }; exit $rc' EXIT
+main "$@"

--- a/tests/chaos_mesh/run_network_chaos.sh
+++ b/tests/chaos_mesh/run_network_chaos.sh
@@ -8,7 +8,13 @@ export CLUSTER_NAME="wp-chaos"
 export CR_NAME="my-woodpecker"
 export NAMESPACE="default"
 export REPLICAS=3
-export MK_CPUS="${MK_CPUS:-6}" MK_MEMORY="${MK_MEMORY:-8192}" MK_RUNTIME="${MK_RUNTIME:-containerd}"
+# Default to minikube's docker runtime: it uses built-in bridge networking and needs no
+# external CNI image. The containerd runtime forces a kindnet CNI whose image
+# (kindest/kindnetd:<ver>) frequently cannot be pulled on constrained/offline hosts, leaving
+# the cluster with no pod networking ("failed to find network info for sandbox"). Chaos Mesh
+# supports the docker runtime, and the injection smoke-check guards correctness either way.
+# Override with MK_RUNTIME=containerd only where the kindnet image is reachable.
+export MK_CPUS="${MK_CPUS:-6}" MK_MEMORY="${MK_MEMORY:-8192}" MK_RUNTIME="${MK_RUNTIME:-}"
 export WP_IMG="zilliztech/woodpecker:v0.1.26"
 export CLIENT_POD="wp-client-test"
 
@@ -24,11 +30,20 @@ bringup() {
 }
 
 install_chaos_mesh() {
+  # chaos-daemon must point at the SAME container runtime minikube uses, else injection is a
+  # silent no-op (caught by injection_smoke_check). Empty MK_RUNTIME = minikube's docker runtime.
+  local daemon_runtime daemon_socket
+  if [ "${MK_RUNTIME:-}" = "containerd" ]; then
+    daemon_runtime=containerd; daemon_socket=/run/containerd/containerd.sock
+  else
+    daemon_runtime=docker; daemon_socket=/var/run/docker.sock
+  fi
+  log "installing chaos-mesh (chaosDaemon.runtime=$daemon_runtime socket=$daemon_socket)"
   helm repo add chaos-mesh https://charts.chaos-mesh.org 2>/dev/null || true
   helm repo update
   helm install chaos-mesh chaos-mesh/chaos-mesh -n chaos-mesh --create-namespace \
-    --set chaosDaemon.runtime=containerd \
-    --set chaosDaemon.socketPath=/run/containerd/containerd.sock \
+    --set chaosDaemon.runtime="$daemon_runtime" \
+    --set chaosDaemon.socketPath="$daemon_socket" \
     --wait --timeout 5m
   kubectl -n chaos-mesh rollout status daemonset/chaos-daemon --timeout=180s
 }

--- a/tests/chaos_mesh/run_network_chaos.sh
+++ b/tests/chaos_mesh/run_network_chaos.sh
@@ -23,8 +23,24 @@ source "$PROJECT_ROOT/deployments/operator/test/lib.sh"
 WORKLOAD_IN_POD=/root/woodpecker/tests/chaos_mesh/workload
 RECORD_FILE=/tmp/wp-chaos-acked.jsonl
 
+# External dependency images (keep etcd/minio in sync with deployments/operator/test/lib.sh).
+ETCD_IMG="quay.io/coreos/etcd:v3.5.18"
+MINIO_IMG="minio/minio:RELEASE.2024-06-13T22-53-53Z"
+
+# The minikube node can't reach external registries when the host uses a loopback proxy
+# (HTTP_PROXY=127.0.0.1:xxxx — minikube logs "Local proxy ignored"). The HOST can pull (its
+# proxy works), so for images we don't build locally we pull on the host and load into the node.
+preload_image() {  # $1 = image ref
+  log "preload: $1"
+  docker pull "$1" || fail "host 'docker pull $1' failed (proxy/network?)"
+  minikube -p "$CLUSTER_NAME" image load "$1" || fail "'minikube image load $1' failed"
+}
+
 bringup() {
-  wp_minikube_start; wp_deploy_operator; wp_build_wp_image
+  wp_minikube_start
+  preload_image "$ETCD_IMG"
+  preload_image "$MINIO_IMG"
+  wp_deploy_operator; wp_build_wp_image
   wp_deploy_deps; wp_create_cr; wp_wait_healthy
   wp_launch_client_pod; wp_write_client_config "$REPLICAS"
 }
@@ -41,9 +57,18 @@ install_chaos_mesh() {
   log "installing chaos-mesh (chaosDaemon.runtime=$daemon_runtime socket=$daemon_socket)"
   helm repo add chaos-mesh https://charts.chaos-mesh.org 2>/dev/null || true
   helm repo update
+  # Preload chaos-mesh images: the node can't reach ghcr.io through the host's loopback proxy.
+  # dashboard.create=false trims a pod we don't need (saves resources on the tight node).
+  local cm_imgs img
+  cm_imgs=$(helm template chaos-mesh chaos-mesh/chaos-mesh -n chaos-mesh --set dashboard.create=false 2>/dev/null \
+    | grep -hoE 'image: *"?[^"[:space:]]+' | sed -E 's/image: *"?//' | sort -u)
+  while read -r img; do
+    [ -n "$img" ] && preload_image "$img"
+  done <<< "$cm_imgs"
   helm install chaos-mesh chaos-mesh/chaos-mesh -n chaos-mesh --create-namespace \
     --set chaosDaemon.runtime="$daemon_runtime" \
     --set chaosDaemon.socketPath="$daemon_socket" \
+    --set dashboard.create=false \
     --wait --timeout 5m
   kubectl -n chaos-mesh rollout status daemonset/chaos-daemon --timeout=180s
 }

--- a/tests/chaos_mesh/run_network_chaos.sh
+++ b/tests/chaos_mesh/run_network_chaos.sh
@@ -38,6 +38,11 @@ preload_image() {  # $1 = image ref
 
 bringup() {
   wp_minikube_start
+  # Single-node minikube has no zone label, but the operator's StatefulSet sets a topology
+  # spread constraint (topologyKey=topology.kubernetes.io/zone, whenUnsatisfiable=DoNotSchedule),
+  # so server pods stay Pending ("didn't match pod topology spread constraints"). Give the node a
+  # synthetic zone/region so all replicas can schedule (we don't test physical AZ separation).
+  kubectl label node "$CLUSTER_NAME" topology.kubernetes.io/zone=zone-a topology.kubernetes.io/region=region-local --overwrite
   preload_image "$ETCD_IMG"
   preload_image "$MINIO_IMG"
   wp_deploy_operator; wp_build_wp_image

--- a/tests/chaos_mesh/run_network_chaos.sh
+++ b/tests/chaos_mesh/run_network_chaos.sh
@@ -20,7 +20,7 @@ export CLIENT_POD="wp-client-test"
 
 source "$PROJECT_ROOT/deployments/operator/test/lib.sh"
 
-WORKLOAD_IN_POD=/root/woodpecker/tests/chaos_mesh/workload
+WORKLOAD_BIN_IN_POD=/root/workload.test
 RECORD_FILE=/tmp/wp-chaos-acked.jsonl
 
 # External dependency images (keep etcd/minio in sync with deployments/operator/test/lib.sh).
@@ -70,7 +70,8 @@ install_chaos_mesh() {
   while read -r img; do
     [ -n "$img" ] && preload_image "$img"
   done <<< "$cm_imgs"
-  helm install chaos-mesh chaos-mesh/chaos-mesh -n chaos-mesh --create-namespace \
+  # upgrade --install is idempotent so re-running against an existing cluster doesn't error.
+  helm upgrade --install chaos-mesh chaos-mesh/chaos-mesh -n chaos-mesh --create-namespace \
     --set chaosDaemon.runtime="$daemon_runtime" \
     --set chaosDaemon.socketPath="$daemon_socket" \
     --set dashboard.create=false \
@@ -78,15 +79,19 @@ install_chaos_mesh() {
   kubectl -n chaos-mesh rollout status daemonset/chaos-daemon --timeout=180s
 }
 
-# Deliver CURRENT source into the pod (Correction #5 / refinement B), then it's ready for `go test`.
+# Build the workload test binary ON THE HOST (it has the Go module cache + a working proxy) and
+# copy the static linux/<arch> binary into the pod. The pod can't reach the Go module proxy (the
+# same host-loopback-proxy limit that blocks registries), so an in-pod `go build` can't fetch deps.
+# Host arch == minikube-node arch (the node is a container on the host's Docker), so go env GOARCH
+# is correct for the node.
 push_workload() {
-  local tgz=/tmp/wp-src.tgz
-  tar --exclude='./.git' --exclude='./tests/chaos_mesh/artifacts' -czf "$tgz" -C "$PROJECT_ROOT" .
-  kubectl exec "$CLIENT_POD" -- mkdir -p /root/woodpecker
-  kubectl cp "$tgz" "$CLIENT_POD:/tmp/wp-src.tgz"
-  kubectl exec "$CLIENT_POD" -- bash -c "tar -xzf /tmp/wp-src.tgz -C /root/woodpecker"
-  kubectl exec "$CLIENT_POD" -- bash -c "cd $WORKLOAD_IN_POD && go build ./..." \
-    || fail "in-pod go build failed (module/source delivery problem)"
+  local bin=/tmp/workload.test
+  log "building workload test binary on host (GOOS=linux GOARCH=$(go env GOARCH) CGO_ENABLED=0)"
+  ( cd "$PROJECT_ROOT" && GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 \
+      go test -c -o "$bin" ./tests/chaos_mesh/workload ) || fail "host build of workload test binary failed"
+  kubectl cp "$bin" "$CLIENT_POD:$WORKLOAD_BIN_IN_POD"
+  kubectl exec "$CLIENT_POD" -- chmod +x "$WORKLOAD_BIN_IN_POD"
+  log "workload binary delivered to $CLIENT_POD:$WORKLOAD_BIN_IN_POD"
 }
 
 # Spec Layer 2 / Risk #1: prove injection is NOT a silent no-op before trusting any result.
@@ -107,11 +112,12 @@ injection_smoke_check() {
   log "Injection smoke-check PASSED (${before}ms -> ${after}ms)"
 }
 
-run_phase() {  # $1 = phase ; $2 = optional extra go-test flags
-  kubectl exec -i "$CLIENT_POD" -- /bin/bash -c "
-    set -e; cd $WORKLOAD_IN_POD
-    go test -v -count=1 -timeout 16m -run TestNetworkChaosWorkload \
-      -config-file /tmp/test-config.yaml -phase $1 -record-file $RECORD_FILE ${2:-} ."
+run_phase() {  # $1 = phase ; $2 = optional extra workload flags (e.g. "-window 60")
+  # Run the prebuilt test binary (compiled flags take the -test. prefix; the workload's own
+  # flags -config-file/-phase/-record-file/-window do not).
+  kubectl exec -i "$CLIENT_POD" -- "$WORKLOAD_BIN_IN_POD" \
+    -test.v -test.count=1 -test.timeout=16m -test.run=TestNetworkChaosWorkload \
+    -config-file /tmp/test-config.yaml -phase "$1" -record-file "$RECORD_FILE" ${2:-}
 }
 
 restart_sum() {  # I6: total server container restarts (host-side; client pod is itself under chaos)

--- a/tests/chaos_mesh/run_network_chaos.sh
+++ b/tests/chaos_mesh/run_network_chaos.sh
@@ -62,11 +62,11 @@ injection_smoke_check() {
   log "Injection smoke-check PASSED (${before}ms -> ${after}ms)"
 }
 
-run_phase() {  # $1 = phase
+run_phase() {  # $1 = phase ; $2 = optional extra go-test flags
   kubectl exec -i "$CLIENT_POD" -- /bin/bash -c "
     set -e; cd $WORKLOAD_IN_POD
     go test -v -count=1 -timeout 16m -run TestNetworkChaosWorkload \
-      -config-file /tmp/test-config.yaml -phase $1 -record-file $RECORD_FILE ."
+      -config-file /tmp/test-config.yaml -phase $1 -record-file $RECORD_FILE ${2:-} ."
 }
 
 restart_sum() {  # I6: total server container restarts (host-side; client pod is itself under chaos)
@@ -88,9 +88,10 @@ collect_artifacts() {  # mirror integration-test-chaos.yaml log collection
 
 run_steady() {  # $1 = manifest basename
   local m="$SCRIPT_DIR/manifests/$1.yaml" rc0; rc0=$(restart_sum)
-  run_phase warmup
-  kubectl apply -f "$m"
-  kubectl wait --for=condition=AllInjected "networkchaos/$1" -n "$NAMESPACE" --timeout=60s
+  run_phase warmup || { collect_artifacts "$1"; return 1; }
+  kubectl apply -f "$m" || { collect_artifacts "$1"; return 1; }
+  kubectl wait --for=condition=AllInjected "networkchaos/$1" -n "$NAMESPACE" --timeout=60s \
+      || { collect_artifacts "$1"; kubectl delete -f "$m" --ignore-not-found; return 1; }
   run_phase under-chaos || { collect_artifacts "$1"; kubectl delete -f "$m" --ignore-not-found; return 1; }
   kubectl delete -f "$m" --ignore-not-found
   run_phase recovery || { collect_artifacts "$1"; return 1; }
@@ -101,9 +102,9 @@ run_steady() {  # $1 = manifest basename
 
 run_blip() {  # $1 = manifest basename (N3/N5)
   local m="$SCRIPT_DIR/manifests/$1.yaml" rc0; rc0=$(restart_sum)
-  run_phase warmup
-  ( run_phase under-chaos ) & local wl=$!
-  for _ in $(seq 1 6); do kubectl apply -f "$m"; sleep 5; kubectl delete -f "$m" --ignore-not-found; sleep 5; done
+  run_phase warmup || { collect_artifacts "$1"; return 1; }
+  ( run_phase under-chaos "-window 60" ) & local wl=$!
+  for _ in $(seq 1 6); do kubectl apply -f "$m" || warn "blip apply failed for $1"; sleep 5; kubectl delete -f "$m" --ignore-not-found; sleep 5; done
   wait "$wl" || { collect_artifacts "$1"; return 1; }
   run_phase recovery && run_phase verify || { collect_artifacts "$1"; return 1; }
   [ "$(restart_sum)" -eq "$rc0" ] || { collect_artifacts "$1"; fail "I6 VIOLATION: server restarted during $1"; }

--- a/tests/chaos_mesh/workload/classify.go
+++ b/tests/chaos_mesh/workload/classify.go
@@ -1,0 +1,27 @@
+package workload
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+
+	"github.com/zilliztech/woodpecker/common/werr"
+)
+
+func payloadHash(b []byte) string { h := sha256.Sum256(b); return hex.EncodeToString(h[:]) }
+
+// isWoodpeckerPermanent reports true ONLY for a Woodpecker-typed, non-retryable error.
+// Raw context deadline / cancellation / transport errors are transient (owned by the
+// client's own retry budget) and must NOT be charged as I5 violations (Correction #4).
+func isWoodpeckerPermanent(err error) bool {
+	if err == nil { return false }
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) { return false }
+	if werr.IsTransportError(err) { return false }
+	// A retryable Woodpecker error is acceptable degradation, not a permanent failure.
+	if werr.IsRetryableErr(err) { return false }
+	// Permanent iff it is a Woodpecker-typed error that is NOT retryable.
+	var wpErr interface{ IsRetryable() bool }
+	if errors.As(err, &wpErr) { return !wpErr.IsRetryable() }
+	return false // unknown / non-WP error: not our I5 target
+}

--- a/tests/chaos_mesh/workload/classify.go
+++ b/tests/chaos_mesh/workload/classify.go
@@ -15,13 +15,23 @@ func payloadHash(b []byte) string { h := sha256.Sum256(b); return hex.EncodeToSt
 // Raw context deadline / cancellation / transport errors are transient (owned by the
 // client's own retry budget) and must NOT be charged as I5 violations (Correction #4).
 func isWoodpeckerPermanent(err error) bool {
-	if err == nil { return false }
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) { return false }
-	if werr.IsTransportError(err) { return false }
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if werr.IsTransportError(err) {
+		return false
+	}
 	// A retryable Woodpecker error is acceptable degradation, not a permanent failure.
-	if werr.IsRetryableErr(err) { return false }
+	if werr.IsRetryableErr(err) {
+		return false
+	}
 	// Permanent iff it is a Woodpecker-typed error that is NOT retryable.
 	var wpErr interface{ IsRetryable() bool }
-	if errors.As(err, &wpErr) { return !wpErr.IsRetryable() }
+	if errors.As(err, &wpErr) {
+		return !wpErr.IsRetryable()
+	}
 	return false // unknown / non-WP error: not our I5 target
 }

--- a/tests/chaos_mesh/workload/classify_test.go
+++ b/tests/chaos_mesh/workload/classify_test.go
@@ -1,0 +1,15 @@
+package workload
+
+import ("context"; "errors"; "testing"; "github.com/stretchr/testify/require")
+
+func TestPayloadHashDeterministic(t *testing.T) {
+	require.Equal(t, payloadHash([]byte("abc")), payloadHash([]byte("abc")))
+	require.NotEqual(t, payloadHash([]byte("abc")), payloadHash([]byte("abd")))
+}
+
+func TestIsWoodpeckerPermanent_TransientAndNil(t *testing.T) {
+	require.False(t, isWoodpeckerPermanent(nil))
+	require.False(t, isWoodpeckerPermanent(context.DeadlineExceeded))
+	require.False(t, isWoodpeckerPermanent(context.Canceled))
+	require.False(t, isWoodpeckerPermanent(errors.New("some random non-wp error")))
+}

--- a/tests/chaos_mesh/workload/classify_test.go
+++ b/tests/chaos_mesh/workload/classify_test.go
@@ -1,6 +1,12 @@
 package workload
 
-import ("context"; "errors"; "testing"; "github.com/stretchr/testify/require")
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestPayloadHashDeterministic(t *testing.T) {
 	require.Equal(t, payloadHash([]byte("abc")), payloadHash([]byte("abc")))

--- a/tests/chaos_mesh/workload/main_test.go
+++ b/tests/chaos_mesh/workload/main_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/zilliztech/woodpecker/common/config"
 	"github.com/zilliztech/woodpecker/common/etcd"
 	"github.com/zilliztech/woodpecker/woodpecker"
@@ -33,7 +34,7 @@ func newClient(ctx context.Context, t *testing.T) (woodpecker.Client, func()) {
 	require.NoError(t, err)
 	cli, err := woodpecker.NewClient(ctx, cfg, etcdCli, true)
 	require.NoError(t, err)
-	return cli, func() { _ = cli.Close(ctx); _ = etcdCli.Close() }
+	return cli, func() { _ = cli.Close(ctx) }
 }
 
 func TestNetworkChaosWorkload(t *testing.T) {
@@ -107,11 +108,13 @@ func runLoadPhase(ctx context.Context, t *testing.T, cli woodpecker.Client, trun
 					continue
 				}
 				atomic.AddInt64(&m.ok, 1)
-				_ = rec.append(AckRecord{
+				if err := rec.append(AckRecord{
 					LogName: L.name, LogId: L.id,
 					SegmentId: res.LogMessageId.SegmentId, EntryId: res.LogMessageId.EntryId,
 					PayloadHash: ph, Seq: seq,
-				})
+				}); err != nil {
+					t.Errorf("failed to persist ack record (logId=%d seg=%d entry=%d): %v", L.id, res.LogMessageId.SegmentId, res.LogMessageId.EntryId, err)
+				}
 			}
 		}(L)
 	}

--- a/tests/chaos_mesh/workload/main_test.go
+++ b/tests/chaos_mesh/workload/main_test.go
@@ -1,0 +1,201 @@
+package workload
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/etcd"
+	"github.com/zilliztech/woodpecker/woodpecker"
+	"github.com/zilliztech/woodpecker/woodpecker/log"
+)
+
+var (
+	configFile = flag.String("config-file", "/tmp/test-config.yaml", "woodpecker config path")
+	phase      = flag.String("phase", "warmup", "warmup|under-chaos|recovery|verify")
+	recordFile = flag.String("record-file", "/tmp/wp-chaos-acked.jsonl", "acked records JSONL")
+	numLogs    = flag.Int("logs", 8, "number of concurrent logs (1 writer each — refinement A)")
+	windowSecs = flag.Int("window", 45, "load-phase duration seconds")
+	logPrefix  = flag.String("log-prefix", "chaos-n152", "stable log name prefix across phases")
+)
+
+func newClient(ctx context.Context, t *testing.T) (woodpecker.Client, func()) {
+	cfg, err := config.NewConfiguration(*configFile)
+	require.NoError(t, err)
+	etcdCli, err := etcd.GetRemoteEtcdClient(cfg.Etcd.GetEndpoints())
+	require.NoError(t, err)
+	cli, err := woodpecker.NewClient(ctx, cfg, etcdCli, true)
+	require.NoError(t, err)
+	return cli, func() { _ = cli.Close(ctx); _ = etcdCli.Close() }
+}
+
+func TestNetworkChaosWorkload(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+	cli, closeFn := newClient(ctx, t)
+	defer closeFn()
+	switch *phase {
+	case "warmup":
+		runLoadPhase(ctx, t, cli, true)
+	case "under-chaos", "recovery":
+		runLoadPhase(ctx, t, cli, false)
+	case "verify":
+		runVerifyPhase(ctx, t, cli)
+	default:
+		t.Fatalf("unknown phase %q", *phase)
+	}
+}
+
+type metrics struct{ ok, errRetryable, errPermanent int64 }
+
+func runLoadPhase(ctx context.Context, t *testing.T, cli woodpecker.Client, truncate bool) {
+	rec, err := openRecorder(*recordFile, truncate)
+	require.NoError(t, err)
+	defer rec.close()
+
+	var m metrics
+	deadline := time.Now().Add(time.Duration(*windowSecs) * time.Second)
+
+	type lh struct {
+		name   string
+		id     int64
+		handle log.LogHandle
+		writer log.LogWriter
+		seq    int64
+	}
+	logs := make([]*lh, *numLogs)
+	for i := range logs {
+		name := fmt.Sprintf("%s-%d", *logPrefix, i)
+		_ = cli.CreateLog(ctx, name) // idempotent across phases
+		h, err := cli.OpenLog(ctx, name)
+		require.NoError(t, err)
+		w, err := h.OpenLogWriter(ctx)
+		require.NoError(t, err)
+		logs[i] = &lh{name: name, id: h.GetId(), handle: h, writer: w}
+	}
+
+	var wg sync.WaitGroup
+	// ---- one WRITER per log (refinement A: unambiguous ordering) ----
+	for _, L := range logs {
+		wg.Add(1)
+		go func(L *lh) {
+			defer wg.Done()
+			for time.Now().Before(deadline) {
+				seq := atomic.AddInt64(&L.seq, 1)
+				payload := []byte(fmt.Sprintf("%s|%d|%d", L.name, time.Now().UnixNano(), seq))
+				ph := payloadHash(payload)
+				opCtx, opCancel := context.WithTimeout(ctx, 30*time.Second) // I4 bound
+				res := <-L.writer.WriteAsync(opCtx, &log.WriteMessage{
+					Payload:    payload,
+					Properties: map[string]string{"hash": ph},
+				})
+				opCancel()
+				if res.Err != nil {
+					if isWoodpeckerPermanent(res.Err) {
+						atomic.AddInt64(&m.errPermanent, 1)
+						t.Errorf("I5 VIOLATION (write): permanent error under transient fault: %v", res.Err)
+					} else {
+						atomic.AddInt64(&m.errRetryable, 1) // acceptable degradation
+					}
+					continue
+				}
+				atomic.AddInt64(&m.ok, 1)
+				_ = rec.append(AckRecord{
+					LogName: L.name, LogId: L.id,
+					SegmentId: res.LogMessageId.SegmentId, EntryId: res.LogMessageId.EntryId,
+					PayloadHash: ph, Seq: seq,
+				})
+			}
+		}(L)
+	}
+	// ---- one tail READER per log (liveness / no-hang) ----
+	for _, L := range logs {
+		wg.Add(1)
+		go func(L *lh) {
+			defer wg.Done()
+			earliest := log.EarliestLogMessageID()
+			r, err := L.handle.OpenLogReader(ctx, &earliest, "chaos-tail-"+L.name)
+			if err != nil {
+				return
+			}
+			defer r.Close(ctx)
+			for time.Now().Before(deadline) {
+				rCtx, rCancel := context.WithTimeout(ctx, 30*time.Second)
+				_, err := r.ReadNext(rCtx)
+				rCancel()
+				if err != nil && isWoodpeckerPermanent(err) {
+					t.Errorf("I5 VIOLATION (read): permanent error under transient fault: %v", err)
+				}
+			}
+		}(L)
+	}
+	wg.Wait()
+	for _, L := range logs {
+		_ = L.writer.Close(ctx)
+	}
+
+	require.Greater(t, m.ok, int64(0),
+		"I7 VIOLATION: zero successful writes in phase %s (no forward progress)", *phase)
+	t.Logf("phase=%s ok=%d retryableErr=%d permanentErr=%d",
+		*phase, m.ok, m.errRetryable, m.errPermanent)
+}
+
+func runVerifyPhase(ctx context.Context, t *testing.T, cli woodpecker.Client) {
+	recs, err := loadRecords(*recordFile)
+	require.NoError(t, err)
+	require.Greater(t, len(recs), 0, "no acked records to verify")
+
+	byLog := map[string][]AckRecord{}
+	for _, r := range recs {
+		byLog[r.LogName] = append(byLog[r.LogName], r)
+	}
+
+	for name, want := range byLog {
+		sort.Slice(want, func(i, j int) bool { return want[i].Seq < want[j].Seq })
+		h, err := cli.OpenLog(ctx, name)
+		require.NoError(t, err)
+		earliest := log.EarliestLogMessageID()
+		r, err := h.OpenLogReader(ctx, &earliest, "verify-"+name)
+		require.NoError(t, err)
+
+		ackedHash := map[[2]int64]string{}
+		for _, w := range want {
+			ackedHash[[2]int64{w.SegmentId, w.EntryId}] = w.PayloadHash
+		}
+
+		seen := map[[2]int64]bool{}
+		var lastSeg, lastEntry int64 = -1, -1
+		rctx, rcancel := context.WithTimeout(ctx, 5*time.Minute)
+		for len(seen) < len(ackedHash) {
+			msg, err := r.ReadNext(rctx)
+			require.NoError(t, err, "I1/I4 read-back failed for %s (%d/%d)", name, len(seen), len(ackedHash))
+			k := [2]int64{msg.Id.SegmentId, msg.Id.EntryId}
+			// I2 ordering: strictly increasing (seg,entry) in read order (one writer per log).
+			if msg.Id.SegmentId == lastSeg {
+				require.Greater(t, msg.Id.EntryId, lastEntry, "I2 VIOLATION: non-increasing entryId in %s", name)
+			} else if lastSeg >= 0 {
+				require.Greater(t, msg.Id.SegmentId, lastSeg, "I2 VIOLATION: non-increasing segmentId in %s", name)
+			}
+			lastSeg, lastEntry = msg.Id.SegmentId, msg.Id.EntryId
+			if wantHash, ok := ackedHash[k]; ok {
+				require.Equal(t, wantHash, payloadHash(msg.Payload),
+					"I3 VIOLATION: payload hash mismatch %s seg=%d entry=%d", name, k[0], k[1])
+				require.Equal(t, wantHash, msg.Properties["hash"],
+					"I3 VIOLATION: property hash mismatch %s", name)
+				seen[k] = true
+			}
+		}
+		rcancel()
+		require.Equal(t, len(ackedHash), len(seen),
+			"I1 VIOLATION: %d acked entries missing in %s", len(ackedHash)-len(seen), name)
+		_ = r.Close(ctx)
+		t.Logf("VERIFY %s: %d acked entries durable, ordered, hash-matched", name, len(seen))
+	}
+}

--- a/tests/chaos_mesh/workload/record.go
+++ b/tests/chaos_mesh/workload/record.go
@@ -1,0 +1,53 @@
+package workload
+
+import ("bufio"; "encoding/json"; "os"; "sync")
+
+// AckRecord is the persisted unit of truth for I1/I2/I3 read-back.
+type AckRecord struct {
+	LogName     string `json:"log"`
+	LogId       int64  `json:"logId"`
+	SegmentId   int64  `json:"seg"`
+	EntryId     int64  `json:"entry"`
+	PayloadHash string `json:"hash"`
+	Seq         int64  `json:"seq"`
+}
+
+type recorder struct {
+	mu sync.Mutex
+	f  *os.File
+}
+
+func openRecorder(path string, truncate bool) (*recorder, error) {
+	flags := os.O_CREATE | os.O_WRONLY | os.O_APPEND
+	if truncate { flags = os.O_CREATE | os.O_WRONLY | os.O_TRUNC }
+	f, err := os.OpenFile(path, flags, 0o644)
+	if err != nil { return nil, err }
+	return &recorder{f: f}, nil
+}
+
+func (r *recorder) append(rec AckRecord) error {
+	b, err := json.Marshal(rec)
+	if err != nil { return err }
+	r.mu.Lock(); defer r.mu.Unlock()
+	_, err = r.f.Write(append(b, '\n'))
+	return err
+}
+
+func (r *recorder) close() error { return r.f.Close() }
+
+func loadRecords(path string) ([]AckRecord, error) {
+	f, err := os.Open(path)
+	if err != nil { return nil, err }
+	defer f.Close()
+	var out []AckRecord
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 0, 1024*1024), 8*1024*1024)
+	for s.Scan() {
+		line := s.Bytes()
+		if len(line) == 0 { continue }
+		var rec AckRecord
+		if err := json.Unmarshal(line, &rec); err != nil { return nil, err }
+		out = append(out, rec)
+	}
+	return out, s.Err()
+}

--- a/tests/chaos_mesh/workload/record.go
+++ b/tests/chaos_mesh/workload/record.go
@@ -1,6 +1,11 @@
 package workload
 
-import ("bufio"; "encoding/json"; "os"; "sync")
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"sync"
+)
 
 // AckRecord is the persisted unit of truth for I1/I2/I3 read-back.
 type AckRecord struct {
@@ -19,16 +24,23 @@ type recorder struct {
 
 func openRecorder(path string, truncate bool) (*recorder, error) {
 	flags := os.O_CREATE | os.O_WRONLY | os.O_APPEND
-	if truncate { flags = os.O_CREATE | os.O_WRONLY | os.O_TRUNC }
+	if truncate {
+		flags = os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	}
 	f, err := os.OpenFile(path, flags, 0o644)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return &recorder{f: f}, nil
 }
 
 func (r *recorder) append(rec AckRecord) error {
 	b, err := json.Marshal(rec)
-	if err != nil { return err }
-	r.mu.Lock(); defer r.mu.Unlock()
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	_, err = r.f.Write(append(b, '\n'))
 	return err
 }
@@ -37,16 +49,22 @@ func (r *recorder) close() error { return r.f.Close() }
 
 func loadRecords(path string) ([]AckRecord, error) {
 	f, err := os.Open(path)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	defer f.Close()
 	var out []AckRecord
 	s := bufio.NewScanner(f)
 	s.Buffer(make([]byte, 0, 1024*1024), 8*1024*1024)
 	for s.Scan() {
 		line := s.Bytes()
-		if len(line) == 0 { continue }
+		if len(line) == 0 {
+			continue
+		}
 		var rec AckRecord
-		if err := json.Unmarshal(line, &rec); err != nil { return nil, err }
+		if err := json.Unmarshal(line, &rec); err != nil {
+			return nil, err
+		}
 		out = append(out, rec)
 	}
 	return out, s.Err()

--- a/tests/chaos_mesh/workload/record_test.go
+++ b/tests/chaos_mesh/workload/record_test.go
@@ -1,6 +1,12 @@
 package workload
 
-import ("os"; "path/filepath"; "testing"; "github.com/stretchr/testify/require")
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestRecorderRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "acked.jsonl")
@@ -10,7 +16,9 @@ func TestRecorderRoundTrip(t *testing.T) {
 		{LogName: "chaos-n152-0", LogId: 1, SegmentId: 0, EntryId: 0, PayloadHash: "aa", Seq: 1},
 		{LogName: "chaos-n152-0", LogId: 1, SegmentId: 0, EntryId: 1, PayloadHash: "bb", Seq: 2},
 	}
-	for _, rec := range in { require.NoError(t, r.append(rec)) }
+	for _, rec := range in {
+		require.NoError(t, r.append(rec))
+	}
 	require.NoError(t, r.close())
 	out, err := loadRecords(path)
 	require.NoError(t, err)

--- a/tests/chaos_mesh/workload/record_test.go
+++ b/tests/chaos_mesh/workload/record_test.go
@@ -1,0 +1,19 @@
+package workload
+
+import ("os"; "path/filepath"; "testing"; "github.com/stretchr/testify/require")
+
+func TestRecorderRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "acked.jsonl")
+	r, err := openRecorder(path, true)
+	require.NoError(t, err)
+	in := []AckRecord{
+		{LogName: "chaos-n152-0", LogId: 1, SegmentId: 0, EntryId: 0, PayloadHash: "aa", Seq: 1},
+		{LogName: "chaos-n152-0", LogId: 1, SegmentId: 0, EntryId: 1, PayloadHash: "bb", Seq: 2},
+	}
+	for _, rec := range in { require.NoError(t, r.append(rec)) }
+	require.NoError(t, r.close())
+	out, err := loadRecords(path)
+	require.NoError(t, err)
+	require.Equal(t, in, out)
+	_ = os.Remove(path)
+}


### PR DESCRIPTION
## Summary

Adds a **nightly-only** Chaos Mesh suite (`tests/chaos_mesh/`) that injects network jitter — delay+jitter, packet loss, and transient partition "blips" — on Woodpecker's three key links (server↔MinIO, server↔etcd, client↔server) and asserts the system only degrades gracefully. Closes the gap in #152 (the existing `tests/docker/chaos/` covers only hard failures; soft network degradation was unimplemented).

**Included:**
- `tests/chaos_mesh/run_network_chaos.sh` — host orchestrator: reuses the operator bring-up (extracted into a shared `deployments/operator/test/lib.sh`), installs Chaos Mesh, runs an **injection smoke-check** (guards against a silent no-op), then 7 scenarios via `warmup → inject → under-chaos → recovery → verify`.
- `tests/chaos_mesh/manifests/` — 7 `NetworkChaos` CRs (N1–N7).
- `tests/chaos_mesh/workload/` — phase-based Go workload + verifier asserting invariants **I1–I7** (durability / ordering / CRC / liveness / no spurious permanent error / no crash / bounded retry); records every acked `(logId, segmentId, entryId, payloadHash)` and reads it all back.
- `.github/workflows/nightly-chaos-mesh.yaml` + a `nightly.yaml` job — **nightly only, never PR-gating**.

## Results (first local minikube run — see `tests/chaos_mesh/README.md`)

**No serious bugs.** All 7 realistic-jitter scenarios passed with **zero client-visible errors and zero data loss**; under moderate jitter Woodpecker degrades only in latency/throughput (writes ack from the local staged buffer, MinIO/etcd work is async). Manual stress confirmed the recovery path: **60% client→server loss** → occasional retryable errors with continued progress, **zero permanent errors**, then full recovery and zero data loss; a near-total 20s±14s delay fails safe and fully recovers.

## Test plan

- [x] Workload unit tests + `golangci-lint` clean on the new package
- [x] `bash -n` on lib.sh / smoke-test.sh / run_network_chaos.sh
- [x] Full suite on minikube: **7/7 scenarios PASS**, exit 0
- [ ] Nightly job green on the CI runner

Design + plan: `docs/superpowers/specs/2026-06-04-chaos-mesh-network-jitter-design.md`, `docs/superpowers/plans/2026-06-04-chaos-mesh-network-jitter.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)