### PR TITLE
enhance(docker): bundle wp (wpcli) into server images for zero-config in-pod ops (#187)

### DIFF
--- a/build/docker/amazonlinux2023/Dockerfile
+++ b/build/docker/amazonlinux2023/Dockerfile
@@ -46,6 +46,12 @@ RUN mkdir -p /woodpecker/bin && \
 # Copy Woodpecker binary
 COPY --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
 
+# Copy wp CLI binary (operational CLI; bundled for zero-config in-pod ops)
+COPY --chmod=755 ./bin/wp /woodpecker/bin/wp
+
+# Put wp on PATH so `wp ...` works from any directory in the pod
+RUN ln -sf /woodpecker/bin/wp /usr/local/bin/wp
+
 # Copy startup and health check scripts
 COPY --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
 COPY --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
@@ -69,7 +75,8 @@ ENV GOSSIP_PORT=17946 \
     MINIO_SECRET_KEY="" \
     MINIO_BUCKET="" \
     SEEDS="" \
-    SERVICE_SEEDS=""
+    SERVICE_SEEDS="" \
+    WOODPECKER_ENDPOINT="http://localhost:9091"
 
 # Expose ports (use fixed ports for better documentation)
 EXPOSE 18080 17946

--- a/build/docker/rockylinux8/Dockerfile
+++ b/build/docker/rockylinux8/Dockerfile
@@ -50,6 +50,12 @@ RUN mkdir -p /woodpecker/bin && \
 # Copy Woodpecker binary
 COPY --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
 
+# Copy wp CLI binary (operational CLI; bundled for zero-config in-pod ops)
+COPY --chmod=755 ./bin/wp /woodpecker/bin/wp
+
+# Put wp on PATH so `wp ...` works from any directory in the pod
+RUN ln -sf /woodpecker/bin/wp /usr/local/bin/wp
+
 # Copy startup and health check scripts
 COPY --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
 COPY --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
@@ -73,7 +79,8 @@ ENV GOSSIP_PORT=17946 \
     MINIO_SECRET_KEY="" \
     MINIO_BUCKET="" \
     SEEDS="" \
-    SERVICE_SEEDS=""
+    SERVICE_SEEDS="" \
+    WOODPECKER_ENDPOINT="http://localhost:9091"
 
 # Expose ports (use fixed ports for better documentation)
 EXPOSE 18080 17946

--- a/build/docker/ubuntu20.04/Dockerfile
+++ b/build/docker/ubuntu20.04/Dockerfile
@@ -53,6 +53,12 @@ RUN mkdir -p /woodpecker/bin && \
 # Copy Woodpecker binary
 COPY --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
 
+# Copy wp CLI binary (operational CLI; bundled for zero-config in-pod ops)
+COPY --chmod=755 ./bin/wp /woodpecker/bin/wp
+
+# Put wp on PATH so `wp ...` works from any directory in the pod
+RUN ln -sf /woodpecker/bin/wp /usr/local/bin/wp
+
 # Copy startup and health check scripts
 COPY --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
 COPY --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
@@ -76,7 +82,8 @@ ENV GOSSIP_PORT=17946 \
     MINIO_SECRET_KEY="" \
     MINIO_BUCKET="" \
     SEEDS="" \
-    SERVICE_SEEDS=""
+    SERVICE_SEEDS="" \
+    WOODPECKER_ENDPOINT="http://localhost:9091"
 
 # Expose ports (use fixed ports for better documentation)
 EXPOSE 18080 17946

--- a/build/docker/ubuntu22.04/Dockerfile
+++ b/build/docker/ubuntu22.04/Dockerfile
@@ -56,6 +56,9 @@ COPY --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker
 # Copy wp CLI binary (optional — built via `make wpcli`)
 COPY --chmod=755 ./bin/wp /woodpecker/bin/wp
 
+# Put wp on PATH so `wp ...` works from any directory in the pod
+RUN ln -sf /woodpecker/bin/wp /usr/local/bin/wp
+
 # Copy startup and health check scripts
 COPY --chmod=755 ./build/docker/scripts/start-woodpecker.sh /woodpecker/bin/start-woodpecker.sh
 COPY --chmod=755 ./build/docker/scripts/health-check.sh /woodpecker/bin/health-check.sh
@@ -79,7 +82,8 @@ ENV GOSSIP_PORT=17946 \
     MINIO_SECRET_KEY="" \
     MINIO_BUCKET="" \
     SEEDS="" \
-    SERVICE_SEEDS=""
+    SERVICE_SEEDS="" \
+    WOODPECKER_ENDPOINT="http://localhost:9091"
 
 # Expose ports (use fixed ports for better documentation)
 EXPOSE 18080 17946

--- a/cmd/wpcli/README.md
+++ b/cmd/wpcli/README.md
@@ -13,6 +13,32 @@ See [`docs/wpcli-design.md`](../../docs/wpcli-design.md) for the full design.
 
 See [`docs/wpcli/quickstart.md`](../../docs/wpcli/quickstart.md) for a 15-minute onboarding guide.
 
+## In-pod usage (zero-config)
+
+`wp` is bundled in all server images and is on `PATH`, so you can operate a
+cluster straight from a server pod with nothing to install:
+
+```bash
+kubectl exec -it <woodpecker-pod> -- wp cluster info
+kubectl exec -it <woodpecker-pod> -- wp node list
+```
+
+This works with no flags because the images set
+`WOODPECKER_ENDPOINT=http://localhost:9091` and the admin HTTP API listens on
+`9091` inside the container.
+
+### Endpoint precedence
+
+`wp` resolves the admin endpoint in this order (highest priority first):
+
+1. `--endpoint <url>` flag
+2. `$WOODPECKER_ENDPOINT`
+3. `cli.yaml` active context
+
+Because `$WOODPECKER_ENDPOINT` is baked into the server images, a `cli.yaml`
+mounted into a pod is overridden by it; pass `--endpoint` to target a different
+cluster from inside a pod.
+
 ## Minimum config
 
 Create `~/.woodpecker/cli.yaml`:

--- a/cmd/wpcli/cmd/resolver.go
+++ b/cmd/wpcli/cmd/resolver.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/zilliztech/woodpecker/cmd/wpcli/client"
 	"github.com/zilliztech/woodpecker/cmd/wpcli/config"
@@ -34,9 +35,8 @@ func resolveAndDiscover() (*resolved, error) {
 	}
 
 	// 2. Flag / env overrides on top of context.
-	if Globals.Endpoint != "" {
-		ctx.Endpoint = Globals.Endpoint
-	}
+	// Endpoint precedence: --endpoint flag > $WOODPECKER_ENDPOINT > cli.yaml context.
+	ctx.Endpoint = resolveEndpoint(Globals.Endpoint, os.Getenv("WOODPECKER_ENDPOINT"), ctx.Endpoint)
 	if Globals.AdminPort != 0 {
 		ctx.AdminPort = Globals.AdminPort
 	}
@@ -66,4 +66,21 @@ func resolveAndDiscover() (*resolved, error) {
 	}
 
 	return &resolved{Context: ctx, Client: c, Members: ml}, nil
+}
+
+// resolveEndpoint applies the wp endpoint precedence:
+// --endpoint flag > $WOODPECKER_ENDPOINT env > cli.yaml context.
+// It returns the first non-empty value in that order, or "" if all are empty
+// (which the caller reports as a usage error). Env is intentionally above
+// cli.yaml so the server images' baked-in WOODPECKER_ENDPOINT gives zero-config
+// in-pod ops; pass --endpoint to override from inside a pod.
+func resolveEndpoint(flagEndpoint, envEndpoint, ctxEndpoint string) string {
+	switch {
+	case flagEndpoint != "":
+		return flagEndpoint
+	case envEndpoint != "":
+		return envEndpoint
+	default:
+		return ctxEndpoint
+	}
 }

--- a/cmd/wpcli/cmd/resolver_test.go
+++ b/cmd/wpcli/cmd/resolver_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEndpoint(t *testing.T) {
+	const flag, env, ctx = "http://flag:9091", "http://env:9091", "http://ctx:9091"
+	tests := []struct {
+		name           string
+		flag, env, ctx string
+		want           string
+	}{
+		{"flag beats env and ctx", flag, env, ctx, flag},
+		{"flag beats env (no ctx)", flag, env, "", flag},
+		{"flag beats ctx (no env)", flag, "", ctx, flag},
+		{"flag only", flag, "", "", flag},
+		{"env beats ctx (no flag)", "", env, ctx, env},
+		{"env only", "", env, "", env},
+		{"ctx only", "", "", ctx, ctx},
+		{"all empty -> empty", "", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, resolveEndpoint(tt.flag, tt.env, tt.ctx))
+		})
+	}
+}

--- a/docs/admin-guides/wpcli/configuration.md
+++ b/docs/admin-guides/wpcli/configuration.md
@@ -87,9 +87,16 @@ defaults:
 Values are resolved in this order (highest priority first):
 
 1. **Command-line flags** (`--endpoint`, `--timeout`, etc.)
-2. **Environment variables** (`$WOODPECKER_CLI_CONFIG`)
+2. **Environment variables** — `$WOODPECKER_ENDPOINT` (the admin endpoint;
+   overrides the cli.yaml context); `$WOODPECKER_CLI_CONFIG` (selects which
+   `cli.yaml` to load)
 3. **cli.yaml context** (the active context)
 4. **Hardcoded defaults** (admin_port=9091, timeout=30s, etc.)
+
+> Server images set `WOODPECKER_ENDPOINT=http://localhost:9091`, so `wp` runs
+> zero-config inside a pod. Because env beats the cli.yaml context, this also
+> overrides a `cli.yaml` mounted into the pod — pass `--endpoint` to target a
+> different cluster from in-pod.
 
 ## Flag-to-config mapping
 

--- a/docs/superpowers/plans/2026-06-17-bundle-wpcli-in-images.md
+++ b/docs/superpowers/plans/2026-06-17-bundle-wpcli-in-images.md
@@ -1,0 +1,309 @@
+# Bundle `wp` into server images — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. (This plan is being executed via the user-requested Workflow orchestration; the task boundaries below map 1:1 to the workflow's parallel stages.)
+
+**Goal:** Make `wp` a first-class, zero-config in-pod tool across all four Woodpecker server images, and implement the `WOODPECKER_ENDPOINT` env var.
+
+**Architecture:** Three independent, disjoint-file deliverables — (1) a Go env-fallback in `cmd/wpcli/cmd/resolver.go` with a pure, unit-tested helper; (2) consistent Dockerfile edits across all four server images (COPY `wp`, symlink onto `PATH`, set `ENV`); (3) doc reconciliation. No build-pipeline change (`bin/wp` already produced).
+
+**Tech Stack:** Go (cobra CLI, `testify/require`), Docker (multi-stage server images), Markdown docs.
+
+## Global Constraints
+
+- **Endpoint precedence (verbatim):** `--endpoint flag > $WOODPECKER_ENDPOINT > cli.yaml context > defaults`. Env is **above** cli.yaml. This diverges from issue #187 (which proposed env lowest) per maintainer decision.
+- **In-pod default endpoint:** `http://localhost:9091` (admin HTTP API; `METRICS_PORT` defaults to 9091, unset in images).
+- **Scope:** Only `WOODPECKER_ENDPOINT` is implemented at the value level. Do **not** wire other env vars.
+- **Four server images only:** `build/docker/{ubuntu20.04,ubuntu22.04,amazonlinux2023,rockylinux8}/Dockerfile`. Do **not** touch `deployments/operator/Dockerfile` or `tests/upgrade/Dockerfile.writer`.
+- **Commit style:** conventional commits; end messages with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Implement `WOODPECKER_ENDPOINT` env fallback (Go)
+
+**Files:**
+- Modify: `cmd/wpcli/cmd/resolver.go` (imports; step 2 of `resolveAndDiscover`; add helper)
+- Test: `cmd/wpcli/cmd/resolver_test.go` (create)
+
+**Interfaces:**
+- Produces: `func resolveEndpoint(flagEndpoint, envEndpoint, ctxEndpoint string) string` — returns the first non-empty of (flag, env, ctx) in that order; `""` if all empty.
+
+- [ ] **Step 1: Write the failing test** — create `cmd/wpcli/cmd/resolver_test.go`:
+
+```go
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveEndpoint(t *testing.T) {
+	const flag, env, ctx = "http://flag:9091", "http://env:9091", "http://ctx:9091"
+	tests := []struct {
+		name             string
+		flag, env, ctx   string
+		want             string
+	}{
+		{"flag beats env and ctx", flag, env, ctx, flag},
+		{"flag beats env (no ctx)", flag, env, "", flag},
+		{"flag beats ctx (no env)", flag, "", ctx, flag},
+		{"flag only", flag, "", "", flag},
+		{"env beats ctx (no flag)", "", env, ctx, env},
+		{"env only", "", env, "", env},
+		{"ctx only", "", "", ctx, ctx},
+		{"all empty -> empty", "", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, resolveEndpoint(tt.flag, tt.env, tt.ctx))
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./cmd/wpcli/cmd/ -run TestResolveEndpoint`
+Expected: FAIL — `undefined: resolveEndpoint`.
+
+- [ ] **Step 3: Add the `"os"` import** to `cmd/wpcli/cmd/resolver.go`:
+
+```go
+import (
+	"fmt"
+	"os"
+
+	"github.com/zilliztech/woodpecker/cmd/wpcli/client"
+	"github.com/zilliztech/woodpecker/cmd/wpcli/config"
+	wperrors "github.com/zilliztech/woodpecker/cmd/wpcli/internal/errors"
+)
+```
+
+- [ ] **Step 4: Replace the endpoint flag-override block.** In `resolveAndDiscover`, replace:
+
+```go
+	// 2. Flag / env overrides on top of context.
+	if Globals.Endpoint != "" {
+		ctx.Endpoint = Globals.Endpoint
+	}
+```
+
+with:
+
+```go
+	// 2. Flag / env overrides on top of context.
+	// Endpoint precedence: --endpoint flag > $WOODPECKER_ENDPOINT > cli.yaml context.
+	ctx.Endpoint = resolveEndpoint(Globals.Endpoint, os.Getenv("WOODPECKER_ENDPOINT"), ctx.Endpoint)
+```
+
+- [ ] **Step 5: Add the helper** at the end of `cmd/wpcli/cmd/resolver.go`:
+
+```go
+// resolveEndpoint applies the wp endpoint precedence:
+// --endpoint flag > $WOODPECKER_ENDPOINT env > cli.yaml context.
+// It returns the first non-empty value in that order, or "" if all are empty
+// (which the caller reports as a usage error). Env is intentionally above
+// cli.yaml so the server images' baked-in WOODPECKER_ENDPOINT gives zero-config
+// in-pod ops; pass --endpoint to override from inside a pod.
+func resolveEndpoint(flagEndpoint, envEndpoint, ctxEndpoint string) string {
+	switch {
+	case flagEndpoint != "":
+		return flagEndpoint
+	case envEndpoint != "":
+		return envEndpoint
+	default:
+		return ctxEndpoint
+	}
+}
+```
+
+- [ ] **Step 6: Run tests + build to verify pass**
+
+Run: `go test ./cmd/wpcli/... && go build ./...`
+Expected: PASS; build clean.
+
+- [ ] **Step 7: Lint changed file**
+
+Run: `golangci-lint run cmd/wpcli/cmd/...` (skip gracefully if not installed)
+Expected: no new findings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/wpcli/cmd/resolver.go cmd/wpcli/cmd/resolver_test.go
+git commit -m "feat(wpcli): read WOODPECKER_ENDPOINT as endpoint fallback (#187)"
+```
+
+---
+
+### Task 2: Bundle `wp` in all four server images
+
+**Files (all Modify):**
+- `build/docker/ubuntu20.04/Dockerfile`
+- `build/docker/ubuntu22.04/Dockerfile` (already has the COPY — add symlink + ENV only)
+- `build/docker/amazonlinux2023/Dockerfile`
+- `build/docker/rockylinux8/Dockerfile`
+
+**Interfaces:** none (image config). Deliverable: every image contains the `wp` COPY, the `/usr/local/bin/wp` symlink, and `ENV WOODPECKER_ENDPOINT=http://localhost:9091`.
+
+- [ ] **Step 1: ubuntu20.04 / amazonlinux2023 / rockylinux8 — add COPY + symlink.** After the line `COPY --chmod=755 ./bin/woodpecker /woodpecker/bin/woodpecker`, insert:
+
+```dockerfile
+
+# Copy wp CLI binary (operational CLI; bundled for zero-config in-pod ops)
+COPY --chmod=755 ./bin/wp /woodpecker/bin/wp
+
+# Put wp on PATH so `wp ...` works from any directory in the pod
+RUN ln -sf /woodpecker/bin/wp /usr/local/bin/wp
+```
+
+- [ ] **Step 2: ubuntu22.04 — add symlink only** (COPY already present at the `# Copy wp CLI binary` block). Immediately after `COPY --chmod=755 ./bin/wp /woodpecker/bin/wp`, insert:
+
+```dockerfile
+
+# Put wp on PATH so `wp ...` works from any directory in the pod
+RUN ln -sf /woodpecker/bin/wp /usr/local/bin/wp
+```
+
+- [ ] **Step 3: All four — add the ENV.** In each `ENV` block, change the final line `    SERVICE_SEEDS=""` to:
+
+```dockerfile
+    SERVICE_SEEDS="" \
+    WOODPECKER_ENDPOINT="http://localhost:9091"
+```
+
+- [ ] **Step 4: Consistency check**
+
+Run:
+```bash
+for d in ubuntu20.04 ubuntu22.04 amazonlinux2023 rockylinux8; do
+  f=build/docker/$d/Dockerfile
+  echo "== $d =="
+  grep -c 'COPY --chmod=755 ./bin/wp /woodpecker/bin/wp' "$f"
+  grep -c 'ln -sf /woodpecker/bin/wp /usr/local/bin/wp' "$f"
+  grep -c 'WOODPECKER_ENDPOINT="http://localhost:9091"' "$f"
+done
+```
+Expected: each count is exactly `1` for all four images.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add build/docker/*/Dockerfile
+git commit -m "enhance(docker): bundle wp in all server images, on PATH, zero-config endpoint (#187)"
+```
+
+---
+
+### Task 3: Reconcile docs
+
+**Files (all Modify):**
+- `cmd/wpcli/README.md`
+- `docs/admin-guides/wpcli/configuration.md`
+- `docs/wip/wpcli/wpcli-design.md`
+
+- [ ] **Step 1: `cmd/wpcli/README.md` — add an in-pod section** after the `## Quick start` block (after the line linking quickstart.md):
+
+```markdown
+
+## In-pod usage (zero-config)
+
+`wp` is bundled in all server images and is on `PATH`, so you can operate a
+cluster straight from a server pod with nothing to install:
+
+```bash
+kubectl exec -it <woodpecker-pod> -- wp cluster info
+kubectl exec -it <woodpecker-pod> -- wp node list
+```
+
+This works with no flags because the images set
+`WOODPECKER_ENDPOINT=http://localhost:9091` and the admin HTTP API listens on
+`9091` inside the container.
+
+### Endpoint precedence
+
+`wp` resolves the admin endpoint in this order (highest priority first):
+
+1. `--endpoint <url>` flag
+2. `$WOODPECKER_ENDPOINT`
+3. `cli.yaml` active context
+
+Because `$WOODPECKER_ENDPOINT` is baked into the server images, a `cli.yaml`
+mounted into a pod is overridden by it; pass `--endpoint` to target a different
+cluster from inside a pod.
+```
+
+- [ ] **Step 2: `docs/admin-guides/wpcli/configuration.md` — update §Precedence.** Replace item 2 line `2. **Environment variables** (`$WOODPECKER_CLI_CONFIG`)` with:
+
+```markdown
+2. **Environment variables** — `$WOODPECKER_ENDPOINT` (the admin endpoint;
+   overrides the cli.yaml context); `$WOODPECKER_CLI_CONFIG` (selects which
+   `cli.yaml` to load)
+```
+
+Then add, immediately after the precedence list (after the `4. **Hardcoded defaults**` line):
+
+```markdown
+
+> Server images set `WOODPECKER_ENDPOINT=http://localhost:9091`, so `wp` runs
+> zero-config inside a pod. Because env beats the cli.yaml context, this also
+> overrides a `cli.yaml` mounted into the pod — pass `--endpoint` to target a
+> different cluster from in-pod.
+```
+
+- [ ] **Step 3: `docs/wip/wpcli/wpcli-design.md` — annotate §3.2.** Immediately after the flag/env/context mapping table (after the `-v, --verbose` row), add:
+
+```markdown
+
+> **Note (#187):** `WOODPECKER_ENDPOINT` is implemented in
+> `cmd/wpcli/cmd/resolver.go` and is the zero-config in-pod default — all server
+> images set `WOODPECKER_ENDPOINT=http://localhost:9091`. Per the chain above it
+> sits above the cli.yaml context, so it overrides a pod-mounted `cli.yaml`.
+```
+
+- [ ] **Step 4: Sanity check** the three edits land:
+
+Run:
+```bash
+grep -c 'In-pod usage' cmd/wpcli/README.md
+grep -c 'WOODPECKER_ENDPOINT' docs/admin-guides/wpcli/configuration.md
+grep -c 'Note (#187)' docs/wip/wpcli/wpcli-design.md
+```
+Expected: `1` each.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/wpcli/README.md docs/admin-guides/wpcli/configuration.md docs/wip/wpcli/wpcli-design.md
+git commit -m "docs(wpcli): document in-pod wp usage and WOODPECKER_ENDPOINT precedence (#187)"
+```
+
+---
+
+### Task 4: Final verification (cross-cutting)
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Build + test + vet**
+
+Run: `go build ./... && go test ./cmd/wpcli/... && go vet ./cmd/wpcli/...`
+Expected: all clean/PASS.
+
+- [ ] **Step 2: Lint**
+
+Run: `golangci-lint run cmd/wpcli/cmd/...` (skip gracefully if not installed)
+Expected: no new findings.
+
+- [ ] **Step 3: Dockerfile consistency** — rerun Task 2 Step 4; expect `1` for all four.
+
+- [ ] **Step 4: Optional real image build** (only if Docker available + `bin/wp` built):
+
+Run: `make build-linux && docker build -f build/docker/ubuntu22.04/Dockerfile -t wp-check:local . && docker run --rm --entrypoint wp wp-check:local version`
+Expected: `wp` resolves on PATH and prints its version. (Skip if Docker unavailable.)
+
+## Self-Review
+
+- **Spec coverage:** Dockerfile COPY+PATH+ENV → Task 2; `WOODPECKER_ENDPOINT` Go + precedence + unit test → Task 1; docs (README + configuration.md + design §3.2) → Task 3; verification → Task 4. All spec sections covered.
+- **Placeholder scan:** none — every step has concrete code/commands.
+- **Type consistency:** `resolveEndpoint(flagEndpoint, envEndpoint, ctxEndpoint string) string` is defined in Task 1 Step 5 and called identically in Task 1 Step 4 and tested in Task 1 Step 1. Argument order (flag, env, ctx) matches the precedence everywhere.

--- a/docs/superpowers/specs/2026-06-17-bundle-wpcli-in-images-design.md
+++ b/docs/superpowers/specs/2026-06-17-bundle-wpcli-in-images-design.md
@@ -1,0 +1,129 @@
+# Bundle `wp` (wpcli) into server images for zero-config in-pod ops
+
+- **Issue:** [zilliztech/woodpecker#187](https://github.com/zilliztech/woodpecker/issues/187)
+- **Date:** 2026-06-17
+- **Status:** Approved design, ready for implementation plan
+
+## Problem
+
+`wp` (the Woodpecker operational CLI, `cmd/wpcli/`) is how we operate service-mode
+clusters (`wp node`, `wp cluster`, `wp logstore`, `wp metrics`, …). Today it ships
+only as standalone release binaries, so an operator must download/install the right
+arch binary and point it at the cluster. The in-image plumbing is half-done:
+
+1. **Inconsistent packaging.** `make build-linux` / `build-linux-arm64`
+   (`Makefile:171-178`) already build `bin/wp` (static, `CGO_ENABLED=0`, with version
+   ldflags) for both arches, and `build/build_bin.sh:102-107` asserts it exists — so
+   `bin/wp` is always present at COPY time. Yet only `build/docker/ubuntu22.04/Dockerfile`
+   copies it in; `ubuntu20.04`, `amazonlinux2023`, and `rockylinux8` do not.
+2. **Not on `PATH`.** Where present it lives at `/woodpecker/bin/wp` (WORKDIR
+   `/woodpecker`), so an operator must type `bin/wp …` or a full path.
+3. **Not zero-config in-pod.** `wp` resolves its endpoint from `--endpoint`, a
+   `cli.yaml` context, or — per the error string at `cmd/wpcli/cmd/resolver.go:55` —
+   `$WOODPECKER_ENDPOINT`. But `WOODPECKER_ENDPOINT` is **advertised yet never read**
+   anywhere in `cmd/wpcli/`, so every in-pod command needs `--endpoint http://localhost:9091`.
+
+The natural in-pod endpoint is `http://localhost:9091`: the admin HTTP API is served by
+`commonhttp.Start` on `METRICS_PORT`, which defaults to `9091`
+(`common/http/server.go:70-71`); the server images don't set `METRICS_PORT`, so the
+server listens on 9091 inside the container.
+
+## Goals
+
+- `kubectl exec -it <woodpecker-pod> -- wp cluster info` (and `wp node list`, …) work
+  with nothing to install and no flags, across **all four** server images.
+- External/binary usage (`wp` on a laptop against a remote cluster) is unaffected and
+  still errors loudly when no target is configured.
+- All four server Dockerfiles are consistent.
+- Docs accurately describe the in-pod experience and the endpoint precedence.
+
+## Non-Goals
+
+- **No build-pipeline change.** `bin/wp` is already produced for both arches.
+- **Standalone `release-wpcli.yaml` flow stays as-is.**
+- **Operator image** (`deployments/operator/Dockerfile`) and the upgrade-test writer
+  image (`tests/upgrade/Dockerfile.writer`) do not get `wp` — different components.
+- **Only `WOODPECKER_ENDPOINT`** is implemented at the value level. Other env vars in
+  the design-doc table (`WOODPECKER_CONTEXT`, `WOODPECKER_ADMIN_PORT`, …) are out of
+  scope and remain unimplemented.
+
+## Key decision — endpoint precedence (diverges from the issue)
+
+The issue proposes `--endpoint > cli.yaml > $WOODPECKER_ENDPOINT` (env **lowest**).
+Per maintainer decision we instead implement:
+
+```
+--endpoint flag  >  $WOODPECKER_ENDPOINT  >  cli.yaml context  >  defaults
+```
+
+i.e. **env above cli.yaml**, matching the precedence already documented in
+`docs/wip/wpcli/wpcli-design.md` §3.2 (`flag > env > context > defaults`) and
+`docs/admin-guides/wpcli/configuration.md` §Precedence. Choosing this keeps the
+existing docs consistent rather than introducing a per-variable special case.
+
+**Consequence (must be documented):** the image-baked `ENV
+WOODPECKER_ENDPOINT=http://localhost:9091` will override a `cli.yaml` *mounted into the
+pod*. To target a different endpoint in-pod, use `--endpoint` (highest priority). This
+is an intentional divergence from the issue text and will be called out in the PR.
+
+**Why this still satisfies all goals:**
+- In-pod, zero config: no flag, no user env → image `ENV` provides `localhost:9091`. ✓
+- On a laptop: the image `ENV` is not present, so behavior is unchanged; a user who
+  sets `WOODPECKER_ENDPOINT` themselves gets the documented override. ✓
+- Downstream tolerates the otherwise-empty context: `client.New` defaults `Timeout`→30s
+  and treats `AdminPort==0` as "extract from seed"; `cmd/wpcli/client/fanout.go:26-29`
+  defaults `Concurrency`→8 and `Timeout`→30s. So endpoint is the only wiring needed.
+
+## Design
+
+### A. Dockerfiles — make all four consistent
+For `ubuntu20.04`, `ubuntu22.04`, `amazonlinux2023`, `rockylinux8`:
+1. `COPY --chmod=755 ./bin/wp /woodpecker/bin/wp` — add to the three missing it
+   (ubuntu22.04 already has it), right after the `woodpecker` COPY.
+2. `RUN ln -sf /woodpecker/bin/wp /usr/local/bin/wp` — add to all four, after the COPY,
+   so `wp` is on `PATH` from any directory.
+3. Append `WOODPECKER_ENDPOINT="http://localhost:9091"` to the existing `ENV` block in
+   all four (matching the quoted style already used).
+
+### B. Go — `cmd/wpcli/cmd/resolver.go`
+- Add a pure helper:
+  ```go
+  // resolveEndpoint applies endpoint precedence:
+  // --endpoint flag > $WOODPECKER_ENDPOINT > cli.yaml context.
+  func resolveEndpoint(flagEndpoint, envEndpoint, ctxEndpoint string) string
+  ```
+- In `resolveAndDiscover`, replace the endpoint flag-override block with
+  `ctx.Endpoint = resolveEndpoint(Globals.Endpoint, os.Getenv("WOODPECKER_ENDPOINT"), ctx.Endpoint)`
+  (where `ctx.Endpoint` is the cli.yaml-loaded value). Add the `"os"` import. Leave the
+  `AdminPort`/`Timeout`/`Concurrency`/`Strict` overrides unchanged.
+
+### C. Test — `cmd/wpcli/cmd/resolver_test.go` (new)
+- Table-driven unit test of `resolveEndpoint` proving precedence across every
+  flag/env/ctx combination (flag wins; else env; else ctx; else empty), `testify/require`
+  style consistent with `cmd/wpcli/cmd/*_test.go`.
+
+### D. Docs (all three)
+- `cmd/wpcli/README.md`: add an "In-pod usage" note (`kubectl exec … -- wp cluster info`,
+  zero-config, bundled in all server images) and the `WOODPECKER_ENDPOINT` precedence.
+- `docs/admin-guides/wpcli/configuration.md`: extend §Precedence item 2 to name
+  `WOODPECKER_ENDPOINT` (value-level, overrides cli.yaml) and document the in-pod default.
+- `docs/wip/wpcli/wpcli-design.md` §3.2: note `WOODPECKER_ENDPOINT` is now implemented
+  and is the in-pod default via the image `ENV` (the chain already reads `flag > env >
+  context`).
+
+## Verification
+
+- `go build ./...` clean.
+- `go test ./cmd/wpcli/...` passes (incl. the new `resolveEndpoint` test).
+- `golangci-lint run` clean on changed Go files.
+- Cross-Dockerfile consistency: all four contain the `wp` COPY, the `ln` to
+  `/usr/local/bin/wp`, and the `WOODPECKER_ENDPOINT` ENV.
+- Docs accurately state `flag > env > cli.yaml`.
+
+## Execution
+
+- Branch: `enhance/issue-187-bundle-wpcli-in-images`.
+- Implement via a workflow: parallel edits of independent file-groups (Go+test / four
+  Dockerfiles / docs) → verify phase (build, test, lint, Dockerfile-consistency,
+  docs-accuracy) → adversarial review of the precedence logic.
+- Then code review → PR (explicitly noting the deliberate precedence divergence from #187).

--- a/docs/wip/wpcli/wpcli-design.md
+++ b/docs/wip/wpcli/wpcli-design.md
@@ -971,6 +971,11 @@ cmdline flag  >  env var  >  current context field  >  defaults section  >  buil
 | `--no-color` | `NO_COLOR` | `defaults.no_color` | auto-detect tty |
 | `-v, --verbose` | `WOODPECKER_VERBOSE` | — | `0` |
 
+> **Note (#187):** `WOODPECKER_ENDPOINT` is implemented in
+> `cmd/wpcli/cmd/resolver.go` and is the zero-config in-pod default — all server
+> images set `WOODPECKER_ENDPOINT=http://localhost:9091`. Per the chain above it
+> sits above the cli.yaml context, so it overrides a pod-mounted `cli.yaml`.
+
 ### 3.3 Global flags
 
 ```


### PR DESCRIPTION
## What

Make `wp` (the operational CLI, `cmd/wpcli/`) a first-class, **zero-config** tool inside the server pods, and finish the half-done in-image plumbing. Closes #187.

Works in any server pod with nothing to install and no flags:

```bash
kubectl exec -it <woodpecker-pod> -- wp cluster info
kubectl exec -it <woodpecker-pod> -- wp node list
```

## Changes

- **All four server images** (`ubuntu20.04`, `ubuntu22.04`, `amazonlinux2023`, `rockylinux8`) now:
  - `COPY` `bin/wp` (added to the three that lacked it; `ubuntu22.04` already had it),
  - symlink it onto `PATH` (`ln -sf /woodpecker/bin/wp /usr/local/bin/wp`),
  - set `ENV WOODPECKER_ENDPOINT=http://localhost:9091`.
- **`cmd/wpcli/cmd/resolver.go`**: implement the previously advertised-but-unread `WOODPECKER_ENDPOINT` via a pure, unit-tested `resolveEndpoint(flag, env, ctx)` helper.
- **Docs**: README "In-pod usage" section + `configuration.md` precedence + `wpcli-design.md` §3.2 note.

No build-pipeline change — `bin/wp` is already produced (static, both arches).

## ⚠️ Deliberate divergence from the issue — endpoint precedence

The issue proposed env **lowest** (`--endpoint > cli.yaml > $WOODPECKER_ENDPOINT`). Per maintainer decision this PR instead uses:

```
--endpoint flag > $WOODPECKER_ENDPOINT > cli.yaml context > defaults
```

i.e. **env above cli.yaml**, matching the precedence already documented in `wpcli-design.md` §3.2 and `configuration.md` (keeps the docs consistent rather than introducing a per-variable special case).

**Consequence:** the image-baked `WOODPECKER_ENDPOINT` overrides a `cli.yaml` *mounted into a pod*; pass `--endpoint` to target a different cluster from in-pod. Laptop usage is unaffected (the env is only set inside the image).

## Verification

- `go build ./...`, `go vet ./cmd/wpcli/...` clean; `go test ./cmd/wpcli/...` green; new `TestResolveEndpoint` covers all 8 flag/env/ctx combinations.
- `golangci-lint run cmd/wpcli/cmd/...` → 0 issues.
- All four Dockerfiles consistent (COPY + symlink + ENV).
- **End-to-end docker smoke** (built `ubuntu22.04` image): `wp` resolves on `PATH`; `wp cluster info` with no flags/config dialed `http://localhost:9091` from the baked-in env (connection refused, as expected with no server) — confirming zero-config resolution.

## Out of scope

- Operator image (`deployments/operator/Dockerfile`) and the upgrade-test writer image.
- The standalone `release-wpcli.yaml` flow (unchanged).
- Other env vars from the design-doc table (only `WOODPECKER_ENDPOINT` is implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
