### PR TITLE
enhance(docker): run server images as root by default

### DIFF
--- a/build/docker/amazonlinux2023/Dockerfile
+++ b/build/docker/amazonlinux2023/Dockerfile
@@ -24,8 +24,8 @@ LABEL maintainer="zilliz-team@zilliz.com"
 LABEL version="1.0.0"
 LABEL description="Woodpecker distributed log store server"
 
-# Install dependencies including user management tools
-RUN yum install -y wget libgomp libaio libatomic openblas-devel shadow-utils && \
+# Install dependencies
+RUN yum install -y wget libgomp libaio libatomic openblas-devel && \
     rm -rf /var/cache/yum/*
 
 # Install tini for proper signal handling (multi-platform support)
@@ -37,27 +37,21 @@ RUN case ${TARGETPLATFORM} in \
     wget -O /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TINI_ARCH} && \
     chmod +x /tini
 
-# Create woodpecker user and directories
-RUN useradd -r -u 1000 -g root -s /bin/bash -d /woodpecker woodpecker && \
-    mkdir -p /woodpecker/bin && \
+# Create directories
+RUN mkdir -p /woodpecker/bin && \
     mkdir -p /woodpecker/configs && \
     mkdir -p /woodpecker/data && \
-    mkdir -p /woodpecker/logs && \
-    chown -R woodpecker:root /woodpecker && \
-    chmod -R g=u /woodpecker
+    mkdir -p /woodpecker/logs
 
 # Copy Woodpecker binary
-COPY --chown=woodpecker:root --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
+COPY --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
 
 # Copy startup and health check scripts
-COPY --chown=woodpecker:root --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
-COPY --chown=woodpecker:root --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
+COPY --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
+COPY --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
 
 # Set working directory
 WORKDIR /woodpecker
-
-# Switch to woodpecker user
-USER woodpecker
 
 # Environment variables with defaults (removed sensitive defaults)
 ENV GOSSIP_PORT=17946 \

--- a/build/docker/rockylinux8/Dockerfile
+++ b/build/docker/rockylinux8/Dockerfile
@@ -25,8 +25,8 @@ LABEL maintainer="zilliz-team@zilliz.com"
 LABEL version="1.0.0"
 LABEL description="Woodpecker distributed log store server"
 
-# Install dependencies including user management tools
-RUN dnf install -y wget libgomp libaio libatomic shadow-utils
+# Install dependencies
+RUN dnf install -y wget libgomp libaio libatomic
 
 RUN dnf -y install dnf-plugins-core && \
     dnf config-manager --set-enabled powertools && \
@@ -41,27 +41,21 @@ RUN case ${TARGETPLATFORM} in \
     wget -O /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TINI_ARCH} && \
     chmod +x /tini
 
-# Create woodpecker user and directories
-RUN useradd -r -u 1000 -g root -s /bin/bash -d /woodpecker woodpecker && \
-    mkdir -p /woodpecker/bin && \
+# Create directories
+RUN mkdir -p /woodpecker/bin && \
     mkdir -p /woodpecker/configs && \
     mkdir -p /woodpecker/data && \
-    mkdir -p /woodpecker/logs && \
-    chown -R woodpecker:root /woodpecker && \
-    chmod -R g=u /woodpecker
+    mkdir -p /woodpecker/logs
 
 # Copy Woodpecker binary
-COPY --chown=woodpecker:root --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
+COPY --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
 
 # Copy startup and health check scripts
-COPY --chown=woodpecker:root --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
-COPY --chown=woodpecker:root --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
+COPY --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
+COPY --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
 
 # Set working directory
 WORKDIR /woodpecker
-
-# Switch to woodpecker user
-USER woodpecker
 
 # Environment variables with defaults (removed sensitive defaults)
 ENV GOSSIP_PORT=17946 \

--- a/build/docker/ubuntu20.04/Dockerfile
+++ b/build/docker/ubuntu20.04/Dockerfile
@@ -44,27 +44,21 @@ RUN case ${TARGETPLATFORM} in \
     curl -L -o /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TINI_ARCH} && \
     chmod +x /tini
 
-# Create woodpecker user and directories
-RUN useradd -r -u 1000 -g root -s /bin/bash -d /woodpecker woodpecker && \
-    mkdir -p /woodpecker/bin && \
+# Create directories
+RUN mkdir -p /woodpecker/bin && \
     mkdir -p /woodpecker/configs && \
     mkdir -p /woodpecker/data && \
-    mkdir -p /woodpecker/logs && \
-    chown -R woodpecker:root /woodpecker && \
-    chmod -R g=u /woodpecker
+    mkdir -p /woodpecker/logs
 
 # Copy Woodpecker binary
-COPY --chown=woodpecker:root --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
+COPY --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
 
 # Copy startup and health check scripts
-COPY --chown=woodpecker:root --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
-COPY --chown=woodpecker:root --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
+COPY --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
+COPY --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
 
 # Set working directory
 WORKDIR /woodpecker
-
-# Switch to woodpecker user
-USER woodpecker
 
 # Environment variables with defaults (removed sensitive defaults)
 ENV GOSSIP_PORT=17946 \

--- a/build/docker/ubuntu22.04/Dockerfile
+++ b/build/docker/ubuntu22.04/Dockerfile
@@ -44,30 +44,24 @@ RUN case ${TARGETPLATFORM} in \
     curl -L -o /tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-${TINI_ARCH} && \
     chmod +x /tini
 
-# Create woodpecker user and directories
-RUN useradd -r -u 1000 -g root -s /bin/bash -d /woodpecker woodpecker && \
-    mkdir -p /woodpecker/bin && \
+# Create directories
+RUN mkdir -p /woodpecker/bin && \
     mkdir -p /woodpecker/configs && \
     mkdir -p /woodpecker/data && \
-    mkdir -p /woodpecker/logs && \
-    chown -R woodpecker:root /woodpecker && \
-    chmod -R g=u /woodpecker
+    mkdir -p /woodpecker/logs
 
 # Copy Woodpecker binary
-COPY --chown=woodpecker:root --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
+COPY --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
 
 # Copy wp CLI binary (optional — built via `make wpcli`)
-COPY --chown=woodpecker:root --chmod=755 ./bin/wp /woodpecker/bin/wp
+COPY --chmod=755 ./bin/wp /woodpecker/bin/wp
 
 # Copy startup and health check scripts
-COPY --chown=woodpecker:root --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
-COPY --chown=woodpecker:root --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
+COPY --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
+COPY --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
 
 # Set working directory
 WORKDIR /woodpecker
-
-# Switch to woodpecker user
-USER woodpecker
 
 # Environment variables with defaults (removed sensitive defaults)
 ENV GOSSIP_PORT=17946 \


### PR DESCRIPTION
## Summary

Make the Woodpecker server images run as **root** by default by removing the dedicated `woodpecker` (uid 1000) user from all four Dockerfiles under `build/docker/`. Anyone with pod exec access already has root-equivalent access, so the non-root user added operational friction (volume uid-mismatch, chown/chmod bookkeeping) without meaningful protection.

Closes #185

## Changes

Applied to `ubuntu22.04`, `ubuntu20.04`, `amazonlinux2023`, and `rockylinux8`:

- Drop `USER woodpecker`
- Remove the `useradd` user creation and the `chown -R woodpecker:root` / `chmod -R g=u` of `/woodpecker`
- Drop `--chown=woodpecker:root` from `COPY` (keep `--chmod=755`)
- Remove the now-unused `shadow-utils` package from `amazonlinux2023` and `rockylinux8`

## Scope / out of scope

- Only the data-plane server images under `build/docker/` are touched.
- The operator/controller-manager image (`deployments/operator/Dockerfile`, distroless `nonroot`) and `config/manager/manager.yaml` (`runAsNonRoot: true`) are intentionally **left unchanged**.
- The operator sets no `securityContext`/`runAsUser` on the Woodpecker workload, so removing the image `USER` is sufficient for the pods to run as root — no operator change needed.

## Note

Namespaces enforcing Pod Security Standards `restricted` (or OpenShift's default SCC) require non-root and would reject these images. Acceptable for our deployment model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)