### PR TITLE
fix(objectstorage): silence idle-spin DEBUG logs in MinioFileWriter sync loop

### DIFF
--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -107,6 +107,22 @@ func globalLogger() *zap.Logger {
 	return _globalLogger.Load().(*zap.Logger)
 }
 
+// ReplaceGlobals swaps the global logger for l and returns a function that
+// restores the previous logger.
+//
+// FOR TESTS ONLY. It exists so tests can capture log output (e.g. via a
+// zaptest/observer core), since Ctx/WithFields always derive from the global
+// logger. Do not call this from production code.
+func ReplaceGlobals(l *zap.Logger) func() {
+	prev := _globalLogger.Load()
+	_globalLogger.Store(l)
+	return func() {
+		if prev != nil {
+			_globalLogger.Store(prev.(*zap.Logger))
+		}
+	}
+}
+
 func Ctx(ctx context.Context) *zap.Logger {
 	if ctx == nil {
 		return globalLogger()

--- a/server/storage/objectstorage/writer_impl.go
+++ b/server/storage/objectstorage/writer_impl.go
@@ -806,21 +806,27 @@ func (f *MinioFileWriter) waitIfFlushingBufferSizeExceededUnsafe(ctx context.Con
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, SegmentWriterScope, "waitIfFlushingBufferSizeExceededUnsafe")
 	defer sp.End()
 	startTime := time.Now()
-	logger.Ctx(ctx).Debug("waitIfFlushingBufferSizeExceededUnsafe: checking flushing buffer size", zap.String("segmentFileKey", f.segmentFileKey))
 	// Check if current flushing buffer size exceeds the maximum allowed buffer size
+	waited := false
 	for {
 		currentFlushingSize := f.flushingBufferSize.Load()
 		if currentFlushingSize < f.maxBufferSize {
-			// Safe to proceed, flushing buffer size is within limits
-			logger.Ctx(ctx).Debug("Flushing buffer size check passed",
-				zap.String("segmentFileKey", f.segmentFileKey),
-				zap.Int64("currentFlushingSize", currentFlushingSize),
-				zap.Int64("maxBufferSize", f.maxBufferSize),
-				zap.Int64("elapsedTime", time.Since(startTime).Milliseconds()))
+			// Safe to proceed, flushing buffer size is within limits. Only log when we
+			// actually had to wait for space (backpressure, a rare and notable event);
+			// the common no-wait path runs on every periodic sync and must stay silent
+			// to avoid idle-spin logging (issue #189).
+			if waited {
+				logger.Ctx(ctx).Debug("Flushing buffer size check passed after waiting",
+					zap.String("segmentFileKey", f.segmentFileKey),
+					zap.Int64("currentFlushingSize", currentFlushingSize),
+					zap.Int64("maxBufferSize", f.maxBufferSize),
+					zap.Int64("elapsedTime", time.Since(startTime).Milliseconds()))
+			}
 			return nil
 		}
 
 		// Flushing buffer size exceeded, need to wait
+		waited = true
 		logger.Ctx(ctx).Debug("Flushing buffer size exceeded, waiting for space",
 			zap.String("segmentFileKey", f.segmentFileKey),
 			zap.Int64("currentFlushingSize", currentFlushingSize),
@@ -1026,7 +1032,8 @@ func (f *MinioFileWriter) Sync(ctx context.Context) (retErr error) {
 		return err
 	}
 	if len(toFlushData) == 0 {
-		logger.Ctx(ctx).Debug("Sync skipped: no data to flush", zap.String("segmentFileKey", f.segmentFileKey), zap.String("bufInst", fmt.Sprintf("%p", currentBuffer)))
+		// idle path: nothing to flush this cycle — return silently instead of
+		// logging on every periodic sync (issue #189).
 		return nil
 	}
 
@@ -1066,18 +1073,17 @@ func (f *MinioFileWriter) rollBufferUnsafe(ctx context.Context) (*cache.Sequenti
 	// get current buffer
 	currentBuffer := f.buffer.Load()
 
-	logger.Ctx(ctx).Debug("start roll buffer", zap.String("segmentFileKey", f.segmentFileKey), zap.String("bufInst", fmt.Sprintf("%p", currentBuffer)))
-
 	// check if there are any entries to be written
 	entryCount := len(currentBuffer.Entries)
 	if entryCount == 0 {
-		logger.Ctx(ctx).Debug("Sync skipped: buffer is empty", zap.String("segmentFileKey", f.segmentFileKey), zap.String("bufInst", fmt.Sprintf("%p", currentBuffer)))
+		// idle path: nothing buffered since the last flush — return silently
+		// instead of logging on every periodic sync (issue #189).
 		return currentBuffer, make([]*cache.BufferEntry, 0), -1, nil
 	}
 	expectedNextEntryId := currentBuffer.ExpectedNextEntryId.Load()
 	// get flush point to flush
 	if expectedNextEntryId-currentBuffer.FirstEntryId == 0 {
-		logger.Ctx(ctx).Debug("Sync skipped: buffer is empty", zap.String("segmentFileKey", f.segmentFileKey), zap.String("bufInst", fmt.Sprintf("%p", currentBuffer)))
+		// idle path: no new sequentially-ready entries to flush — return silently (issue #189).
 		return currentBuffer, make([]*cache.BufferEntry, 0), -1, nil
 	}
 	// get flush data

--- a/server/storage/objectstorage/writer_impl_test.go
+++ b/server/storage/objectstorage/writer_impl_test.go
@@ -29,10 +29,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/zilliztech/woodpecker/common/channel"
 	"github.com/zilliztech/woodpecker/common/conc"
 	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/logger"
 	"github.com/zilliztech/woodpecker/common/metrics"
 	minioHandler "github.com/zilliztech/woodpecker/common/minio"
 	commonObjectStorage "github.com/zilliztech/woodpecker/common/objectstorage"
@@ -1140,6 +1144,31 @@ func TestMinioFileWriter_Sync_EmptyBuffer(t *testing.T) {
 
 	err := w.Sync(ctx)
 	assert.NoError(t, err)
+}
+
+// TestMinioFileWriter_Sync_EmptyBuffer_EmitsNoDebugLogs verifies that a periodic
+// sync over an idle writer (empty buffer, nothing appended since the last flush)
+// produces NO debug log lines. The periodic ticker calls Sync on every interval
+// regardless of whether anything was written; on the idle path it must stay
+// silent instead of emitting per-tick "no data to flush" noise (issue #189).
+func TestMinioFileWriter_Sync_EmptyBuffer_EmitsNoDebugLogs(t *testing.T) {
+	core, recorded := observer.New(zapcore.DebugLevel)
+	restore := logger.ReplaceGlobals(zap.New(core))
+	defer restore()
+
+	ctx := context.Background()
+	w := newTestMinioFileWriter() // empty buffer, nothing appended
+
+	err := w.Sync(ctx)
+	assert.NoError(t, err)
+
+	debugLines := make([]string, 0)
+	for _, e := range recorded.All() {
+		if e.Level == zapcore.DebugLevel {
+			debugLines = append(debugLines, e.Message)
+		}
+	}
+	assert.Empty(t, debugLines, "idle Sync (empty buffer) must not emit debug logs, got: %v", debugLines)
 }
 
 // ===== Compact tests =====


### PR DESCRIPTION
## What

Stop `MinioFileWriter` (object-storage segment writer) from emitting DEBUG logs on idle periodic syncs.

Fixes #189.

## Why

The writer's periodic ticker calls `Sync()` every `maxInterval` (default **200ms**) regardless of whether anything was appended. On the idle path it unconditionally emitted **5 no-op DEBUG lines per tick (~25 lines/sec per segment writer)**, which dominates log volume at scale — milvus-io/milvus#48976 reports **~9M DEBUG lines / 3GB+ per streamingnode** during normal E2E runs, with these messages as the top sources.

The sibling writers already do the right thing and stay silent when idle: `LocalFileWriter` (disk) guards on `needSync`, `StagedFileWriter` (service) guards on `hasSyncableEntries()`. Only `MinioFileWriter` lacked the guard. This PR brings it to parity.

## What changed

`server/storage/objectstorage/writer_impl.go` — gate the 5 no-op DEBUG sites:

| site | before | after |
|---|---|---|
| `waitIfFlushingBufferSizeExceededUnsafe` entry | `checking flushing buffer size` (every call) | removed |
| `waitIfFlushingBufferSizeExceededUnsafe` pass | `Flushing buffer size check passed` (every call) | only logged after an actual wait (backpressure) |
| `rollBufferUnsafe` | early `start roll buffer` | removed (redundant with the data-carrying one) |
| `rollBufferUnsafe` | `Sync skipped: buffer is empty` ×2 | removed |
| `Sync` | `Sync skipped: no data to flush` | removed |

The real flush-chain logs (`Sync start/submitted flush tasks`, the data-carrying `start roll buffer` with counts, per-block flush logs, and the backpressure `Flushing buffer size exceeded, waiting for space`) are **all preserved** — "one write → full debug chain" is unchanged.

`common/logger/logger.go` — adds `ReplaceGlobals(l) func()`, a small test seam (mirrors `zap.ReplaceGlobals`) so tests can capture log output via a `zaptest/observer` core.

## Tests / verification

- **New unit test** `TestMinioFileWriter_Sync_EmptyBuffer_EmitsNoDebugLogs` (deterministic, no minio/etcd): asserts an idle `Sync()` over an empty buffer emits **0** DEBUG lines. Written test-first — it fails before the change (5 idle-spin lines) and passes after.
- **Integration reproduction** (writer kept open, 8s idle, 0 writes, `log.level: debug`): ObjectStorage idle-window writer DEBUG lines **195 → 0**, while the active write burst still logs the full flush chain. `local`/`service` modes were already 0 and are unaffected.
- `go test ./server/storage/objectstorage/...` and `./common/logger/...` pass; `go build ./...`, `go vet`, `gofmt` clean.

## Notes

- `logger.Ctx()` returns a plain `*zap.Logger` (no Trace level), so the no-op logs are removed/gated rather than downgraded.
- The read-path logging (`reader_impl.go` per-block verbosity + idle tail-read poll) is tracked separately in #190 and intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
