### PR TITLE
fix: cut read-path DEBUG log volume (per-read verbosity + idle tail-read spin)

### DIFF
--- a/server/processor/segment_processor.go
+++ b/server/processor/segment_processor.go
@@ -217,7 +217,6 @@ func (s *segmentProcessor) ReadBatchEntriesAdv(ctx context.Context, fromEntryId 
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, ProcessorScopeName, "ReadBatchEntries")
 	defer sp.End()
 	s.updateAccessTime()
-	logger.Ctx(ctx).Debug("segment processor read batch entries", zap.Int64("logId", s.logId), zap.Int64("segId", s.segId), zap.Int64("fromEntryId", fromEntryId), zap.Int64("maxEntries", maxEntries))
 	reader, err := s.getOrCreateSegmentReader(ctx)
 	if err != nil {
 		return nil, err
@@ -236,11 +235,11 @@ func (s *segmentProcessor) ReadBatchEntriesAdv(ctx context.Context, fromEntryId 
 		MaxBatchEntries: maxEntries,
 	}, lastState)
 	if err != nil {
-		if werr.ErrEntryNotFound.Is(err) {
-			logger.Ctx(ctx).Debug("failed to read entry", zap.Int64("logId", s.logId), zap.Int64("segId", s.segId), zap.Int64("fromEntryId", fromEntryId), zap.Error(err))
-		} else if werr.ErrFileReaderEndOfFile.Is(err) {
+		// ErrEntryNotFound is the steady-state of a caught-up tail reader; stay
+		// silent on it (issue #190) and only log genuine EOF/errors.
+		if werr.ErrFileReaderEndOfFile.Is(err) {
 			logger.Ctx(ctx).Info("failed to read entry", zap.Int64("logId", s.logId), zap.Int64("segId", s.segId), zap.Int64("fromEntryId", fromEntryId), zap.Error(err))
-		} else {
+		} else if !werr.ErrEntryNotFound.Is(err) {
 			logger.Ctx(ctx).Warn("failed to read entry", zap.Int64("logId", s.logId), zap.Int64("segId", s.segId), zap.Int64("fromEntryId", fromEntryId), zap.Error(err))
 		}
 		return nil, err

--- a/server/storage/objectstorage/reader_impl.go
+++ b/server/storage/objectstorage/reader_impl.go
@@ -126,8 +126,6 @@ type FooterAndIndex struct {
 func (f *MinioFileReaderAdv) readFooterAndIndexUnsafe(ctx context.Context) (*FooterAndIndex, error) {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, SegmentReaderScope, "readFooterAndIndexUnsafe")
 	defer sp.End()
-	logger.Ctx(ctx).Debug("reading footer and block indexes", zap.String("segmentFileKey", f.segmentFileKey))
-
 	// Check if footer.blk exists
 	footerKey := getFooterBlockKey(f.segmentFileKey)
 	statSize, _, err := f.client.StatObject(ctx, f.bucket, footerKey, f.nsStr, f.logIdStr)
@@ -237,8 +235,6 @@ func (f *MinioFileReaderAdv) readFooterAndIndexUnsafe(ctx context.Context) (*Foo
 func (f *MinioFileReaderAdv) tryReadFooterAndIndex(ctx context.Context) error {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, SegmentReaderScope, "tryReadFooterAndIndex")
 	defer sp.End()
-	logger.Ctx(ctx).Debug("try to read footer and block indexes", zap.String("segmentFileKey", f.segmentFileKey))
-
 	if f.isCompleted.Load() {
 		// already parse a footer
 		return nil
@@ -421,13 +417,6 @@ func (f *MinioFileReaderAdv) GetLastEntryID(ctx context.Context) (int64, error) 
 func (f *MinioFileReaderAdv) ReadNextBatchAdv(ctx context.Context, opt storage.ReaderOpt, lastReadBatchInfo *proto.LastReadState) (*proto.BatchReadResult, error) {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, SegmentReaderScope, "ReadNextBatchAdv")
 	defer sp.End()
-	logger.Ctx(ctx).Debug("ReadNextBatchAdv called",
-		zap.Int64("startEntryID", opt.StartEntryID),
-		zap.Int64("maxBatchEntries", opt.MaxBatchEntries),
-		zap.Bool("isCompacted", f.isCompacted.Load()),
-		zap.Any("opt", opt),
-		zap.Any("lastReadBatchInfo", lastReadBatchInfo))
-
 	lastReadState := lastReadBatchInfo
 	// apply adv options if possible
 	if lastReadState != nil {
@@ -532,8 +521,6 @@ func (f *MinioFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stora
 	defer sp.End()
 	startTime := time.Now()
 
-	logger.Ctx(ctx).Debug("read data blocks start", zap.String("segmentFileKey", f.segmentFileKey), zap.Int64("startBlockID", startBlockID), zap.Int64("startEntryId", opt.StartEntryID), zap.Int64("maxBatchEntries", opt.MaxBatchEntries))
-
 	maxEntries := opt.MaxBatchEntries // soft count limit: Read the minimum number of blocks exceeding the count limit
 	if maxEntries <= 0 {
 		maxEntries = 100
@@ -551,7 +538,7 @@ func (f *MinioFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stora
 	// Keep reading batches until we have data or reach end
 	for {
 		// 1. Read one batch of blocks (up to maxBytes)
-		batchFutures, nextBlockID, batchRawSize, hasMoreBlocks, readBlockBatchErr := f.readBlockBatchUnsafe(ctx, currentBlockID, maxBytes, opt.StartEntryID)
+		batchFutures, nextBlockID, _, hasMoreBlocks, readBlockBatchErr := f.readBlockBatchUnsafe(ctx, currentBlockID, maxBytes, opt.StartEntryID)
 
 		if readBlockBatchErr != nil {
 			hasDataReadError = true
@@ -561,14 +548,6 @@ func (f *MinioFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stora
 			// No blocks to read
 			break
 		}
-
-		logger.Ctx(ctx).Debug("submitted batch reading tasks",
-			zap.String("segmentFileKey", f.segmentFileKey),
-			zap.Int64("currentBlockID", currentBlockID),
-			zap.Int("batchTasks", len(batchFutures)),
-			zap.Int64("batchRawSize", batchRawSize),
-			zap.Bool("hasDataReadError", hasDataReadError),
-			zap.Bool("hasMoreBlocks", hasMoreBlocks))
 
 		// 2. Collect and process batch results
 		batchResults := make([]*BlockReadResult, 0, len(batchFutures))
@@ -607,13 +586,6 @@ func (f *MinioFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stora
 		allEntries = append(allEntries, batchEntries...)
 		totalReadBytes += batchReadBytes
 		totalCollectedSize += int64(batchReadBytes)
-
-		logger.Ctx(ctx).Debug("processed batch",
-			zap.String("segmentFileKey", f.segmentFileKey),
-			zap.Int("batchEntries", len(batchEntries)),
-			zap.Int("batchReadBytes", batchReadBytes),
-			zap.Int("totalEntries", len(allEntries)),
-			zap.Int64("totalCollectedSize", totalCollectedSize))
 
 		// Move to next batch
 		currentBlockID = nextBlockID
@@ -659,11 +631,6 @@ func (f *MinioFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stora
 	// Check final results
 	if len(allEntries) == 0 {
 		metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
-		logger.Ctx(ctx).Debug("no entry extracted after reading all available blocks",
-			zap.String("segmentFileKey", f.segmentFileKey),
-			zap.Int64("startEntryId", opt.StartEntryID),
-			zap.Int64("maxBatchEntries", opt.MaxBatchEntries),
-			zap.Int("entriesReturned", len(allEntries)))
 
 		// If no data read error (or error is compaction-related), determine if it is EOF
 		if !hasDataReadError {
@@ -835,21 +802,12 @@ func (f *MinioFileReaderAdv) processBlockData(ctx context.Context, blockID int64
 		LastEntryID:  blockHeaderRecord.LastEntryID,
 	}
 
-	logger.Ctx(ctx).Debug("processed block data",
-		zap.String("segmentFileKey", f.segmentFileKey),
-		zap.Int64("blockNumber", blockID),
-		zap.Int32("readBlockNumber", blockHeaderRecord.BlockNumber),
-		zap.Int("extractedEntries", len(entries)),
-		zap.Int("readBytes", readBytes))
-
 	return entries, readBytes, blockInfo, nil
 }
 
 func (f *MinioFileReaderAdv) isFooterExists(ctx context.Context) bool {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, SegmentReaderScope, "tryReadFooterAndIndex")
 	defer sp.End()
-	logger.Ctx(ctx).Debug("try to read footer and block indexes", zap.String("segmentFileKey", f.segmentFileKey))
-
 	// Check if footer.blk exists
 	footerKey := getFooterBlockKey(f.segmentFileKey)
 	statSize, _, err := f.client.StatObject(ctx, f.bucket, footerKey, f.nsStr, f.logIdStr)
@@ -890,13 +848,6 @@ func (f *MinioFileReaderAdv) verifyBlockDataIntegrity(ctx context.Context, block
 				zap.Error(err))
 			return err // Stop reading on error, return what we have so far
 		}
-
-		logger.Ctx(ctx).Debug("block data integrity verified successfully",
-			zap.String("segmentFileKey", f.segmentFileKey),
-			zap.Int64("blockNumber", currentBlockID),
-			zap.Int32("recordBlockNumber", blockHeaderRecord.BlockNumber),
-			zap.Uint32("blockLength", blockHeaderRecord.BlockLength),
-			zap.Uint32("blockCrc", blockHeaderRecord.BlockCrc))
 	}
 	return nil
 }
@@ -930,9 +881,6 @@ func (f *MinioFileReaderAdv) readBlockBatchUnsafe(ctx context.Context, startBloc
 				handleErr := f.handleBlockNotFoundByCompaction(ctx, currentBlockID, "StatObject")
 				if handleErr == nil {
 					// Block legitimately doesn't exist - normal EOF
-					logger.Ctx(ctx).Debug("block not found, no more data",
-						zap.String("segmentFileKey", f.segmentFileKey),
-						zap.Int64("blockNumber", currentBlockID))
 					hasMoreBlocks = false
 					break
 				}
@@ -971,24 +919,7 @@ func (f *MinioFileReaderAdv) readBlockBatchUnsafe(ctx context.Context, startBloc
 		futures = append(futures, future)
 		totalRawSize += objSize
 		currentBlockID++
-
-		logger.Ctx(ctx).Debug("submitted reading task for block",
-			zap.String("segmentFileKey", f.segmentFileKey),
-			zap.String("blockKey", blockObjKey),
-			zap.Bool("compacted", f.isCompacted.Load()),
-			zap.Int64("blockNumber", currentBlockID-1),
-			zap.Int64("blockSize", objSize),
-			zap.Int64("totalRawSize", totalRawSize))
 	}
-
-	logger.Ctx(ctx).Debug("readBlockBatch completed",
-		zap.String("segmentFileKey", f.segmentFileKey),
-		zap.Int64("startBlockID", startBlockID),
-		zap.Int64("nextBlockID", currentBlockID),
-		zap.Int("batchSize", len(futures)),
-		zap.Int64("totalRawSize", totalRawSize),
-		zap.Bool("hasMoreBlocks", hasMoreBlocks),
-		zap.Bool("hasReadBlockBatchErr", readBlockBatchErr == nil))
 
 	return futures, currentBlockID, totalRawSize, hasMoreBlocks, readBlockBatchErr
 }
@@ -1043,11 +974,6 @@ func (f *MinioFileReaderAdv) handleBlockNotFoundByCompaction(ctx context.Context
 	if f.isCompacted.Load() {
 		return fmt.Errorf("block %d not found during %s", blockID, operation)
 	}
-
-	logger.Ctx(ctx).Debug("Block not found, checking for compaction",
-		zap.String("segmentFileKey", f.segmentFileKey),
-		zap.Int64("blockNumber", blockID),
-		zap.String("operation", operation))
 
 	// Read footer to check if segment was compacted
 	footerAndIndex, err := f.readFooterAndIndexUnsafe(ctx)

--- a/tests/integration/idle_log_volume_test.go
+++ b/tests/integration/idle_log_volume_test.go
@@ -1,0 +1,265 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/etcd"
+	"github.com/zilliztech/woodpecker/common/logger"
+	"github.com/zilliztech/woodpecker/tests/utils"
+	"github.com/zilliztech/woodpecker/woodpecker"
+	"github.com/zilliztech/woodpecker/woodpecker/log"
+)
+
+// manualLogVolumeEnv gates the log-volume inspection harnesses in this file.
+// They are NOT assertion tests — they emit debug logs bracketed by
+// WP_IDLE_START / WP_IDLE_END so idle-spin log volume can be eyeballed/grepped
+// (see milvus-io/milvus#48976, zilliztech/woodpecker#189 & #190). They need
+// etcd + minio (+ a mini-cluster for service mode) and are skipped by default;
+// run one explicitly with:
+//
+//	WP_LOG_VOLUME_MANUAL=1 go test ./tests/integration/ -run TestIdleLogVolume/ObjectStorage -v
+const manualLogVolumeEnv = "WP_LOG_VOLUME_MANUAL"
+
+func skipUnlessManualLogVolume(t *testing.T) {
+	if os.Getenv(manualLogVolumeEnv) == "" {
+		t.Skip("manual log-volume inspection harness; set " + manualLogVolumeEnv + "=1 to run")
+	}
+}
+
+// TestIdleLogVolume reproduces the "idle-spin" debug logging problem reported in
+// milvus-io/milvus#48976. It writes only a handful of entries and then leaves the
+// writer idle for a fixed window. The body of the idle window is bracketed by
+// WP_IDLE_START / WP_IDLE_END markers so the number of debug lines emitted while
+// NOTHING is being written can be counted precisely.
+//
+// Run per mode and grep between the markers, e.g.:
+//
+//	go test ./tests/integration/ -run 'TestIdleLogVolume/ObjectStorage' -v 2>&1 | tee /tmp/wp_object.log
+func TestIdleLogVolume(t *testing.T) {
+	skipUnlessManualLogVolume(t)
+	const (
+		writeCount = 5
+		idleWindow = 8 * time.Second
+	)
+
+	tmpDir := t.TempDir()
+	rootPath := filepath.Join(tmpDir, "TestIdleLogVolume")
+	testCases := []struct {
+		name        string
+		storageType string
+		rootPath    string
+		needCluster bool
+	}{
+		{name: "LocalFsStorage", storageType: "local", rootPath: rootPath, needCluster: false},
+		{name: "ObjectStorage", storageType: "", rootPath: "", needCluster: false},
+		{name: "ServiceStorage", storageType: "service", rootPath: rootPath + "_service", needCluster: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			cfg, err := config.NewConfiguration("../../config/woodpecker.yaml")
+			assert.NoError(t, err)
+			cfg.Log.Level = "debug"
+			logger.InitLogger(cfg)
+
+			if tc.storageType != "" {
+				cfg.Woodpecker.Storage.Type = tc.storageType
+			}
+			if tc.rootPath != "" {
+				cfg.Woodpecker.Storage.RootPath = tc.rootPath
+			}
+
+			var client woodpecker.Client
+			if tc.needCluster {
+				const nodeCount = 3
+				cluster, ccfg, _, serviceSeeds := utils.StartMiniClusterWithCfg(t, nodeCount, tc.rootPath, cfg)
+				ccfg.Woodpecker.Client.Quorum.BufferPools[0].Seeds = serviceSeeds
+				cfg = ccfg
+				defer cluster.StopMultiNodeCluster(t)
+
+				etcdCli, etcdErr := etcd.GetRemoteEtcdClient(cfg.Etcd.GetEndpoints())
+				assert.NoError(t, etcdErr)
+				defer etcdCli.Close()
+
+				client, err = woodpecker.NewClient(ctx, cfg, etcdCli, true)
+				assert.NoError(t, err)
+			} else {
+				client, err = woodpecker.NewEmbedClientFromConfig(ctx, cfg)
+				assert.NoError(t, err)
+				defer func() {
+					_ = woodpecker.StopEmbedLogStore()
+				}()
+			}
+			defer client.Close(context.TODO())
+
+			logName := "TestIdleLogVolume_" + t.Name() + "_" + time.Now().Format("20060102150405")
+			_ = client.CreateLog(ctx, logName)
+			logHandle, openErr := client.OpenLog(ctx, logName)
+			assert.NoError(t, openErr)
+
+			logWriter, openWriterErr := logHandle.OpenLogWriter(ctx)
+			assert.NoError(t, openWriterErr)
+
+			// --- brief active burst: write a few entries ---
+			resultChan := make([]<-chan *log.WriteResult, writeCount)
+			for i := 0; i < writeCount; i++ {
+				resultChan[i] = logWriter.WriteAsync(ctx, &log.WriteMessage{
+					Payload: []byte(fmt.Sprintf("hello world %d", i)),
+				})
+			}
+			for i := 0; i < writeCount; i++ {
+				res := <-resultChan[i]
+				assert.NoError(t, res.Err)
+			}
+			// let the burst settle / flush
+			time.Sleep(1 * time.Second)
+
+			// --- idle window: write NOTHING, just let the sync loop tick ---
+			logger.Ctx(ctx).Info("WP_IDLE_START", zap.String("mode", tc.name), zap.Int("writeCount", writeCount), zap.Duration("idleWindow", idleWindow))
+			time.Sleep(idleWindow)
+			logger.Ctx(ctx).Info("WP_IDLE_END", zap.String("mode", tc.name))
+
+			closeErr := logWriter.Close(ctx)
+			assert.NoError(t, closeErr)
+		})
+	}
+}
+
+// TestIdleTailReadLogVolume reproduces the read-side "idle-spin" logging from
+// milvus-io/milvus#48976 (reader_impl.go: "submitted reading task for block",
+// "processed block data", "block data integrity verified", ~670K each).
+//
+// It writes a few entries, keeps the writer OPEN (so the segment stays active /
+// incomplete — the tail-read case), catches a reader up to the tail, then leaves
+// the reader polling the idle tail (no new writes) for a fixed window. The body
+// of the idle window is bracketed by WP_IDLE_START / WP_IDLE_END so the DEBUG
+// lines emitted while there is NOTHING new to read can be counted.
+//
+//	go test ./tests/integration/ -run 'TestIdleTailReadLogVolume/ObjectStorage' -v 2>&1 | tee /tmp/wp_tailread_object.log
+func TestIdleTailReadLogVolume(t *testing.T) {
+	skipUnlessManualLogVolume(t)
+	const (
+		writeCount = 5
+		idleWindow = 8 * time.Second
+	)
+
+	tmpDir := t.TempDir()
+	rootPath := filepath.Join(tmpDir, "TestIdleTailReadLogVolume")
+	testCases := []struct {
+		name        string
+		storageType string
+		rootPath    string
+		needCluster bool
+	}{
+		{name: "LocalFsStorage", storageType: "local", rootPath: rootPath, needCluster: false},
+		{name: "ObjectStorage", storageType: "", rootPath: "", needCluster: false},
+		{name: "ServiceStorage", storageType: "service", rootPath: rootPath + "_service", needCluster: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			cfg, err := config.NewConfiguration("../../config/woodpecker.yaml")
+			assert.NoError(t, err)
+			cfg.Log.Level = "debug"
+			logger.InitLogger(cfg)
+
+			if tc.storageType != "" {
+				cfg.Woodpecker.Storage.Type = tc.storageType
+			}
+			if tc.rootPath != "" {
+				cfg.Woodpecker.Storage.RootPath = tc.rootPath
+			}
+
+			var client woodpecker.Client
+			if tc.needCluster {
+				const nodeCount = 3
+				cluster, ccfg, _, serviceSeeds := utils.StartMiniClusterWithCfg(t, nodeCount, tc.rootPath, cfg)
+				ccfg.Woodpecker.Client.Quorum.BufferPools[0].Seeds = serviceSeeds
+				cfg = ccfg
+				defer cluster.StopMultiNodeCluster(t)
+
+				etcdCli, etcdErr := etcd.GetRemoteEtcdClient(cfg.Etcd.GetEndpoints())
+				assert.NoError(t, etcdErr)
+				defer etcdCli.Close()
+
+				client, err = woodpecker.NewClient(ctx, cfg, etcdCli, true)
+				assert.NoError(t, err)
+			} else {
+				client, err = woodpecker.NewEmbedClientFromConfig(ctx, cfg)
+				assert.NoError(t, err)
+				defer func() {
+					_ = woodpecker.StopEmbedLogStore()
+				}()
+			}
+			defer client.Close(context.TODO())
+
+			logName := "TestIdleTailReadLogVolume_" + t.Name() + "_" + time.Now().Format("20060102150405")
+			_ = client.CreateLog(ctx, logName)
+			logHandle, openErr := client.OpenLog(ctx, logName)
+			assert.NoError(t, openErr)
+
+			// writer stays OPEN for the whole test -> segment stays active (tail-read case)
+			logWriter, openWriterErr := logHandle.OpenLogWriter(ctx)
+			assert.NoError(t, openWriterErr)
+			defer logWriter.Close(ctx)
+
+			// --- write a few entries and confirm them ---
+			resultChan := make([]<-chan *log.WriteResult, writeCount)
+			for i := 0; i < writeCount; i++ {
+				resultChan[i] = logWriter.WriteAsync(ctx, &log.WriteMessage{
+					Payload: []byte(fmt.Sprintf("hello world %d", i)),
+				})
+			}
+			for i := 0; i < writeCount; i++ {
+				res := <-resultChan[i]
+				assert.NoError(t, res.Err)
+			}
+
+			// --- open a tail reader and catch up to the tail ---
+			earliest := log.EarliestLogMessageID()
+			logReader, openReaderErr := logHandle.OpenLogReader(ctx, &earliest, "idle-tail-reader")
+			assert.NoError(t, openReaderErr)
+			defer logReader.Close(ctx)
+			for i := 0; i < writeCount; i++ {
+				readCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+				_, rErr := logReader.ReadNext(readCtx)
+				cancel()
+				assert.NoError(t, rErr)
+			}
+
+			// --- idle window: reader polls the tail, NOTHING new is written ---
+			logger.Ctx(ctx).Info("WP_IDLE_START", zap.String("mode", tc.name), zap.Duration("idleWindow", idleWindow))
+			idleCtx, idleCancel := context.WithTimeout(ctx, idleWindow)
+			_, _ = logReader.ReadNext(idleCtx) // blocks, polling the idle tail until the deadline
+			idleCancel()
+			logger.Ctx(ctx).Info("WP_IDLE_END", zap.String("mode", tc.name))
+		})
+	}
+}

--- a/woodpecker/log/log_reader.go
+++ b/woodpecker/log/log_reader.go
@@ -182,7 +182,6 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 			// If entry not found, wait and retry until EOF
 			if werr.ErrEntryNotFound.Is(readBatchErr) {
 				// just wait and retry
-				logger.Ctx(ctx).Debug("segment has no entry to read, wait and retry", zap.String("logName", l.logName), zap.Int64("logId", l.logId), zap.String("readerName", l.readerName), zap.Int64("segmentId", segId), zap.Int64("entryId", entryId))
 				if waitErr := l.waitWithContext(ctx); waitErr != nil {
 					metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "cancel").Observe(float64(time.Since(start).Milliseconds()))
 					return nil, waitErr
@@ -367,12 +366,6 @@ func (l *logBatchReaderImpl) isEntryInCurrentSegment(ctx context.Context) bool {
 	}
 
 	// For active segments, always try to read the segment
-	logger.Ctx(ctx).Debug("current active segment, try to read",
-		zap.String("logName", l.logName),
-		zap.Int64("logId", l.logId),
-		zap.Int64("segmentId", l.currentSegmentHandle.GetId(ctx)),
-		zap.String("readerName", l.readerName),
-		zap.Int64("pendingReadEntryId", l.pendingReadEntryId))
 	return true
 }
 
@@ -383,12 +376,6 @@ func (l *logBatchReaderImpl) findNextReadableSegment(ctx context.Context, latest
 	nextEntryId := l.pendingReadEntryId
 
 	for nextSegmentId <= latestSegmentId {
-		logger.Ctx(ctx).Debug("trying to find next segment",
-			zap.String("logName", l.logName),
-			zap.Int64("logId", l.logId),
-			zap.Int64("nextSegmentId", nextSegmentId),
-			zap.String("readerName", l.readerName))
-
 		segHandle, err := l.logHandle.GetExistsReadonlySegmentHandle(context.Background(), nextSegmentId)
 		if err != nil && !werr.ErrSegmentNotFound.Is(err) {
 			logger.Ctx(ctx).Warn("get segment handle error",
@@ -439,12 +426,8 @@ func (l *logBatchReaderImpl) findNextReadableSegment(ctx context.Context, latest
 		nextSegmentId++
 	}
 
-	// No existing segment found, wait for future segment
-	logger.Ctx(ctx).Debug("no existing segment found, wait for future segment",
-		zap.String("logName", l.logName),
-		zap.Int64("logId", l.logId),
-		zap.Int64("latestSegmentId", latestSegmentId),
-		zap.String("readerName", l.readerName))
+	// No existing segment found, wait for future segment (silent: this is the
+	// steady-state of an idle tail reader and must not log on every poll, issue #190).
 	return nil, -1, -1, werr.ErrSegmentNotFound.WithCauseErrMsg("no existing readable segment found")
 }
 

--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -459,7 +459,6 @@ func (s *segmentHandleImpl) ReadBatchAdv(ctx context.Context, from int64, maxEnt
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, SegmentHandleScopeName, "ReadBatch")
 	defer sp.End()
 	s.updateAccessTime()
-	logger.Ctx(ctx).Debug("start read batch", zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.Int64("from", from), zap.Int64("maxEntries", maxEntries))
 
 	// Use direct read from object storage for sealed segments when enabled
 	if s.canDirectRead() {
@@ -629,15 +628,6 @@ func (s *segmentHandleImpl) quorumReadBatch(ctx context.Context, from int64, max
 	// Cycle through nodes starting from the preferred index
 	for i, candidate := range candidates {
 		node := candidate.node
-		logger.Ctx(ctx).Debug("attempting to read from node",
-			zap.String("logName", s.logName),
-			zap.Int64("logId", s.logId),
-			zap.Int64("segId", s.segmentId),
-			zap.String("node", node),
-			zap.Int("nodeIndex", candidate.originalIndex),
-			zap.Int("attempt", i+1),
-			zap.Bool("isLastReadNode", lastReadState != nil && lastReadState.Node == node))
-
 		cli, err := s.ClientPool.GetLogStoreClient(ctx, node)
 		if err != nil {
 			logger.Ctx(ctx).Warn("failed to get client for node, trying next",
@@ -658,10 +648,9 @@ func (s *segmentHandleImpl) quorumReadBatch(ctx context.Context, from int64, max
 
 		batchResult, err := cli.ReadEntriesBatchAdv(ctx, s.bucketName, s.rootPath, s.logId, s.segmentId, from, maxEntries, nodeLastReadState)
 		if err != nil {
-			if werr.ErrEntryNotFound.Is(err) {
-				logger.Ctx(ctx).Debug("read batch empty on node",
-					zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.String("node", node))
-			} else {
+			// ErrEntryNotFound is the steady-state of a caught-up tail reader;
+			// only log genuine read failures (issue #190).
+			if !werr.ErrEntryNotFound.Is(err) {
 				logger.Ctx(ctx).Warn("read batch failed on node",
 					zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.String("node", node), zap.Error(err))
 			}
@@ -691,10 +680,7 @@ func (s *segmentHandleImpl) quorumReadBatch(ctx context.Context, from int64, max
 	}
 
 	// All nodes failed
-	if werr.ErrEntryNotFound.Is(lastError) {
-		logger.Ctx(ctx).Debug("read batch empty on all quorum nodes",
-			zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.Int("totalNodes", nodeCount))
-	} else {
+	if !werr.ErrEntryNotFound.Is(lastError) {
 		logger.Ctx(ctx).Warn("read batch failed on all quorum nodes",
 			zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.Int("totalNodes", nodeCount), zap.Error(lastError))
 	}


### PR DESCRIPTION
## What

Cut the read-path DEBUG log volume. This is the second half of milvus-io/milvus#48976 (the `reader_impl.go` sources reported at ~670K lines each per streamingnode).

Addresses #190. Logging only — the perf items (per-poll etcd / footer re-read) are a separate follow-up (see below).

## Two distinct problems

**1. Per-read verbosity (`objectstorage/reader_impl.go`).** A single client read of an N-block batch logged ~3N+ lines — per **block** (`submitted reading task for block`, `processed block data`, `block data integrity verified`) plus per-**batch/request** chatter (`read data blocks start`, `submitted batch reading tasks`, `processed batch`, `readBlockBatch completed`, `ReadNextBatchAdv called`). These fire on every real read and scale with read traffic (the ~670K offenders). Removed them; kept the single `read data blocks completed` summary and **all** Warn/error logs.

**2. Idle tail-read spin.** A caught-up tail reader polls every 200ms and re-emitted the same chain forever, through **two** steady states:
- *waiting for a next segment* — `log_reader.go`: `no existing segment found, wait for future segment`, `segment has no entry to read, wait and retry`, `trying to find next segment`.
- *re-reading the active segment tail* — `log_reader.go` (`current active segment, try to read`), `reader_impl.go` (footer re-read, `block not found`, `no entry extracted`, compaction-check), `segment_handle.go` (`start read batch`, `attempting to read from node`, `read batch empty on node/quorum`), `segment_processor.go` (`read batch entries`, `failed to read entry`).

`ErrEntryNotFound` is the *normal* caught-up steady state, so those per-poll DEBUG lines are removed/gated, while genuine **EOF** (`Info`) and **read failures** (`Warn`) are preserved (the `if/else` chains were restructured, not gutted).

## Verification (`tests/integration` `TestIdleTailReadLogVolume`, ObjectStorage)

| scenario | before | after |
|---|---|---|
| 8s idle tail-read window, reader-side DEBUG | ~450 (≈12 lines/poll) | **1** (a one-time ctx-cancel log at the window boundary) |
| one real read (per-read chain) | ~9 lines | **~1** summary |

The idle reader took both steady states across runs; both are now quiet. `go build ./...`, `go vet`, `gofmt`, and the `server/storage/objectstorage`, `server/processor`, `woodpecker/segment`, `woodpecker/log` package tests all pass.

## Out of scope — separate perf follow-up

The idle tail reader still does real IO per poll: a `GetAllSegmentMetadata` **etcd** read and a **footer re-read** from object storage. That's a behavior/perf change (throttle/cache), riskier than log removal, and is intentionally left for a separate PR — this one is logging only. (The remaining `metadata_etcd.go` debug line per poll goes away with that change.)

## Notes

- `logger.Ctx()` returns a plain `*zap.Logger` (no Trace level), so logs are removed/gated rather than downgraded.
- Companion to #189 (writer-side idle-spin). No observer-based unit test here because the `logger.ReplaceGlobals` test seam lives in the still-open #189 PR; verification is via the integration reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
