### PR TITLE
Rename metric label `namespace`→`log_ns` + k8s (minikube) monitoring suite & dashboards

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,6 +63,7 @@ linters:
       - mocks
       - tests/benchmark
       - tests/docker
+      - tests/k8s
       - tests/stability
       - bin
       - build
@@ -100,6 +101,7 @@ formatters:
       - mocks
       - tests/benchmark
       - tests/docker
+      - tests/k8s
       - tests/stability
       - bin
       - build

--- a/common/metrics/client_metrics.go
+++ b/common/metrics/client_metrics.go
@@ -37,7 +37,7 @@ var (
 		Subsystem: clientRole,
 		Name:      "log_name_id_mapping",
 		Help:      "Mapping between log name and id",
-	}, []string{"namespace", "log_name"})
+	}, []string{"log_ns", "log_name"})
 
 	// Segment state tracking: gauge value = number of segments in that state
 	WpClientSegmentState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -45,7 +45,7 @@ var (
 		Subsystem: clientRole,
 		Name:      "segment_state",
 		Help:      "Number of segments in each state per log",
-	}, []string{"namespace", "log_id", "state"})
+	}, []string{"log_ns", "log_id", "state"})
 
 	// client append data to log
 	WpClientAppendRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -53,21 +53,21 @@ var (
 		Subsystem: clientRole,
 		Name:      "append_requests_total",
 		Help:      "Total number of append requests",
-	}, []string{"namespace", "log_id"})
+	}, []string{"log_ns", "log_id"})
 	WpClientAppendBytes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "append_bytes",
 		Help:      "Size of append operations in bytes",
 		Buckets:   prometheus.ExponentialBuckets(256, 4, 8), // 256B ~ 4MB
-	}, []string{"namespace", "log_id"})
+	}, []string{"log_ns", "log_id"})
 	WpClientAppendLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "append_latency",
 		Help:      "Latency of append operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
-	}, []string{"namespace", "log_id"})
+	}, []string{"log_ns", "log_id"})
 
 	// LogHandle metrics
 	WpLogHandleOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -75,14 +75,14 @@ var (
 		Subsystem: clientRole,
 		Name:      "log_handle_operations_total",
 		Help:      "Total number of log handle operations",
-	}, []string{"namespace", "log_id", "operation", "status"})
+	}, []string{"log_ns", "log_id", "operation", "status"})
 	WpLogHandleOperationLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "log_handle_operation_latency",
 		Help:      "Latency of log handle operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
-	}, []string{"namespace", "log_id", "operation", "status"})
+	}, []string{"log_ns", "log_id", "operation", "status"})
 
 	// Client read metrics
 	WpClientReadRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -90,20 +90,20 @@ var (
 		Subsystem: clientRole,
 		Name:      "read_requests_total",
 		Help:      "Total number of read requests",
-	}, []string{"namespace", "log_id"})
+	}, []string{"log_ns", "log_id"})
 	WpClientReadEntriesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "read_entries_total",
 		Help:      "Total number of entries read",
-	}, []string{"namespace", "log_id"})
+	}, []string{"log_ns", "log_id"})
 	WpClientReadLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "read_latency",
 		Help:      "Latency of read operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
-	}, []string{"namespace", "log_id"})
+	}, []string{"log_ns", "log_id"})
 
 	// LogReader metrics
 	WpLogReaderBytesRead = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -111,14 +111,14 @@ var (
 		Subsystem: clientRole,
 		Name:      "reader_bytes_read",
 		Help:      "Total bytes read by log readers",
-	}, []string{"namespace", "log_id", "reader_name"})
+	}, []string{"log_ns", "log_id", "reader_name"})
 	WpLogReaderOperationLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "reader_operation_latency",
 		Help:      "Latency of log reader operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
-	}, []string{"namespace", "log_id", "operation", "status"})
+	}, []string{"log_ns", "log_id", "operation", "status"})
 
 	// LogWriter metrics
 	WpLogWriterBytesWritten = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -126,14 +126,14 @@ var (
 		Subsystem: clientRole,
 		Name:      "writer_bytes_written",
 		Help:      "Total bytes written by log writers",
-	}, []string{"namespace", "log_id"})
+	}, []string{"log_ns", "log_id"})
 	WpLogWriterOperationLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "writer_operation_latency",
 		Help:      "Latency of log writer operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
-	}, []string{"namespace", "log_id", "operation", "status"})
+	}, []string{"log_ns", "log_id", "operation", "status"})
 
 	// SegmentHandle metrics
 	WpSegmentHandleOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -141,20 +141,20 @@ var (
 		Subsystem: clientRole,
 		Name:      "segment_handle_operations_total",
 		Help:      "Total number of segment handle operations",
-	}, []string{"namespace", "log_id", "operation", "status"})
+	}, []string{"log_ns", "log_id", "operation", "status"})
 	WpSegmentHandleOperationLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "segment_handle_operation_latency",
 		Help:      "Latency of segment handle operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
-	}, []string{"namespace", "log_id", "operation", "status"})
+	}, []string{"log_ns", "log_id", "operation", "status"})
 	WpSegmentHandlePendingAppendOps = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "segment_handle_pending_append_ops",
 		Help:      "Number of pending append operations in segment handles",
-	}, []string{"namespace", "log_id"})
+	}, []string{"log_ns", "log_id"})
 
 	// Direct read metrics (client reads sealed segments directly from object storage)
 	WpClientDirectReadRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -162,14 +162,14 @@ var (
 		Subsystem: clientRole,
 		Name:      "direct_read_requests_total",
 		Help:      "Total number of direct read requests from object storage for sealed segments",
-	}, []string{"namespace", "log_id", "status"})
+	}, []string{"log_ns", "log_id", "status"})
 	WpClientDirectReadLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "direct_read_latency",
 		Help:      "Latency of direct read operations from object storage for sealed segments",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
-	}, []string{"namespace", "log_id"})
+	}, []string{"log_ns", "log_id"})
 
 	// Etcd Meta metrics
 	WpEtcdMetaOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -177,14 +177,14 @@ var (
 		Subsystem: clientRole,
 		Name:      "etcd_meta_operations_total",
 		Help:      "Total number of etcd meta related operations",
-	}, []string{"namespace", "operation", "status"})
+	}, []string{"log_ns", "operation", "status"})
 	WpEtcdMetaOperationLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "etcd_meta_operation_latency",
 		Help:      "Latency of etcd meta related operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
-	}, []string{"namespace", "operation", "status"})
+	}, []string{"log_ns", "operation", "status"})
 )
 
 // RegisterClientMetricsWithRegisterer registers all client-side metrics with the given registerer.

--- a/common/metrics/metrics_registration_test.go
+++ b/common/metrics/metrics_registration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildMetricsNamespace(t *testing.T) {
@@ -164,4 +165,44 @@ func TestUpdateSegmentState_MultipleTransitions(t *testing.T) {
 	sealedMetric := &dto.Metric{}
 	WpClientSegmentState.WithLabelValues(namespace, logId, "Sealed").Write(sealedMetric)
 	assert.Equal(t, float64(1), sealedMetric.GetGauge().GetValue())
+}
+
+// TestMetrics_UseLogNsLabel guards the rename of the application namespace
+// label to log_ns (issue #193): the k8s scrape owns `namespace`, so the app
+// must not emit it.
+func TestMetrics_UseLogNsLabel(t *testing.T) {
+	check := func(t *testing.T, reg *prometheus.Registry, metricName string) {
+		mfs, err := reg.Gather()
+		require.NoError(t, err)
+		for _, mf := range mfs {
+			if mf.GetName() != metricName {
+				continue
+			}
+			for _, m := range mf.GetMetric() {
+				names := map[string]bool{}
+				for _, lp := range m.GetLabel() {
+					names[lp.GetName()] = true
+				}
+				require.True(t, names["log_ns"], "%s must carry log_ns", metricName)
+				require.False(t, names["namespace"], "%s must NOT carry namespace", metricName)
+				return
+			}
+		}
+		t.Fatalf("metric %s not found in registry", metricName)
+	}
+
+	t.Run("server", func(t *testing.T) {
+		WpServerRegisterOnce = sync.Once{}
+		reg := prometheus.NewRegistry()
+		RegisterServerMetricsWithRegisterer(reg)
+		WpLogStoreActiveLogs.WithLabelValues("node-1", "bucket/root").Set(1)
+		check(t, reg, "woodpecker_server_logstore_active_logs")
+	})
+	t.Run("client", func(t *testing.T) {
+		WpClientRegisterOnce = sync.Once{}
+		reg := prometheus.NewRegistry()
+		RegisterClientMetricsWithRegisterer(reg)
+		WpClientAppendRequestsTotal.WithLabelValues("bucket/root", "1").Inc()
+		check(t, reg, "woodpecker_client_append_requests_total")
+	})
 }

--- a/common/metrics/service_metrics.go
+++ b/common/metrics/service_metrics.go
@@ -57,19 +57,19 @@ var (
 		Subsystem: serverRole,
 		Name:      "logstore_active_logs",
 		Help:      "Number of active logs in the log store",
-	}, []string{"node_id", "namespace"})
+	}, []string{"node_id", "log_ns"})
 	WpLogStoreActiveSegments = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "logstore_active_segments",
 		Help:      "Number of active segments in the log store",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 	WpFileReaders = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "file_reader",
 		Help:      "Number of active segment file readers for log",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 
 	// LogStore metrics
 	WpLogStoreRunningTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -83,20 +83,20 @@ var (
 		Subsystem: serverRole,
 		Name:      "logstore_operations_total",
 		Help:      "Total number of log store operations",
-	}, []string{"node_id", "namespace", "log_id", "operation", "status"})
+	}, []string{"node_id", "log_ns", "log_id", "operation", "status"})
 	WpLogStoreOperationLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "logstore_operation_latency",
 		Help:      "Latency of log store operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
-	}, []string{"node_id", "namespace", "log_id", "operation", "status"})
+	}, []string{"node_id", "log_ns", "log_id", "operation", "status"})
 	WpLogStoreActiveSegmentProcessors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "logstore_active_segment_processors",
 		Help:      "Number of active segment processors in log store",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 
 	// Buffer wait latency
 	WpServerBufferWaitLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -105,7 +105,7 @@ var (
 		Name:      "buffer_wait_latency",
 		Help:      "Time entries spend waiting in the buffer before being notified (ms)",
 		Buckets:   prometheus.ExponentialBuckets(0.1, 2, 15), // 0.1ms ~ ~1638ms
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 
 	// Segment File Impl metrics
 	WpFileOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -113,20 +113,20 @@ var (
 		Subsystem: serverRole,
 		Name:      "file_operations_total",
 		Help:      "Total number of file operations",
-	}, []string{"node_id", "namespace", "log_id", "operation", "status"})
+	}, []string{"node_id", "log_ns", "log_id", "operation", "status"})
 	WpFileOperationLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "file_operation_latency",
 		Help:      "Latency of file operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
-	}, []string{"node_id", "namespace", "log_id", "operation", "status"})
+	}, []string{"node_id", "log_ns", "log_id", "operation", "status"})
 	WpFileWriters = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "file_writer",
 		Help:      "Number of segment file writer for log",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 
 	WpFileReadBatchLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
@@ -134,13 +134,13 @@ var (
 		Name:      "read_batch_latency",
 		Help:      "Latency of read batch operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 15), // 1ms to 1024ms
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 	WpFileReadBatchBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "read_batch_bytes_total",
 		Help:      "Total bytes read in batch operations",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 
 	WpFileFlushLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
@@ -148,13 +148,13 @@ var (
 		Name:      "file_flush_latency",
 		Help:      "Latency of flush blocks operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 15), // 1ms to 1024ms
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 	WpFileFlushBytesWritten = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "flush_bytes_written",
 		Help:      "Total block bytes flushed",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 
 	WpFileCompactLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
@@ -162,13 +162,13 @@ var (
 		Name:      "file_compaction_latency",
 		Help:      "Latency of compaction blocks operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 15), // 1ms to 1024ms
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 	WpFileCompactBytesWritten = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "compact_bytes_written",
 		Help:      "Total block bytes written by compaction",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 
 	// Object storage metrics
 	WpObjectStorageOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -176,27 +176,27 @@ var (
 		Subsystem: serverRole,
 		Name:      "object_storage_operations_total",
 		Help:      "Total number of object storage operations",
-	}, []string{"node_id", "namespace", "log_id", "operation", "status"})
+	}, []string{"node_id", "log_ns", "log_id", "operation", "status"})
 	WpObjectStorageOperationLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "object_storage_operation_latency",
 		Help:      "Latency of object storage operations",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 15), // 1ms to ~16s
-	}, []string{"node_id", "namespace", "log_id", "operation", "status"})
+	}, []string{"node_id", "log_ns", "log_id", "operation", "status"})
 	WpObjectStorageRequestBytes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "object_storage_request_bytes",
 		Help:      "Size of individual object storage requests in bytes",
 		Buckets:   prometheus.ExponentialBuckets(1024, 4, 8), // 1KB ~ 16MB
-	}, []string{"node_id", "namespace", "log_id", "operation"})
+	}, []string{"node_id", "log_ns", "log_id", "operation"})
 	WpObjectStorageBytesTransferred = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "object_storage_bytes_transferred",
 		Help:      "Total bytes transferred to/from object storage",
-	}, []string{"node_id", "namespace", "log_id", "operation"})
+	}, []string{"node_id", "log_ns", "log_id", "operation"})
 
 	// Stored data size gauges
 	WpObjectStorageStoredBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -204,25 +204,25 @@ var (
 		Subsystem: serverRole,
 		Name:      "object_storage_stored_bytes",
 		Help:      "Current total bytes stored in object storage",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 	WpObjectStorageStoredObjects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "object_storage_stored_objects",
 		Help:      "Current number of objects stored in object storage",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 	WpFileStoredBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "file_stored_bytes",
 		Help:      "Current total bytes stored in local files",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 	WpFileStoredCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: serverRole,
 		Name:      "file_stored_count",
 		Help:      "Current number of local segment files",
-	}, []string{"node_id", "namespace", "log_id"})
+	}, []string{"node_id", "log_ns", "log_id"})
 
 	WpSyncSchedulerScheduled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: woodpeckerNamespace,

--- a/deployments/operator/test/lib.sh
+++ b/deployments/operator/test/lib.sh
@@ -98,7 +98,7 @@ metadata:
 spec:
   containers:
     - name: etcd
-      image: ${ETCD_IMG:-quay.io/coreos/etcd:v3.5.18}
+      image: ${ETCD_IMG:-quay.io/coreos/etcd:v3.5.25}
       command: ["etcd", "--listen-client-urls=http://0.0.0.0:2379",
                 "--advertise-client-urls=http://etcd.default.svc:2379"]
       ports: [{ containerPort: 2379 }]
@@ -119,7 +119,7 @@ metadata:
 spec:
   containers:
     - name: minio
-      image: ${MINIO_IMG:-minio/minio:RELEASE.2024-06-13T22-53-53Z}
+      image: ${MINIO_IMG:-minio/minio:RELEASE.2024-12-18T13-15-44Z}
       command: ["minio", "server", "/data"]
       env:
         - { name: MINIO_ROOT_USER, value: minioadmin }

--- a/deployments/operator/test/lib.sh
+++ b/deployments/operator/test/lib.sh
@@ -89,7 +89,7 @@ wp_deploy_deps() {
         return 0
     fi
 
-    kubectl apply -f - <<'EOF'
+    kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
@@ -98,7 +98,7 @@ metadata:
 spec:
   containers:
     - name: etcd
-      image: quay.io/coreos/etcd:v3.5.18
+      image: ${ETCD_IMG:-quay.io/coreos/etcd:v3.5.18}
       command: ["etcd", "--listen-client-urls=http://0.0.0.0:2379",
                 "--advertise-client-urls=http://etcd.default.svc:2379"]
       ports: [{ containerPort: 2379 }]
@@ -119,7 +119,7 @@ metadata:
 spec:
   containers:
     - name: minio
-      image: minio/minio:RELEASE.2024-06-13T22-53-53Z
+      image: ${MINIO_IMG:-minio/minio:RELEASE.2024-06-13T22-53-53Z}
       command: ["minio", "server", "/data"]
       env:
         - { name: MINIO_ROOT_USER, value: minioadmin }

--- a/docs/superpowers/plans/2026-06-22-k8s-monitor-log-ns.md
+++ b/docs/superpowers/plans/2026-06-22-k8s-monitor-log-ns.md
@@ -1,0 +1,1109 @@
+# `log_ns` Rename + K8s Monitoring Suite — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the Woodpecker app metric label `namespace`→`log_ns`, update the Docker monitor dashboards to match, and add a minikube monitoring E2E suite (`kube-prometheus-stack` + `PodMonitor`) with new k8s server/client dashboard templates.
+
+**Architecture:** Three phases. **A** renames the label at the source (`common/metrics/`). **B** updates the in-repo Docker dashboards/tests/docs to `log_ns`. **C** adds `tests/k8s/monitor/` — a minikube mirror of `tests/docker/monitor/` that reuses `deployments/operator/test/lib.sh` for bring-up, installs `kube-prometheus-stack` via Helm, scrapes Woodpecker via a `PodMonitor` (identical to the prod wiki, no relabel needed after A), drives an in-cluster client load generator, and verifies `woodpecker_{server,client}_*` metrics over a port-forwarded Prometheus.
+
+**Tech Stack:** Go 1.24, Prometheus `client_golang`, Prometheus Operator CRDs (`monitoring.coreos.com/v1`), `kube-prometheus-stack` Helm chart, minikube, kubectl, Grafana.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-22-k8s-monitor-suite-design.md`. Issue: #193. Branch: `feat/k8s-monitor-log-ns`.
+- Go module: `github.com/zilliztech/woodpecker`. License header (Apache, the 16-line block at the top of existing `.go`/`.sh` files) is REQUIRED on every new `.go` and `.sh` file — copy it verbatim from `tests/docker/monitor/run_monitor_tests.sh`.
+- The metric label key string is exactly `"log_ns"` (snake_case). The k8s namespace stays the target label `namespace`.
+- k8s suite knobs (exported before sourcing `lib.sh`): `CLUSTER_NAME=wp-monitor`, `CR_NAME=my-woodpecker`, `NAMESPACE=woodpecker`, `REPLICAS=3`, monitoring Helm release `kps` in namespace `monitoring`, Prometheus external label `cluster=woodpecker-minikube`.
+- Woodpecker server pods are labeled `app.kubernetes.io/{name=woodpecker, instance=$CR_NAME, component=server}` and expose container port `metrics` (9091). The client load-gen pod is labeled `…/component=client` with a named port `metrics` (29099).
+- TDD throughout: failing test → run → minimal change → run → commit. Frequent commits, each referencing `#193`.
+
+---
+
+## Phase A — Rename `namespace` → `log_ns` in `common/metrics/`
+
+### Task A1: Rename the metric label key
+
+**Files:**
+- Modify: `common/metrics/service_metrics.go` (24 label-name slice entries)
+- Modify: `common/metrics/client_metrics.go` (21 label-name slice entries)
+- Test: `common/metrics/metrics_registration_test.go` (add a label-name guard)
+
+**Interfaces:**
+- Consumes: existing `RegisterServerMetricsWithRegisterer(prometheus.Registerer)` and `RegisterClientMetricsWithRegisterer(prometheus.Registerer)`.
+- Produces: all `woodpecker_server_*` / `woodpecker_client_*` metrics now carry label `log_ns` (was `namespace`). No function signatures change.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `common/metrics/metrics_registration_test.go`:
+
+```go
+// TestMetrics_UseLogNsLabel guards the rename of the application namespace
+// label to log_ns (issue #193): the k8s scrape owns `namespace`, so the app
+// must not emit it.
+func TestMetrics_UseLogNsLabel(t *testing.T) {
+	check := func(t *testing.T, reg *prometheus.Registry, metricName string) {
+		mfs, err := reg.Gather()
+		require.NoError(t, err)
+		for _, mf := range mfs {
+			if mf.GetName() != metricName {
+				continue
+			}
+			for _, m := range mf.GetMetric() {
+				names := map[string]bool{}
+				for _, lp := range m.GetLabel() {
+					names[lp.GetName()] = true
+				}
+				require.True(t, names["log_ns"], "%s must carry log_ns", metricName)
+				require.False(t, names["namespace"], "%s must NOT carry namespace", metricName)
+				return
+			}
+		}
+		t.Fatalf("metric %s not found in registry", metricName)
+	}
+
+	t.Run("server", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		RegisterServerMetricsWithRegisterer(reg)
+		WpLogStoreActiveLogs.WithLabelValues("node-1", "bucket/root").Set(1)
+		check(t, reg, "woodpecker_server_logstore_active_logs")
+	})
+	t.Run("client", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		RegisterClientMetricsWithRegisterer(reg)
+		WpClientAppendRequestsTotal.WithLabelValues("bucket/root", "1").Inc()
+		check(t, reg, "woodpecker_client_append_requests_total")
+	})
+}
+```
+
+Ensure the file imports `"github.com/prometheus/client_golang/prometheus"` and `"github.com/stretchr/testify/require"` (add if missing).
+
+- [ ] **Step 2: Run the test, verify it FAILS**
+
+Run: `go test ./common/metrics/ -run TestMetrics_UseLogNsLabel -v`
+Expected: FAIL — `... must carry log_ns` (label is still `namespace`).
+
+- [ ] **Step 3: Apply the rename**
+
+The key string `"namespace"` appears in these two files **only** inside `[]string{…}` label-name slices (verified: no other quoted `"namespace"` occurrences; the metric-name prefix uses the identifier `woodpeckerNamespace`, untouched). Replace all:
+
+```bash
+cd /Users/zilliz/workspace_zilliz/e2e_src/woodpecker
+sed -i '' 's/"namespace"/"log_ns"/g' common/metrics/service_metrics.go common/metrics/client_metrics.go
+```
+
+Verify nothing else changed and counts are right:
+
+```bash
+grep -c '"log_ns"' common/metrics/service_metrics.go   # expect 24
+grep -c '"log_ns"' common/metrics/client_metrics.go     # expect 21
+grep -rn '"namespace"' common/metrics/                  # expect: no matches
+```
+
+- [ ] **Step 4: Run the metrics package tests, verify PASS**
+
+Run: `go test ./common/metrics/... -v`
+Expected: PASS, including `TestMetrics_UseLogNsLabel` and the existing `TestBuildMetricsNamespace` (value builder is unchanged).
+
+- [ ] **Step 5: Build the whole module to confirm no call-site breakage**
+
+Run: `go build ./...`
+Expected: success (call sites pass the value positionally; only the label key changed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add common/metrics/service_metrics.go common/metrics/client_metrics.go common/metrics/metrics_registration_test.go
+git commit -m "refactor(metrics): rename app metric label namespace -> log_ns (#193)
+
+The k8s scrape owns the namespace label; emitting our own collides with it.
+Renaming to log_ns frees namespace for the real k8s namespace.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase B — Update Docker monitor dashboards/tests/docs to `log_ns`
+
+### Task B1: Swap `namespace`→`log_ns` in the Docker monitor templates
+
+**Files:**
+- Modify: `tests/docker/monitor/grafana/templates/dashboard_server.json`
+- Modify: `tests/docker/monitor/grafana/templates/dashboard_client.json`
+- Modify: `tests/docker/monitor/README.md` (metrics-table "Labels" column)
+- Modify: `tests/docker/monitor/monitor_test.go` (only if it references the `namespace` label in PromQL)
+
+**Interfaces:**
+- Consumes: the renamed metric label from Task A1.
+- Produces: Docker dashboards that filter on `log_ns` (variable renamed; `__DATASOURCE_UID__` datasource refs preserved for `grafana/setup.go`).
+
+- [ ] **Step 1: Confirm the templates are on the committed `__DATASOURCE_UID__` base**
+
+Run: `git -C /Users/zilliz/workspace_zilliz/e2e_src/woodpecker status --short tests/docker/monitor/grafana/templates/`
+Expected: no output (clean). If there are stray `${datasource}` edits, `git checkout -- tests/docker/monitor/grafana/templates/dashboard_*.json` first.
+
+- [ ] **Step 2: Write the transform + verification script**
+
+Create `tests/docker/monitor/grafana/templates/.rename_log_ns.py` (a throwaway transform; deleted in Step 5):
+
+```python
+import json, sys, re, pathlib
+
+DIR = pathlib.Path(__file__).parent
+
+def transform(path):
+    raw = path.read_text()
+    obj = json.loads(raw)
+
+    # 1. rename template variables named "namespace" -> "log_ns"
+    for v in obj.get("templating", {}).get("list", []):
+        if v.get("name") == "namespace":
+            v["name"] = "log_ns"
+
+    # 2. in every string field, rewrite the label key and the variable ref.
+    #    - PromQL label key:  namespace=~ / max by (namespace) / label_values(..., namespace)
+    #    - Grafana var ref:   $namespace  and  ${namespace}
+    #    - regex extractor:   /namespace="([^"]+)"/
+    def fix(s):
+        s = s.replace('namespace=~', 'log_ns=~')
+        s = s.replace('max by (namespace)', 'max by (log_ns)')
+        s = re.sub(r'label_values\(([^,]*),\s*namespace\)', r'label_values(\1, log_ns)', s)
+        s = s.replace('$namespace', '$log_ns').replace('${namespace}', '${log_ns}')
+        s = s.replace('namespace="([^"]+)"', 'log_ns="([^"]+)"')
+        return s
+
+    def walk(o):
+        if isinstance(o, dict):
+            return {k: walk(fix(val) if isinstance(val, str) else val) for k, val in o.items()}
+        if isinstance(o, list):
+            return [walk(x) for x in o]
+        return o
+
+    obj = walk(obj)
+    path.write_text(json.dumps(obj, indent=2) + "\n")
+    blob = json.dumps(obj)
+    assert '$namespace' not in blob and '${namespace}' not in blob, f"{path}: stray $namespace"
+    assert 'namespace=~' not in blob, f"{path}: stray namespace=~ filter"
+    assert '__DATASOURCE_UID__' in blob, f"{path}: datasource placeholder lost"
+    print(f"OK {path.name}: log_ns refs =", blob.count('log_ns'))
+
+for name in ("dashboard_server.json", "dashboard_client.json"):
+    transform(DIR / name)
+```
+
+- [ ] **Step 3: Run the transform, verify assertions pass**
+
+Run: `python3 tests/docker/monitor/grafana/templates/.rename_log_ns.py`
+Expected: two `OK …: log_ns refs = N` lines, no assertion errors. (Server has the `namespace`+`log_id`+`server_job` vars; client has the single var.)
+
+- [ ] **Step 4: Update the README labels + check `monitor_test.go`**
+
+In `tests/docker/monitor/README.md`, in the metrics-reference tables, change the `namespace` label entries in the "Labels" column to `log_ns` (the rows for `woodpecker_server_logstore_*`, `woodpecker_server_file_*`, `woodpecker_client_*`, etc.). Then check the test for PromQL referencing the label:
+
+```bash
+grep -n 'namespace' tests/docker/monitor/monitor_test.go
+```
+Expected: the test asserts only metric *names* (e.g. `woodpecker_server_logstore_active_logs`), not the `namespace` label — so no change needed. If any PromQL string contains `namespace=~`, change it to `log_ns=~`.
+
+- [ ] **Step 5: Validate JSON + remove the throwaway script**
+
+```bash
+python3 -c "import json; [json.load(open('tests/docker/monitor/grafana/templates/'+f)) for f in ('dashboard_server.json','dashboard_client.json')]; print('valid')"
+rm tests/docker/monitor/grafana/templates/.rename_log_ns.py
+```
+Expected: `valid`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/docker/monitor/grafana/templates/dashboard_server.json tests/docker/monitor/grafana/templates/dashboard_client.json tests/docker/monitor/README.md tests/docker/monitor/monitor_test.go
+git commit -m "test(monitor): update Docker dashboards to log_ns label (#193)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Phase C — `tests/k8s/monitor/` minikube monitoring suite
+
+### Task C1: Package skeleton — `K8sMonitorCluster` (port-forward + Prometheus query helpers)
+
+**Files:**
+- Create: `tests/k8s/monitor/k8s_monitor_cluster.go`
+- Test: `tests/k8s/monitor/k8s_monitor_cluster_test.go`
+
+**Interfaces:**
+- Produces:
+  - `type K8sMonitorCluster struct { PromBaseURL string }`
+  - `func NewK8sMonitorCluster(promBaseURL string) *K8sMonitorCluster`
+  - `func (c *K8sMonitorCluster) WaitForPrometheusReady(t *testing.T, timeout time.Duration)`
+  - `func (c *K8sMonitorCluster) QueryPromQL(t *testing.T, query string) (string, bool)`
+  - `func (c *K8sMonitorCluster) QueryVector(t *testing.T, query string) []map[string]string` — returns each result's label set
+  - `func (c *K8sMonitorCluster) QueryMetricHasValue(t *testing.T, metricName string) bool`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/k8s/monitor/k8s_monitor_cluster_test.go`:
+
+```go
+package monitor
+
+import "testing"
+
+func TestPromBaseURL_Default(t *testing.T) {
+	c := NewK8sMonitorCluster("http://localhost:9090")
+	if c.PromBaseURL != "http://localhost:9090" {
+		t.Fatalf("got %q", c.PromBaseURL)
+	}
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL (undefined)**
+
+Run: `go test ./tests/k8s/monitor/ -run TestPromBaseURL_Default -v`
+Expected: FAIL — `undefined: NewK8sMonitorCluster`.
+
+- [ ] **Step 3: Implement `k8s_monitor_cluster.go`**
+
+Create `tests/k8s/monitor/k8s_monitor_cluster.go` (Apache header + below). The query helpers mirror `tests/docker/monitor/monitor_cluster.go` but take a configurable base URL:
+
+```go
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// K8sMonitorCluster queries a Prometheus reachable at PromBaseURL (typically a
+// kubectl port-forward to svc/prometheus-operated in the monitoring namespace).
+type K8sMonitorCluster struct {
+	PromBaseURL string
+}
+
+func NewK8sMonitorCluster(promBaseURL string) *K8sMonitorCluster {
+	return &K8sMonitorCluster{PromBaseURL: promBaseURL}
+}
+
+type promResult struct {
+	Status string `json:"status"`
+	Data   struct {
+		Result []struct {
+			Metric map[string]string `json:"metric"`
+			Value  []interface{}     `json:"value"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+func (c *K8sMonitorCluster) WaitForPrometheusReady(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	client := &http.Client{Timeout: 5 * time.Second}
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(c.PromBaseURL + "/-/ready")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				t.Log("Prometheus is ready")
+				return
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("Prometheus at %s not ready within %v", c.PromBaseURL, timeout)
+}
+
+func (c *K8sMonitorCluster) query(t *testing.T, q string) *promResult {
+	t.Helper()
+	reqURL := fmt.Sprintf("%s/api/v1/query?query=%s", c.PromBaseURL, url.QueryEscape(q))
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(reqURL)
+	if err != nil {
+		t.Logf("prometheus query failed: %v", err)
+		return nil
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var r promResult
+	if err := json.Unmarshal(body, &r); err != nil {
+		t.Logf("prometheus parse failed: %v", err)
+		return nil
+	}
+	if r.Status != "success" {
+		return nil
+	}
+	return &r
+}
+
+// QueryPromQL returns the first sample value as a string.
+func (c *K8sMonitorCluster) QueryPromQL(t *testing.T, q string) (string, bool) {
+	t.Helper()
+	r := c.query(t, q)
+	if r == nil || len(r.Data.Result) == 0 || len(r.Data.Result[0].Value) < 2 {
+		return "", false
+	}
+	v, ok := r.Data.Result[0].Value[1].(string)
+	return v, ok
+}
+
+// QueryVector returns the label set of every result series.
+func (c *K8sMonitorCluster) QueryVector(t *testing.T, q string) []map[string]string {
+	t.Helper()
+	r := c.query(t, q)
+	if r == nil {
+		return nil
+	}
+	out := make([]map[string]string, 0, len(r.Data.Result))
+	for _, s := range r.Data.Result {
+		out = append(out, s.Metric)
+	}
+	return out
+}
+
+// QueryMetricHasValue reports whether the metric exists with a non-zero value.
+func (c *K8sMonitorCluster) QueryMetricHasValue(t *testing.T, metricName string) bool {
+	t.Helper()
+	r := c.query(t, metricName)
+	if r == nil {
+		return false
+	}
+	for _, s := range r.Data.Result {
+		if len(s.Value) >= 2 {
+			if vs, ok := s.Value[1].(string); ok && vs != "0" && vs != "0.0" {
+				return true
+			}
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `go test ./tests/k8s/monitor/ -run TestPromBaseURL_Default -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/k8s/monitor/k8s_monitor_cluster.go tests/k8s/monitor/k8s_monitor_cluster_test.go
+git commit -m "test(k8s-monitor): add K8sMonitorCluster prometheus query helpers (#193)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task C2: Client load generator (`loadgen/main.go`)
+
+**Files:**
+- Create: `tests/k8s/monitor/loadgen/main.go`
+
+**Interfaces:**
+- Consumes: `config.NewConfiguration`, `etcd.GetRemoteEtcdClient`, `woodpecker.NewClient`, `metrics.RegisterClientMetricsWithRegisterer`, the `log.*` write/read API (signatures from `tests/chaos_mesh/workload/main_test.go`).
+- Produces: a `main` binary that serves `/metrics` on `:29099` and continuously appends/reads, populating `woodpecker_client_*` and (via the servers) `woodpecker_server_*`.
+
+- [ ] **Step 1: Implement `loadgen/main.go`** (Apache header + below)
+
+```go
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/etcd"
+	"github.com/zilliztech/woodpecker/common/metrics"
+	"github.com/zilliztech/woodpecker/woodpecker"
+	"github.com/zilliztech/woodpecker/woodpecker/log"
+)
+
+func main() {
+	configFile := flag.String("config-file", "/tmp/test-config.yaml", "woodpecker config path")
+	metricsAddr := flag.String("metrics-addr", ":29099", "Prometheus /metrics listen address")
+	logName := flag.String("log", "k8s-monitor-loadgen", "log name to write")
+	interval := flag.Duration("interval", 50*time.Millisecond, "append interval")
+	flag.Parse()
+
+	// Expose client metrics for the woodpecker-client PodMonitor to scrape.
+	metrics.RegisterClientMetricsWithRegisterer(prometheus.DefaultRegisterer)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	go func() {
+		if err := http.ListenAndServe(*metricsAddr, mux); err != nil {
+			panic(fmt.Sprintf("metrics server: %v", err))
+		}
+	}()
+
+	ctx := context.Background()
+	cfg, err := config.NewConfiguration(*configFile)
+	if err != nil {
+		panic(fmt.Sprintf("load config: %v", err))
+	}
+	etcdCli, err := etcd.GetRemoteEtcdClient(cfg.Etcd.GetEndpoints())
+	if err != nil {
+		panic(fmt.Sprintf("etcd client: %v", err))
+	}
+	cli, err := woodpecker.NewClient(ctx, cfg, etcdCli, true)
+	if err != nil {
+		panic(fmt.Sprintf("woodpecker client: %v", err))
+	}
+	defer cli.Close(ctx)
+
+	_ = cli.CreateLog(ctx, *logName) // idempotent
+	h, err := cli.OpenLog(ctx, *logName)
+	if err != nil {
+		panic(fmt.Sprintf("open log: %v", err))
+	}
+	w, err := h.OpenLogWriter(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("open writer: %v", err))
+	}
+	defer w.Close(ctx)
+
+	// Tail reader to exercise the read path (read-batch / reader metrics).
+	go func() {
+		earliest := log.EarliestLogMessageID()
+		r, err := h.OpenLogReader(ctx, &earliest, "loadgen-tail")
+		if err != nil {
+			return
+		}
+		defer r.Close(ctx)
+		for {
+			rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			_, _ = r.ReadNext(rctx)
+			cancel()
+		}
+	}()
+
+	fmt.Printf("loadgen: writing to %q every %s, metrics on %s\n", *logName, *interval, *metricsAddr)
+	seq := 0
+	tick := time.NewTicker(*interval)
+	defer tick.Stop()
+	for range tick.C {
+		seq++
+		wctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		res := <-w.WriteAsync(wctx, &log.WriteMessage{
+			Payload:    []byte(fmt.Sprintf("loadgen-%d", seq)),
+			Properties: map[string]string{"seq": fmt.Sprintf("%d", seq)},
+		})
+		cancel()
+		if res.Err != nil {
+			fmt.Printf("write %d err: %v\n", seq, res.Err)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Verify it compiles for the minikube node arch (linux)**
+
+Run: `cd /Users/zilliz/workspace_zilliz/e2e_src/woodpecker && GOOS=linux GOARCH=$(go env GOARCH) CGO_ENABLED=0 go build -o /tmp/wp-loadgen ./tests/k8s/monitor/loadgen`
+Expected: builds, `/tmp/wp-loadgen` exists. (If any `log.*`/`woodpecker.*` symbol differs, fix the call to match `tests/chaos_mesh/workload/main_test.go`, which uses the same API.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/k8s/monitor/loadgen/main.go
+git commit -m "test(k8s-monitor): add in-cluster client load generator (#193)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task C3: Monitoring + scrape manifests
+
+**Files:**
+- Create: `tests/k8s/monitor/manifests/kube-prometheus-values.yaml`
+- Create: `tests/k8s/monitor/manifests/podmonitor-server.yaml`
+- Create: `tests/k8s/monitor/manifests/podmonitor-client.yaml`
+- Create: `tests/k8s/monitor/manifests/client-loadgen.yaml`
+
+**Interfaces:**
+- Produces: Helm values (extras off, `externalLabels.cluster`, Grafana anonymous + dashboard sidecar); two PodMonitors; the client load-gen pod (labels `component=client`, named port `metrics` 29099).
+
+- [ ] **Step 1: Create `kube-prometheus-values.yaml`**
+
+```yaml
+nodeExporter: { enabled: false }
+kubeStateMetrics: { enabled: false }
+alertmanager: { enabled: false }
+defaultRules: { create: false }
+kubeApiServer: { enabled: false }
+kubelet: { enabled: false }
+kubeControllerManager: { enabled: false }
+kubeScheduler: { enabled: false }
+kubeProxy: { enabled: false }
+kubeEtcd: { enabled: false }
+coreDns: { enabled: false }
+prometheus:
+  prometheusSpec:
+    externalLabels:
+      cluster: woodpecker-minikube
+    podMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    retention: 2h
+grafana:
+  adminPassword: admin
+  grafana.ini:
+    auth.anonymous:
+      enabled: true
+      org_role: Admin
+    auth:
+      disable_login_form: true
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      labelValue: "1"
+      searchNamespace: ALL
+```
+
+- [ ] **Step 2: Create `podmonitor-server.yaml`**
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: woodpecker-server
+  namespace: woodpecker
+  labels:
+    app.kubernetes.io/name: woodpecker
+    app.kubernetes.io/component: server
+spec:
+  namespaceSelector:
+    matchNames: [woodpecker]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: woodpecker
+      app.kubernetes.io/component: server
+      app.kubernetes.io/instance: my-woodpecker
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      honorLabels: true
+```
+
+- [ ] **Step 3: Create `podmonitor-client.yaml`**
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: woodpecker-client
+  namespace: woodpecker
+  labels:
+    app.kubernetes.io/name: woodpecker
+    app.kubernetes.io/component: client
+spec:
+  namespaceSelector:
+    matchNames: [woodpecker]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: woodpecker
+      app.kubernetes.io/component: client
+      app.kubernetes.io/instance: my-woodpecker
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      honorLabels: true
+```
+
+- [ ] **Step 4: Create `client-loadgen.yaml`** (sleeps; the runner cp's the binary in and execs it)
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: wp-loadgen
+  namespace: woodpecker
+  labels:
+    app.kubernetes.io/name: woodpecker
+    app.kubernetes.io/component: client
+    app.kubernetes.io/instance: my-woodpecker
+spec:
+  containers:
+    - name: loadgen
+      image: golang:1.24
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash", "-c", "sleep infinity"]
+      ports:
+        - name: metrics
+          containerPort: 29099
+      resources:
+        requests: { cpu: "500m", memory: "512Mi" }
+  restartPolicy: Never
+```
+
+- [ ] **Step 5: Validate YAML parses**
+
+Run: `for f in tests/k8s/monitor/manifests/*.yaml; do python3 -c "import yaml,sys; list(yaml.safe_load_all(open('$f'))); print('ok','$f')"; done`
+Expected: `ok` for each file. (If PyYAML is unavailable, `kubectl apply --dry-run=client -f <f>` once a cluster exists — defer to Task C6.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/k8s/monitor/manifests/
+git commit -m "test(k8s-monitor): add kube-prometheus values + PodMonitors + loadgen pod (#193)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task C4: New k8s dashboards (server + client) as ConfigMaps
+
+**Files:**
+- Create: `tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json`
+- Create: `tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json`
+- Create: `tests/k8s/monitor/manifests/dashboard-configmaps.yaml`
+- Test: `tests/k8s/monitor/dashboards_test.go`
+
+**Interfaces:**
+- Produces: two dashboards using a `${prometheus}` datasource variable + `cluster`/`namespace`(k8s)/`log_ns`(+`log_id`/`server_job` on server) variables; both wrapped as `grafana_dashboard="1"` ConfigMaps.
+
+- [ ] **Step 1: Write the generator script**
+
+Create `tests/k8s/monitor/grafana/templates/.gen_k8s_dashboards.py` (throwaway; deleted in Step 5). It reads the **already-log_ns** Docker templates (post Task B1) and adds the front selectors:
+
+```python
+import json, pathlib, copy
+
+DOCKER = pathlib.Path("tests/docker/monitor/grafana/templates")
+OUT = pathlib.Path("tests/k8s/monitor/grafana/templates")
+OUT.mkdir(parents=True, exist_ok=True)
+JOB = 'woodpecker-node[0-9]+|woodpecker/woodpecker-server'
+
+def ds_var():
+    return {"name": "prometheus", "label": "Datasource", "type": "datasource",
+            "query": "prometheus", "current": {}, "options": [], "hide": 0,
+            "refresh": 1, "regex": "", "includeAll": False, "multi": False}
+
+def q_var(name, query, regex=None):
+    v = {"name": name, "type": "query",
+         "datasource": {"type": "prometheus", "uid": "${prometheus}"},
+         "query": query, "refresh": 2, "includeAll": True, "multi": True,
+         "current": {"text": "All", "value": "$__all"}}
+    if regex:
+        v["regex"] = regex
+    return v
+
+def retarget_datasource(o):
+    # point every datasource ref at the ${prometheus} variable
+    if isinstance(o, dict):
+        if o.get("type") == "prometheus" and "uid" in o and o.get("uid") != "${prometheus}":
+            o["uid"] = "${prometheus}"
+        return {k: retarget_datasource(v) for k, v in o.items()}
+    if isinstance(o, list):
+        return [retarget_datasource(x) for x in o]
+    return o
+
+def add_filter(expr, extra):
+    # insert extra label matchers right after the first "{" of each selector
+    out, i = [], 0
+    while True:
+        b = expr.find("{", i)
+        if b < 0:
+            out.append(expr[i:]); break
+        out.append(expr[i:b+1])
+        # if selector is non-empty, add a comma
+        nxt = expr[b+1:].lstrip()
+        sep = "" if nxt.startswith("}") else ", "
+        out.append(extra + sep)
+        i = b + 1
+    return "".join(out)
+
+def build(src, dst, extra_vars, panel_extra, uid):
+    obj = json.loads((DOCKER / src).read_text())
+    obj = retarget_datasource(obj)
+    obj["uid"] = uid
+    obj["title"] = obj["title"] + " (k8s)"
+    # rebuild templating list: prometheus, cluster, namespace, then the originals
+    orig = obj.get("templating", {}).get("list", [])
+    obj["templating"]["list"] = extra_vars + orig
+    # add cluster + k8s namespace + (log_ns already present) to every panel target
+    def walk(o):
+        if isinstance(o, dict):
+            if "expr" in o and isinstance(o["expr"], str):
+                o["expr"] = add_filter(o["expr"], panel_extra)
+            return {k: walk(v) for k, v in o.items()}
+        if isinstance(o, list):
+            return [walk(x) for x in o]
+        return o
+    obj = walk(obj)
+    (OUT / dst).write_text(json.dumps(obj, indent=2) + "\n")
+    blob = json.dumps(obj)
+    assert '__DATASOURCE_UID__' not in blob, f"{dst}: stray placeholder"
+    assert '${prometheus}' in blob, f"{dst}: missing datasource var"
+    names = [v["name"] for v in obj["templating"]["list"]]
+    print(f"OK {dst}: vars={names}")
+
+# Server: prepend prometheus, cluster, namespace(k8s); log_ns/log_id/server_job already exist
+server_vars = [
+    ds_var(),
+    q_var("cluster", "label_values(go_info, cluster)"),
+    q_var("namespace", f'label_values(go_info{{job=~"{JOB}", cluster=~"$cluster"}}, namespace)'),
+]
+build("dashboard_server.json", "dashboard_server_k8s.json", server_vars,
+      'cluster=~"$cluster", namespace=~"$namespace"', "woodpecker-server-k8s")
+
+# Client: prepend prometheus, cluster, namespace(k8s); log_ns already exists
+client_vars = [
+    ds_var(),
+    q_var("cluster", "label_values(go_info, cluster)"),
+    q_var("namespace", 'label_values(woodpecker_client_append_requests_total{cluster=~"$cluster"}, namespace)'),
+]
+build("dashboard_client.json", "dashboard_client_k8s.json", client_vars,
+      'cluster=~"$cluster", namespace=~"$namespace"', "woodpecker-client-k8s")
+```
+
+- [ ] **Step 2: Run the generator, verify assertions**
+
+Run: `python3 tests/k8s/monitor/grafana/templates/.gen_k8s_dashboards.py`
+Expected: two `OK …: vars=['prometheus','cluster','namespace',…]` lines, no assertion errors.
+
+- [ ] **Step 3: Write the dashboard validation test**
+
+Create `tests/k8s/monitor/dashboards_test.go`:
+
+```go
+package monitor
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestK8sDashboards_Valid(t *testing.T) {
+	for _, f := range []string{
+		"grafana/templates/dashboard_server_k8s.json",
+		"grafana/templates/dashboard_client_k8s.json",
+	} {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			t.Fatalf("parse %s: %v", f, err)
+		}
+		s := string(raw)
+		if strings.Contains(s, "__DATASOURCE_UID__") {
+			t.Errorf("%s: stray __DATASOURCE_UID__", f)
+		}
+		if !strings.Contains(s, "${prometheus}") {
+			t.Errorf("%s: missing ${prometheus} datasource var", f)
+		}
+		names := map[string]bool{}
+		for _, v := range obj["templating"].(map[string]any)["list"].([]any) {
+			names[v.(map[string]any)["name"].(string)] = true
+		}
+		for _, want := range []string{"prometheus", "cluster", "namespace", "log_ns"} {
+			if !names[want] {
+				t.Errorf("%s: missing template var %q", f, want)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run the test, verify PASS**
+
+Run: `go test ./tests/k8s/monitor/ -run TestK8sDashboards_Valid -v`
+Expected: PASS.
+
+- [ ] **Step 5: Generate the ConfigMap manifest, remove the throwaway script**
+
+```bash
+cd /Users/zilliz/workspace_zilliz/e2e_src/woodpecker
+{
+  echo '# Generated from grafana/templates/*.json — Grafana sidecar imports these.'
+  for n in server client; do
+    echo '---'
+    echo 'apiVersion: v1'
+    echo 'kind: ConfigMap'
+    echo 'metadata:'
+    echo "  name: woodpecker-${n}-k8s-dashboard"
+    echo '  namespace: monitoring'
+    echo '  labels: { grafana_dashboard: "1" }'
+    echo 'data:'
+    echo "  dashboard_${n}_k8s.json: |"
+    sed 's/^/    /' "tests/k8s/monitor/grafana/templates/dashboard_${n}_k8s.json"
+  done
+} > tests/k8s/monitor/manifests/dashboard-configmaps.yaml
+python3 -c "import yaml; list(yaml.safe_load_all(open('tests/k8s/monitor/manifests/dashboard-configmaps.yaml'))); print('configmaps ok')"
+rm tests/k8s/monitor/grafana/templates/.gen_k8s_dashboards.py
+```
+Expected: `configmaps ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/k8s/monitor/grafana/templates/ tests/k8s/monitor/manifests/dashboard-configmaps.yaml tests/k8s/monitor/dashboards_test.go
+git commit -m "test(k8s-monitor): add k8s server/client dashboards + configmaps (#193)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task C5: E2E verification test + one-click runner + README
+
+**Files:**
+- Create: `tests/k8s/monitor/monitor_test.go`
+- Create: `tests/k8s/monitor/run_monitor_tests.sh` (executable)
+- Create: `tests/k8s/monitor/README.md`
+
+**Interfaces:**
+- Consumes: `K8sMonitorCluster` (C1), the load-gen pod + PodMonitors (C2/C3), the running stack (C5 runner).
+- Produces: `TestK8sMonitor_Metrics` (gated on `WP_K8S_PROM_URL`), and the `run_monitor_tests.sh` entry point.
+
+- [ ] **Step 1: Implement `monitor_test.go`** (Apache header + below)
+
+```go
+package monitor
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestK8sMonitor_Metrics verifies scrape targets and the cluster/namespace/log_ns
+// label scheme against a Prometheus reachable at $WP_K8S_PROM_URL (a kubectl
+// port-forward set up by run_monitor_tests.sh). Skipped when unset so the package
+// stays `go test ./...`-safe without a live cluster.
+func TestK8sMonitor_Metrics(t *testing.T) {
+	base := os.Getenv("WP_K8S_PROM_URL")
+	if base == "" {
+		t.Skip("WP_K8S_PROM_URL unset; run via run_monitor_tests.sh")
+	}
+	c := NewK8sMonitorCluster(base)
+	c.WaitForPrometheusReady(t, 60*time.Second)
+
+	t.Run("ServerTargetUp", func(t *testing.T) {
+		if v, ok := c.QueryPromQL(t, `count(up{job="woodpecker/woodpecker-server"}==1)`); !ok || v == "0" {
+			t.Errorf("no server targets up (got %q)", v)
+		}
+	})
+	t.Run("ClientTargetUp", func(t *testing.T) {
+		if v, ok := c.QueryPromQL(t, `count(up{job="woodpecker/woodpecker-client"}==1)`); !ok || v == "0" {
+			t.Errorf("no client target up (got %q)", v)
+		}
+	})
+	t.Run("ServerMetrics", func(t *testing.T) {
+		for _, m := range []string{
+			"woodpecker_server_logstore_active_logs",
+			"woodpecker_server_logstore_operations_total",
+			"woodpecker_server_file_operations_total",
+		} {
+			if !c.QueryMetricHasValue(t, m) {
+				t.Errorf("server metric %s missing/zero", m)
+			}
+		}
+	})
+	t.Run("ClientMetrics", func(t *testing.T) {
+		for _, m := range []string{
+			"woodpecker_client_append_requests_total",
+			"woodpecker_client_log_handle_operations_total",
+		} {
+			if !c.QueryMetricHasValue(t, m) {
+				t.Errorf("client metric %s missing/zero", m)
+			}
+		}
+	})
+	t.Run("LabelScheme", func(t *testing.T) {
+		series := c.QueryVector(t, "woodpecker_server_logstore_active_logs")
+		if len(series) == 0 {
+			t.Fatal("no logstore_active_logs series")
+		}
+		for _, m := range series {
+			if m["cluster"] != "woodpecker-minikube" {
+				t.Errorf("cluster=%q, want woodpecker-minikube", m["cluster"])
+			}
+			if m["namespace"] != "woodpecker" {
+				t.Errorf("namespace=%q, want k8s namespace woodpecker", m["namespace"])
+			}
+			if m["log_ns"] == "" {
+				t.Errorf("missing log_ns label: %v", m)
+			}
+			if _, bad := m["exported_namespace"]; bad {
+				t.Errorf("unexpected exported_namespace: %v", m)
+			}
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run the test with no cluster, verify it SKIPS**
+
+Run: `go test ./tests/k8s/monitor/ -run TestK8sMonitor_Metrics -v`
+Expected: `--- SKIP` (env var unset). Confirms the package builds and is `go test ./...`-safe.
+
+- [ ] **Step 3: Implement `run_monitor_tests.sh`** (Apache header + below; `chmod +x`)
+
+```bash
+#!/bin/bash
+# <Apache license header — copy from tests/docker/monitor/run_monitor_tests.sh>
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+export CLUSTER_NAME="${CLUSTER_NAME:-wp-monitor}"
+export CR_NAME="${CR_NAME:-my-woodpecker}"
+export NAMESPACE="${NAMESPACE:-woodpecker}"
+export REPLICAS="${REPLICAS:-3}"
+export WP_IMG="${WP_IMG:-zilliztech/woodpecker:v0.1.26}"
+export MK_CPUS="${MK_CPUS:-4}" MK_MEMORY="${MK_MEMORY:-4096}"
+MON_NS="monitoring"
+HELM_RELEASE="kps"
+NO_CLEANUP="${NO_CLEANUP:-false}"
+[ "${1:-}" = "--no-cleanup" ] && NO_CLEANUP=true
+
+source "$PROJECT_ROOT/deployments/operator/test/lib.sh"
+
+preload_image() { log "preload: $1"; docker pull "$1" || fail "docker pull $1"; minikube -p "$CLUSTER_NAME" image load "$1" || fail "image load $1"; }
+
+bringup() {
+  wp_minikube_start
+  kubectl label node "$CLUSTER_NAME" topology.kubernetes.io/zone=zone-a topology.kubernetes.io/region=region-local --overwrite
+  preload_image quay.io/coreos/etcd:v3.5.18
+  preload_image minio/minio:RELEASE.2024-06-13T22-53-53Z
+  kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+  # lib.sh applies deps/CR namespace-lessly, so pin the active namespace to $NAMESPACE
+  # (its seed DNS uses .$NAMESPACE.svc, so this keeps pods and DNS consistent).
+  kubectl config set-context --current --namespace="$NAMESPACE"
+  wp_deploy_operator; wp_build_wp_image
+  wp_deploy_deps; wp_create_cr; wp_wait_healthy
+}
+
+install_monitoring() {
+  helm repo add prometheus-community https://prometheus-community.github.io/helm-charts 2>/dev/null || true
+  helm repo update
+  log "preloading kube-prometheus-stack images"
+  helm template "$HELM_RELEASE" prometheus-community/kube-prometheus-stack -n "$MON_NS" \
+    -f "$SCRIPT_DIR/manifests/kube-prometheus-values.yaml" 2>/dev/null \
+    | grep -hoE 'image: *"?[^"[:space:]]+' | sed -E 's/image: *"?//' | sort -u \
+    | while read -r img; do [ -n "$img" ] && preload_image "$img"; done
+  helm upgrade --install "$HELM_RELEASE" prometheus-community/kube-prometheus-stack \
+    -n "$MON_NS" --create-namespace -f "$SCRIPT_DIR/manifests/kube-prometheus-values.yaml" --wait --timeout 8m
+  kubectl apply -f "$SCRIPT_DIR/manifests/podmonitor-server.yaml"
+  kubectl apply -f "$SCRIPT_DIR/manifests/podmonitor-client.yaml"
+  kubectl apply -f "$SCRIPT_DIR/manifests/dashboard-configmaps.yaml"
+}
+
+start_loadgen() {
+  kubectl apply -f "$SCRIPT_DIR/manifests/client-loadgen.yaml"
+  kubectl -n "$NAMESPACE" wait --for=condition=Ready pod/wp-loadgen --timeout=120s
+  log "building loadgen binary on host"
+  ( cd "$PROJECT_ROOT" && GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 \
+      go build -o /tmp/wp-loadgen ./tests/k8s/monitor/loadgen ) || fail "loadgen build"
+  kubectl -n "$NAMESPACE" cp /tmp/wp-loadgen wp-loadgen:/root/wp-loadgen
+  # client config: reuse the same etcd/minio/seeds the CR uses (see README for the file)
+  kubectl -n "$NAMESPACE" cp "$SCRIPT_DIR/manifests/loadgen-config.yaml" wp-loadgen:/tmp/test-config.yaml
+  kubectl -n "$NAMESPACE" exec wp-loadgen -- bash -c 'chmod +x /root/wp-loadgen && nohup /root/wp-loadgen -config-file=/tmp/test-config.yaml >/tmp/loadgen.log 2>&1 &'
+  log "loadgen started; sleeping 45s to accumulate metrics"; sleep 45
+}
+
+run_tests() {
+  kubectl -n "$MON_NS" port-forward svc/prometheus-operated 9090:9090 >/tmp/pf-prom.log 2>&1 &
+  PF_PID=$!; trap 'kill $PF_PID 2>/dev/null || true' RETURN
+  sleep 5
+  WP_K8S_PROM_URL="http://localhost:9090" go test "$PROJECT_ROOT/tests/k8s/monitor/" -run TestK8sMonitor_Metrics -v -count=1 -timeout 300s
+}
+
+cleanup() {
+  helm uninstall "$HELM_RELEASE" -n "$MON_NS" 2>/dev/null || true
+  minikube delete -p "$CLUSTER_NAME" 2>/dev/null || true
+}
+
+main() {
+  bringup
+  install_monitoring
+  start_loadgen
+  if run_tests; then RC=0; else RC=1; fi
+  if [ "$NO_CLEANUP" = true ]; then
+    log "kept up. Grafana: $(minikube -p "$CLUSTER_NAME" service -n "$MON_NS" "$HELM_RELEASE-grafana" --url 2>/dev/null | head -1)"
+    log "Prometheus: kubectl -n $MON_NS port-forward svc/prometheus-operated 9090:9090"
+  else
+    cleanup
+  fi
+  exit $RC
+}
+main "$@"
+```
+
+Note: `loadgen-config.yaml` is the client config pointing at `etcd.$NAMESPACE.svc` / `minio.$NAMESPACE.svc` and the server seeds — author it in Step 4 (mirror the `client:` block from `lib.sh:wp_write_client_config`, with `NAMESPACE=woodpecker`).
+
+- [ ] **Step 4: Create `tests/k8s/monitor/manifests/loadgen-config.yaml`**
+
+Copy the client config block from `deployments/operator/test/lib.sh` (`wp_write_client_config`), substituting `${NAMESPACE}`→`woodpecker`, `${CR_NAME}`→`my-woodpecker`, `${REPLICAS}`→3 (3 seed entries `my-woodpecker-server-{0,1,2}.my-woodpecker-server-headless.woodpecker.svc:18080`). Validate:
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('tests/k8s/monitor/manifests/loadgen-config.yaml')); print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 5: Write `README.md`**
+
+Create `tests/k8s/monitor/README.md` documenting: prerequisites (minikube, docker, kubectl, helm, go); `./run_monitor_tests.sh` / `--no-cleanup`; the `cluster`/`namespace`(k8s)/`log_ns` label scheme and the **breaking-change** note (prod dashboards must move `namespace`→`log_ns`); resource note (bump `MK_CPUS=6 MK_MEMORY=8192` if pods stay Pending); and that the prod `PodMonitor` needs no change after the `log_ns` rename.
+
+- [ ] **Step 6: Verify the package builds + vets and shell parses**
+
+Run:
+```bash
+go vet ./tests/k8s/monitor/...
+bash -n tests/k8s/monitor/run_monitor_tests.sh
+chmod +x tests/k8s/monitor/run_monitor_tests.sh
+```
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/k8s/monitor/monitor_test.go tests/k8s/monitor/run_monitor_tests.sh tests/k8s/monitor/manifests/loadgen-config.yaml tests/k8s/monitor/README.md
+git commit -m "test(k8s-monitor): add e2e verification test, runner, README (#193)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+### Task C6: Live end-to-end dry run (manual gate)
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Run the suite end to end (requires Docker + minikube)**
+
+Run: `cd /Users/zilliz/workspace_zilliz/e2e_src/woodpecker && ./tests/k8s/monitor/run_monitor_tests.sh --no-cleanup`
+Expected: minikube up → operator + 3 server pods Ready → kube-prometheus-stack installed → both PodMonitors `Up` → `TestK8sMonitor_Metrics` PASS.
+
+- [ ] **Step 2: Confirm the dashboards render with data**
+
+Open the printed Grafana URL → "Woodpecker - Server (Namespace) (k8s)" and the client dashboard. Verify the `cluster` / `namespace` (= `woodpecker`) / `log_ns` dropdowns populate and panels show data. Spot-check in Prometheus that `woodpecker_server_logstore_active_logs` has `namespace="woodpecker"` and a non-empty `log_ns`, and **no** `exported_namespace`.
+
+- [ ] **Step 3: Tear down**
+
+Run: `minikube delete -p wp-monitor`
+Expected: cluster removed.
+
+- [ ] **Step 4: Final review commit (if any fixes were needed during C6)**
+
+```bash
+git add -A && git commit -m "test(k8s-monitor): fixes from end-to-end dry run (#193)"
+```
+
+---
+
+## Self-Review notes (for the implementer)
+
+- **Spec coverage:** A1↔Workstream A; B1↔Workstream B; C1–C6↔Workstream C (cluster helper, loadgen, manifests, dashboards, test+runner+README, dry run). The breaking-change + prod-follow-up are documented in the README (C5 Step 5).
+- **Ordering:** A1 must land before B1 and C4 (dashboards assume the `log_ns` label). C1–C3 are order-independent; C4 depends on B1's log_ns templates; C5 depends on C1–C4.
+- **Type consistency:** `K8sMonitorCluster` methods (`WaitForPrometheusReady`, `QueryPromQL`, `QueryVector`, `QueryMetricHasValue`) are defined in C1 and used unchanged in C5. The loadgen uses the exact `log.*`/`woodpecker.*`/`config.*`/`etcd.*` API from `tests/chaos_mesh/workload/main_test.go`.
+- **Known integration risks to watch:** (1) `wp_create_cr`/`wp_deploy_deps` in `lib.sh` default to `NAMESPACE` — confirm they create resources in `woodpecker`, not `default` (the CR's headless service DNS in `loadgen-config.yaml` must match). (2) kube-prometheus-stack image preload list parsing — verify the `helm template | grep image:` extraction catches all images on the installed chart version.

--- a/docs/superpowers/specs/2026-06-22-k8s-monitor-suite-design.md
+++ b/docs/superpowers/specs/2026-06-22-k8s-monitor-suite-design.md
@@ -1,0 +1,320 @@
+# Woodpecker — `log_ns` metric-label rename + K8s (minikube) Monitoring Suite & Dashboards
+
+- **Issue:** [zilliztech/woodpecker#193](https://github.com/zilliztech/woodpecker/issues/193)
+- **Date:** 2026-06-22
+- **Status:** Approved design, ready for implementation plan
+
+## Problem
+
+The repo has a Docker-Compose monitoring suite (`tests/docker/monitor/`) that brings
+up a 4-node Woodpecker cluster + Prometheus + Grafana, drives I/O, and verifies that
+`woodpecker_*` metrics report correctly, plus Grafana dashboard templates.
+
+We have no equivalent for a **Kubernetes** deployment. In production (Zilliz Cloud /
+VDC) Woodpecker runs under the **Woodpecker operator** and is scraped by a **Prometheus
+Operator** via a **`PodMonitor`** CR. That path is untested locally/in CI.
+
+The deeper issue is a **label-naming collision**:
+
+- Woodpecker emits its own metric label **`namespace`** =
+  `BuildMetricsNamespace(bucket, rootPath)` (e.g. `woodpecker/files`) — an
+  *application/logical* namespace, **not** the k8s namespace. But `namespace` is a
+  reserved dimension in any k8s scrape (Prometheus attaches the pod's k8s namespace as
+  a target label `namespace`). The two fight: on VDC the production `PodMonitor` uses
+  `honorLabels: true`, so the **app** label wins and the **real k8s namespace is
+  destroyed** — you can't filter metrics by k8s namespace / instance.
+
+The fix is to stop using the k8s-reserved word: **rename the application metric label
+`namespace` → `log_ns`** at the source. Then the k8s `namespace` target label is free
+to mean the k8s namespace, `log_ns` carries the logical namespace, and there is no
+collision regardless of `honorLabels`. Dashboards then filter by `cluster`, k8s
+`namespace`, and `log_ns` independently.
+
+## Goals
+
+This is **three coordinated workstreams** (A is a prerequisite for the dashboards in B
+and C to line up with the data):
+
+- **A. Source rename.** Rename the metric label `namespace` → `log_ns` in
+  `common/metrics/` (client + service metrics) so Woodpecker never emits the
+  k8s-reserved `namespace` label.
+- **B. Update the existing Docker monitor dashboards** (`tests/docker/monitor/`) to use
+  `log_ns` instead of `namespace`, matching the renamed metric.
+- **C. New `tests/k8s/monitor/` suite** — a **minikube** mirror of the Docker suite:
+  one command does **build → deploy (operator + WoodpeckerCluster) → install monitoring
+  → run workload → verify metrics**, leaving Grafana reachable to open the dashboard URL
+  (`--no-cleanup`, same ergonomics as Docker). Monitoring is installed the **simplest**
+  way — the `kube-prometheus-stack` Helm chart (Operator + Prometheus + Grafana),
+  trimmed of extras — scraping Woodpecker via a `PodMonitor`. Ships **new k8s server +
+  client dashboard templates** whose variables pre-filter by `cluster`, k8s `namespace`,
+  and `log_ns`, so you can isolate one instance's server or client behavior.
+
+Reuse the existing operator bring-up library (`deployments/operator/test/lib.sh`) and
+the chaos suite's minikube helpers (`preload_image`, zone-label, `push_workload`) — this
+is "add monitoring + dashboards," not "build a k8s e2e from scratch."
+
+## Non-Goals
+
+- Testing Prometheus/Grafana themselves, alerting rules, or long-term storage.
+- Updating **production VDC** dashboards. After the renamed Woodpecker version ships,
+  prod dashboards (incl. the ones fixed earlier this week) must swap `namespace` →
+  `log_ns`; that rollout is a follow-up, tracked separately. The prod `PodMonitor`
+  itself needs **no** change — once the app emits `log_ns`, its `honorLabels: true`
+  already yields a clean k8s `namespace` + `log_ns`.
+- Multi-node / multi-AZ minikube. Single node with a synthetic zone label suffices.
+
+## Grounding (verified facts)
+
+- **Rename is mechanical & contained.** The label key `"namespace"` appears only in the
+  `[]string{…}` label-name slices — 21 in `client_metrics.go`, 24 in
+  `service_metrics.go`. Values are passed **positionally** (`WithLabelValues(namespace,
+  …)`), so renaming the key strings is sufficient; no call-site signature changes. No
+  code outside `common/metrics/` references the label name. `BuildMetricsNamespace`
+  builds the *value* (`bucket/rootPath`) and is unaffected (the value stays; only the
+  label key changes).
+- **Operator labels & port match the wiki `PodMonitor` as-is.** `labels.go` sets
+  `app.kubernetes.io/{name=woodpecker, instance=<CR>, component=server}`;
+  `reconcile_statefulset.go` exposes container port **`metrics`** (`spec.MetricsPort`,
+  default 9091) serving `/metrics` and `/healthz`. No operator changes needed.
+- **In k8s the scrape `job` is `woodpecker/woodpecker-server`** (`<ns>/<podmonitor>`),
+  matching the wiki's `server_job` regex.
+- **Bring-up is reusable.** `lib.sh` provides `wp_minikube_start`, `wp_deploy_operator`,
+  `wp_build_wp_image`, `wp_deploy_deps` (etcd+MinIO), `wp_create_cr`, `wp_wait_healthy`,
+  `wp_launch_client_pod`. The chaos `run_network_chaos.sh` / `smoke-test.sh` add
+  `preload_image` (host-pull → `minikube image load`, dodging the host loopback-proxy
+  that blocks the node from registries), single-node zone labeling, and `push_workload`
+  (build a Go binary on the host, `kubectl cp` into a pod, exec it).
+
+## Workstream A — rename `namespace` → `log_ns` in `common/metrics/`
+
+- In `client_metrics.go` and `service_metrics.go`, change every label-name slice entry
+  `"namespace"` → `"log_ns"` (e.g. `[]string{"node_id", "namespace", "log_id"}` →
+  `[]string{"node_id", "log_ns", "log_id"}`). Positional `WithLabelValues(...)` calls
+  are unchanged. Optionally rename local vars/params named `namespace` → `logNs` for
+  readability (cosmetic).
+- Keep `BuildMetricsNamespace` (returns the value); optionally add a doc note that its
+  result populates the `log_ns` label.
+- Update `common/metrics/*_test.go` that assert on label names; run the package tests.
+- This is a **breaking change** to metric output — see Risks.
+
+## Workstream B — update Docker monitor dashboards to `log_ns`
+
+In `tests/docker/monitor/grafana/templates/`:
+
+- `dashboard_server.json`: rename the `namespace` template variable → `log_ns`
+  (query `query_result(max by (log_ns)(woodpecker_server_logstore_active_logs{…,
+  log_ns=~".+"}))`, regex `/log_ns="([^"]+)"/`); the `log_id` variable's inner filter
+  `namespace=~"$namespace"` → `log_ns=~"$log_ns"`; every panel selector
+  `namespace=~"$namespace"` → `log_ns=~"$log_ns"`.
+- `dashboard_client.json`: rename the `namespace` variable → `log_ns` (query
+  `label_values(woodpecker_client_append_requests_total, log_ns)`); panels
+  `namespace=~"$namespace"` → `log_ns=~"$log_ns"`.
+- `README.md` metrics tables: the "Labels" column `namespace` → `log_ns`.
+- `monitor_test.go`: update any PromQL that references the `namespace` label (verified
+  during implementation).
+
+> Note: the Docker dashboard files currently carry an **uncommitted** half-conversion
+> to a `${datasource}` variable (no variable defined → broken). This work will land them
+> in a coherent state — default plan: revert the stray `${datasource}` edit back to the
+> committed `__DATASOURCE_UID__` base (which `grafana/setup.go` expects) and apply the
+> `log_ns` rename on top. (If you'd rather also finish the datasource-variable
+> conversion, say so and we'll fold it in.)
+
+## Workstream C — k8s (minikube) monitoring suite
+
+### Directory layout (mirrors `tests/docker/monitor/`)
+
+```
+tests/k8s/monitor/
+├── README.md
+├── run_monitor_tests.sh          # one-click bring-up + monitoring install + test
+├── k8s_monitor_cluster.go        # K8sMonitorCluster: kubectl/port-forward + Prometheus query helpers
+├── monitor_test.go               # workload + woodpecker_{server,client}_* metric verification
+├── loadgen/
+│   └── main.go                   # in-cluster client load generator: write/read loop + /metrics endpoint
+├── manifests/
+│   ├── podmonitor-server.yaml    # PodMonitor for server pods (port metrics) — matches prod wiki
+│   ├── podmonitor-client.yaml    # PodMonitor for the client load-gen pod
+│   ├── client-loadgen.yaml       # client pod: labels component=client + named port metrics
+│   ├── kube-prometheus-values.yaml  # trimmed Helm values (externalLabels.cluster, grafana, extras off)
+│   └── dashboard-configmaps.yaml # ConfigMap(s) labeled grafana_dashboard="1" wrapping the dashboard JSON
+└── grafana/templates/
+    ├── dashboard_server_k8s.json # server vars: prometheus/cluster/namespace/log_ns/log_id/server_job
+    └── dashboard_client_k8s.json # client vars: prometheus/cluster/namespace/log_ns
+```
+
+The Prometheus-query helpers (`WaitForPrometheusReady`, `QueryMetric`,
+`QueryMetricHasValue`, `QueryPromQL`) are lifted from the Docker suite's
+`monitor_cluster.go`; they just hit an HTTP endpoint, pointed at a `kubectl
+port-forward` local port instead of `localhost:9090`.
+
+### Bring-up flow (`run_monitor_tests.sh`)
+
+1. `wp_minikube_start`; label the node with synthetic `topology.kubernetes.io/zone` +
+   `region` (single-node spread-constraint workaround, from chaos).
+2. `preload_image` etcd + MinIO; `wp_deploy_operator`; `wp_build_wp_image`;
+   `wp_deploy_deps`; `wp_create_cr` (namespace `woodpecker`); `wp_wait_healthy`.
+3. **Install monitoring (Helm):** `helm repo add prometheus-community … && helm upgrade
+   --install kps prometheus-community/kube-prometheus-stack -n monitoring
+   --create-namespace -f manifests/kube-prometheus-values.yaml --wait`, preloading the
+   chart's images with the chaos `helm template … | preload_image` trick.
+4. `kubectl apply` the server + client `PodMonitor`s, the client load-gen pod, and the
+   dashboard ConfigMaps.
+5. Run workload + `go test`: the load-gen pod drives client writes/reads — populating
+   both `woodpecker_server_*` (via the servers) and `woodpecker_client_*` (its own
+   process); the test verifies via port-forwarded Prometheus (below).
+6. `--no-cleanup`: print the Grafana URL (`minikube service -n monitoring kps-grafana
+   --url`) + Prometheus URL, leave the cluster up. Otherwise `helm uninstall` + delete
+   CR/deps (or `minikube delete`).
+
+Knobs (`CLUSTER_NAME=wp-monitor`, `CR_NAME`, `NAMESPACE=woodpecker`, `REPLICAS=3`,
+`WP_IMG`, `MK_*`) are exported before sourcing `lib.sh`, like `smoke-test.sh`.
+
+### Monitoring stack — `kube-prometheus-values.yaml` (minimal)
+
+```yaml
+# Trim everything we don't need; the suite tests Woodpecker, not the monitoring stack.
+nodeExporter:        { enabled: false }
+kubeStateMetrics:    { enabled: false }
+alertmanager:        { enabled: false }
+defaultRules:        { create: false }
+kubeApiServer:       { enabled: false }   # (other kube* scrape jobs off — only Woodpecker)
+prometheus:
+  prometheusSpec:
+    externalLabels: { cluster: woodpecker-minikube }   # enables the `cluster` variable
+    podMonitorSelectorNilUsesHelmValues: false         # select our PodMonitors w/o the release label
+    serviceMonitorSelectorNilUsesHelmValues: false
+    retention: 2h
+grafana:
+  adminPassword: admin
+  grafana.ini:                                # frictionless viewing (like the Docker suite)
+    auth.anonymous: { enabled: true, org_role: Admin }
+    auth: { disable_login_form: true }
+  sidecar:
+    dashboards: { enabled: true, label: grafana_dashboard, labelValue: "1" }
+  # Prometheus datasource auto-provisioned by the chart (name "Prometheus", default).
+```
+
+Grafana auto-provisions the datasource and the sidecar imports any ConfigMap labeled
+`grafana_dashboard: "1"` — **no custom Grafana setup code** (unlike the Docker suite's
+`grafana/setup.go`).
+
+### `PodMonitor` (matches the prod wiki — no relabel needed)
+
+Because Workstream A makes the app emit `log_ns` (not `namespace`), there is **no label
+collision** and therefore **no `metricRelabelings`**. The `PodMonitor` is literally the
+deploy wiki's:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: woodpecker-server
+  namespace: woodpecker
+  labels: { app.kubernetes.io/name: woodpecker, app.kubernetes.io/component: server }
+spec:
+  namespaceSelector: { matchNames: [woodpecker] }
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: woodpecker
+      app.kubernetes.io/component: server
+      app.kubernetes.io/instance: my-woodpecker   # = $CR_NAME
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      honorLabels: true     # matches the wiki; after the rename, true/false are equivalent (no collision)
+```
+
+Result on every server series: `cluster` (external label), `namespace` = **k8s
+namespace** (`woodpecker`, the target label), `log_ns` = **app/logical namespace**
+(`woodpecker/files`), plus `node_id`, `log_id`, `job=woodpecker/woodpecker-server`,
+`pod`, etc.
+
+A **second `PodMonitor` (`woodpecker-client`)** is identical except its `selector`
+matches `app.kubernetes.io/component: client` (the load-gen pod), producing
+`woodpecker_client_*` under the same `cluster` / `namespace` (k8s) / `log_ns` scheme.
+
+### Workload + verification
+
+- **Client load generator** (`loadgen/main.go`) runs as an **in-cluster pod** labeled
+  `app.kubernetes.io/{name=woodpecker, component=client, instance=<CR>}` with a named
+  container port `metrics`. Built on the host (`GOOS=linux`) and delivered via the chaos
+  `push_workload` pattern (`kubectl cp` + exec), it creates a Woodpecker client against
+  the in-cluster servers/etcd/MinIO, calls `RegisterClientMetricsWithRegisterer` and
+  serves `promhttp` on the `metrics` port (the mechanism the Docker suite uses on
+  `:29099`), and runs a continuous append/read loop. One workload populates **both**
+  `woodpecker_server_*` and `woodpecker_client_*`.
+- **Verification** (`monitor_test.go`, host-side): `kubectl port-forward -n monitoring
+  svc/prometheus-operated 9090` (the operator always creates this stable headless
+  service for the Prometheus CR, regardless of Helm release name), then assert:
+  1. Both targets **Up** — `up{job="woodpecker/woodpecker-server"}==1` (count ==
+     REPLICAS) and `up{job="woodpecker/woodpecker-client"}==1`.
+  2. Representative `woodpecker_server_*` **and** `woodpecker_client_*` metrics exist
+     with non-zero values after the workload.
+  3. The label scheme is correct: series carry `cluster="woodpecker-minikube"`,
+     `namespace="woodpecker"` (k8s), and `log_ns="woodpecker/files"` (app), and **no
+     `namespace` with a slash / no `exported_namespace`** — the regression guard proving
+     the source rename took effect and the k8s namespace is intact.
+
+### New k8s dashboards
+
+**Server (`dashboard_server_k8s.json`)** — derived from `dashboard_server.json`.
+Template variables (`templating.list`, in order):
+
+| var | type | query | regex |
+|---|---|---|---|
+| `prometheus` | datasource | (type `prometheus`, picks the provisioned datasource) | — |
+| `cluster` | query | `label_values(go_info, cluster)` | — |
+| `namespace` | query | `label_values(go_info{job=~"woodpecker-node[0-9]+\|woodpecker/woodpecker-server", cluster=~"$cluster"}, namespace)` | — |
+| `log_ns` | query | `query_result(max by (log_ns)(woodpecker_server_logstore_active_logs{job=~"woodpecker-node[0-9]+\|woodpecker/woodpecker-server", namespace=~"$namespace", log_ns=~".+"}))` | `/log_ns="([^"]+)"/` |
+| `log_id` | query | `query_result(max by (log_id)(woodpecker_server_logstore_active_segments{job=~"woodpecker-node[0-9]+\|woodpecker/woodpecker-server", namespace=~"$namespace", log_ns=~"$log_ns", log_id=~".+"}))` | `/log_id="([^"]+)"/` |
+| `server_job` | query | `label_values(go_goroutines{job=~"woodpecker-node[0-9]+\|woodpecker/woodpecker-server"}, job)` | — |
+
+All datasource refs use `${prometheus}`. Each of the 70 panel selectors is rewritten
+`{namespace=~"$namespace", log_id=~"$log_id"}` →
+`{cluster=~"$cluster", namespace=~"$namespace", log_ns=~"$log_ns", log_id=~"$log_id"}`
+(old app `namespace` filter becomes `log_ns`; new `cluster` + k8s `namespace` added).
+
+**Client (`dashboard_client_k8s.json`)** — derived from `dashboard_client.json` (single
+`namespace` variable today). Prepend the three selectors and rename:
+
+| var | type | query |
+|---|---|---|
+| `prometheus` | datasource | (type `prometheus`) |
+| `cluster` | query | `label_values(go_info, cluster)` |
+| `namespace` | query | `label_values(woodpecker_client_append_requests_total{cluster=~"$cluster"}, namespace)` |
+| `log_ns` | query | `label_values(woodpecker_client_append_requests_total{cluster=~"$cluster", namespace=~"$namespace"}, log_ns)` |
+
+The 14 client panel selectors: `{namespace=~"$namespace"}` →
+`{cluster=~"$cluster", namespace=~"$namespace", log_ns=~"$log_ns"}` (panels still group
+by `log_id`). Both k8s dashboards reference `${prometheus}` and ship as
+`grafana_dashboard="1"` ConfigMaps.
+
+## Testing
+
+- `run_monitor_tests.sh` is the e2e entry point; `monitor_test.go` is the assertion
+  layer. Failure collects `kubectl` describe/logs for the operator, server pods,
+  Prometheus, and the PodMonitor target page — mirroring the Docker suite's
+  `collect_logs_on_failure`.
+- `go test ./common/metrics/...` proves the rename compiles and label-name assertions
+  pass.
+- A tiny unit check validates all four dashboard templates (2 Docker + 2 k8s) parse and
+  that the k8s ones reference only `${prometheus}` (no stray `__DATASOURCE_UID__` /
+  hard-coded UID), guarding the templates the way the earlier datasource bug would have
+  been caught.
+
+## Risks / open considerations
+
+- **Breaking metric change.** Renaming `namespace` → `log_ns` changes Woodpecker's
+  emitted labels. Any dashboard/alert/query filtering on the app `namespace` (the VDC
+  dashboards, including the ones just fixed) breaks until updated to `log_ns`, and only
+  after the renamed Woodpecker version is deployed. Workstreams B updates the in-repo
+  Docker dashboards; prod dashboards are the tracked follow-up. Worth a CHANGELOG/PR
+  note.
+- **Docker dashboard WIP.** The uncommitted `${datasource}` half-edit must be reconciled
+  first (default: revert to the committed `__DATASOURCE_UID__` base) — see Workstream B.
+- **Image pulls on minikube behind a loopback proxy** — mitigated by the chaos
+  host-pull-then-`minikube image load` pattern, applied to kube-prometheus-stack images.
+- **Resource footprint** — trimming extras keeps it light; `MK_CPUS=4 / 4096MB` should
+  suffice for 3 replicas + slim Prometheus + Grafana; README suggests 6/8192 if Pending.

--- a/tests/docker/monitor/grafana/templates/dashboard_client.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_client.json
@@ -55,7 +55,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_append_requests_total{namespace=~\"$namespace\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_append_requests_total{log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -106,12 +106,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append latency P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append latency P99",
           "refId": "B"
         }
@@ -162,12 +162,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append bytes P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append bytes P99",
           "refId": "B"
         }
@@ -218,7 +218,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_read_requests_total{namespace=~\"$namespace\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_read_requests_total{log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -269,12 +269,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Read latency P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Read latency P99",
           "refId": "B"
         }
@@ -325,12 +325,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_reader_bytes_read{namespace=~\"$namespace\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_reader_bytes_read{log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}} read bytes",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(woodpecker_client_writer_bytes_written{namespace=~\"$namespace\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_writer_bytes_written{log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}} write bytes",
           "refId": "B"
         }
@@ -381,7 +381,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{namespace=~\"$namespace\"}[1m])) by (operation, status)",
+          "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
           "legendFormat": "op={{operation}} status={{status}}",
           "refId": "A"
         }
@@ -432,7 +432,7 @@
       },
       "targets": [
         {
-          "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{namespace=~\"$namespace\"}) by (log_id)",
+          "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{log_ns=~\"$log_ns\"}) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_log_name_id_mapping{namespace=~\"$namespace\"}",
+          "expr": "woodpecker_client_log_name_id_mapping{log_ns=~\"$log_ns\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -541,7 +541,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_segment_state{namespace=~\"$namespace\"}",
+          "expr": "woodpecker_client_segment_state{log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} {{state}}",
           "refId": "A"
         }
@@ -570,8 +570,8 @@
         },
         "includeAll": true,
         "multi": true,
-        "name": "namespace",
-        "query": "label_values(woodpecker_client_append_requests_total, namespace)",
+        "name": "log_ns",
+        "query": "label_values(woodpecker_client_append_requests_total, log_ns)",
         "refresh": 2,
         "type": "query"
       }

--- a/tests/docker/monitor/grafana/templates/dashboard_server.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_server.json
@@ -54,17 +54,17 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", log_id=~\"$log_id\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_active_logs{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} logs",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", log_id=~\"$log_id\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_active_segments{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} segments",
               "refId": "B"
             }
           ],
-          "title": "Active Logs \u0026 Segments",
+          "title": "Active Logs & Segments",
           "type": "timeseries"
         },
         {
@@ -110,7 +110,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_instances_total{namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_instances_total{log_ns=~\"$log_ns\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -161,7 +161,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_logstore_operations_total{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
+              "expr": "sum(rate(woodpecker_server_logstore_operations_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
               "legendFormat": "op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -212,12 +212,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
               "legendFormat": "op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
               "legendFormat": "op={{operation}} P99",
               "refId": "B"
             }
@@ -268,7 +268,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_active_segment_processors{namespace=~\"$namespace\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_logstore_active_segment_processors{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -277,7 +277,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "Engine Layer — LogStore",
+      "title": "Engine Layer \u2014 LogStore",
       "type": "row"
     },
     {
@@ -333,12 +333,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Buffer P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Buffer P99",
               "refId": "B"
             }
@@ -389,7 +389,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_file_operations_total{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+              "expr": "sum(rate(woodpecker_server_file_operations_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
               "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -440,12 +440,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -496,17 +496,17 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_writer{namespace=~\"$namespace\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+              "expr": "sum(woodpecker_server_file_writer{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
               "legendFormat": "{{node_id}} logID={{log_id}} writer",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_file_reader{namespace=~\"$namespace\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+              "expr": "sum(woodpecker_server_file_reader{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
               "legendFormat": "{{node_id}} logID={{log_id}} reader",
               "refId": "B"
             }
           ],
-          "title": "Active File Writers \u0026 Readers",
+          "title": "Active File Writers & Readers",
           "type": "timeseries"
         },
         {
@@ -552,12 +552,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Flush P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Flush P99",
               "refId": "B"
             }
@@ -608,12 +608,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} ReadBatch P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} ReadBatch P99",
               "refId": "B"
             }
@@ -664,12 +664,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Compact P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Compact P99",
               "refId": "B"
             }
@@ -720,12 +720,12 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_flush_bytes_written{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+              "expr": "sum(rate(woodpecker_server_flush_bytes_written{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
               "legendFormat": "{{node_id}} flush",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(woodpecker_server_compact_bytes_written{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+              "expr": "sum(rate(woodpecker_server_compact_bytes_written{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
               "legendFormat": "{{node_id}} compact",
               "refId": "B"
             }
@@ -734,7 +734,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "Storage Layer — File I/O \u0026 Buffer",
+      "title": "Storage Layer \u2014 File I/O & Buffer",
       "type": "row"
     },
     {
@@ -790,7 +790,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_object_storage_operations_total{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+              "expr": "sum(rate(woodpecker_server_object_storage_operations_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
               "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -841,12 +841,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -897,12 +897,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -953,7 +953,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{namespace=~\"$namespace\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
+              "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
               "legendFormat": "{{node_id}} op={{operation}}",
               "refId": "A"
             }
@@ -2584,7 +2584,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_stored_bytes{namespace=~\"$namespace\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_file_stored_bytes{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2635,7 +2635,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_object_storage_stored_bytes{namespace=~\"$namespace\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_object_storage_stored_bytes{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2686,7 +2686,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_stored_count{namespace=~\"$namespace\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_file_stored_count{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2737,7 +2737,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_object_storage_stored_objects{namespace=~\"$namespace\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_object_storage_stored_objects{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2770,10 +2770,10 @@
         },
         "includeAll": true,
         "multi": true,
-        "name": "namespace",
-        "query": "query_result(max by (namespace) (woodpecker_server_logstore_active_logs{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", namespace=~\".+\"}))",
+        "name": "log_ns",
+        "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\".+\"}))",
         "refresh": 2,
-        "regex": "/namespace=\"([^\"]+)\"/",
+        "regex": "/log_ns=\"([^\"]+)\"/",
         "type": "query"
       },
       {
@@ -2789,7 +2789,7 @@
         "includeAll": true,
         "multi": true,
         "name": "log_id",
-        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", namespace=~\"$namespace\", log_id=~\".+\"}))",
+        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
         "refresh": 2,
         "regex": "/log_id=\"([^\"]+)\"/",
         "type": "query"

--- a/tests/k8s/monitor/README.md
+++ b/tests/k8s/monitor/README.md
@@ -1,0 +1,79 @@
+# Woodpecker K8s Monitor E2E Tests
+
+End-to-end verification of the Woodpecker Prometheus monitoring stack on Kubernetes (minikube).
+
+## Prerequisites
+
+- [minikube](https://minikube.sigs.k8s.io/) >= 1.32
+- [docker](https://docs.docker.com/get-docker/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [helm](https://helm.sh/docs/intro/install/) >= 3.12
+- [go](https://go.dev/dl/) >= 1.21
+
+## Running the Tests
+
+### One-click run (creates and destroys a minikube cluster)
+
+```bash
+./run_monitor_tests.sh
+```
+
+### Keep the cluster after tests (for manual inspection)
+
+```bash
+./run_monitor_tests.sh --no-cleanup
+```
+
+After a `--no-cleanup` run, the script prints the Grafana URL and the
+`kubectl port-forward` command for Prometheus.
+
+### Tuning resource limits
+
+If pods stay in `Pending` state (CPU/memory pressure), increase minikube
+resources before running:
+
+```bash
+MK_CPUS=6 MK_MEMORY=8192 ./run_monitor_tests.sh
+```
+
+## Label Scheme: `cluster` / `namespace` / `log_ns`
+
+Woodpecker metrics carry three key labels:
+
+| Label | Value | Source |
+|-------|-------|--------|
+| `cluster` | `woodpecker-minikube` | set in `kube-prometheus-values.yaml` via `externalLabels` |
+| `namespace` | Kubernetes namespace (e.g. `woodpecker`) | injected by kube-prometheus-stack from the PodMonitor namespace |
+| `log_ns` | Woodpecker logical log namespace (e.g. `my-log`) | emitted by the server/client as a metric label |
+
+### Breaking-change note for production dashboards
+
+The Woodpecker metric label previously called `namespace` (which referred to
+the **logical** log namespace) has been renamed to `log_ns`. Any production
+Grafana dashboards that filter or group by `namespace` assuming it means the
+Woodpecker log namespace **must be updated** to use `log_ns` instead.
+
+After the rename the Kubernetes namespace is available as `namespace` and the
+Woodpecker logical namespace is `log_ns` — there is no ambiguity.
+
+**The prod `PodMonitor` manifests require no change** after this rename; the
+label is emitted by the application itself and is already present in the
+scraped metric.
+
+## What the Tests Verify
+
+`TestK8sMonitor_Metrics` (in `monitor_test.go`) runs only when
+`WP_K8S_PROM_URL` is set (the runner sets it via `kubectl port-forward`).
+Without a live cluster the test SKIPs automatically, so `go test ./...` is
+always safe.
+
+The test checks:
+
+1. **ServerTargetUp** — at least one `woodpecker-server` scrape target is `up`.
+2. **ClientTargetUp** — the `woodpecker-client` (load generator) scrape target is `up`.
+3. **ServerMetrics** — core server metrics are present and non-zero.
+4. **ClientMetrics** — core client metrics are present and non-zero.
+5. **LabelScheme** — every `woodpecker_server_logstore_active_logs` series
+   carries `cluster=woodpecker-minikube`, `namespace=woodpecker`, a non-empty
+   `log_ns`, and no `exported_namespace` (which would indicate a relabeling
+   conflict).

--- a/tests/k8s/monitor/dashboards_test.go
+++ b/tests/k8s/monitor/dashboards_test.go
@@ -1,0 +1,40 @@
+package monitor
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestK8sDashboards_Valid(t *testing.T) {
+	for _, f := range []string{
+		"grafana/templates/dashboard_server_k8s.json",
+		"grafana/templates/dashboard_client_k8s.json",
+	} {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(raw, &obj); err != nil {
+			t.Fatalf("parse %s: %v", f, err)
+		}
+		s := string(raw)
+		if strings.Contains(s, "__DATASOURCE_UID__") {
+			t.Errorf("%s: stray __DATASOURCE_UID__", f)
+		}
+		if !strings.Contains(s, "${prometheus}") {
+			t.Errorf("%s: missing ${prometheus} datasource var", f)
+		}
+		names := map[string]bool{}
+		for _, v := range obj["templating"].(map[string]any)["list"].([]any) {
+			names[v.(map[string]any)["name"].(string)] = true
+		}
+		for _, want := range []string{"prometheus", "cluster", "namespace", "log_ns"} {
+			if !names[want] {
+				t.Errorf("%s: missing template var %q", f, want)
+			}
+		}
+	}
+}

--- a/tests/k8s/monitor/dashboards_test.go
+++ b/tests/k8s/monitor/dashboards_test.go
@@ -1,3 +1,19 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package monitor
 
 import (

--- a/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
@@ -1,0 +1,632 @@
+{
+  "editable": true,
+  "panels": [
+    {
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "title": "Client Layer",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_append_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "legendFormat": "logID={{log_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Append Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "legendFormat": "logID={{log_id}} Append latency P50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "legendFormat": "logID={{log_id}} Append latency P99",
+          "refId": "B"
+        }
+      ],
+      "title": "Append Latency P50/P99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "legendFormat": "logID={{log_id}} Append bytes P50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "legendFormat": "logID={{log_id}} Append bytes P99",
+          "refId": "B"
+        }
+      ],
+      "title": "Append Bytes P50/P99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 9
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_read_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "legendFormat": "logID={{log_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Read Request Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 9
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "legendFormat": "logID={{log_id}} Read latency P50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "legendFormat": "logID={{log_id}} Read latency P99",
+          "refId": "B"
+        }
+      ],
+      "title": "Read Latency P50/P99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 9
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_reader_bytes_read{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "legendFormat": "logID={{log_id}} read bytes",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(woodpecker_client_writer_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "legendFormat": "logID={{log_id}} write bytes",
+          "refId": "B"
+        }
+      ],
+      "title": "Reader/Writer Bytes Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 17
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
+          "legendFormat": "op={{operation}} status={{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Etcd Meta Ops Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 17
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (log_id)",
+          "legendFormat": "logID={{log_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Pending Append Ops",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 17
+      },
+      "id": 14,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Log ID",
+            "desc": false
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "woodpecker_client_log_name_id_mapping{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Name \u2192 Log ID Mapping",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "namespace": true
+            },
+            "renameByName": {
+              "Value": "Log ID",
+              "log_name": "Log Name"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 25
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "woodpecker_client_segment_state{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} {{state}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Segment State Count by Log",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "woodpecker",
+    "monitoring"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "prometheus",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "options": [],
+        "hide": 0,
+        "refresh": 1,
+        "regex": "",
+        "includeAll": false,
+        "multi": false
+      },
+      {
+        "name": "cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "query": "label_values(go_info, cluster)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "namespace",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "query": "label_values(woodpecker_client_append_requests_total{cluster=~\"$cluster\"}, namespace)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "includeAll": true,
+        "multi": true,
+        "name": "log_ns",
+        "query": "label_values(woodpecker_client_append_requests_total, log_ns)",
+        "refresh": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Woodpecker - Client(Namespace) (k8s)",
+  "uid": "woodpecker-client-k8s"
+}

--- a/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
@@ -1,0 +1,2869 @@
+{
+  "editable": true,
+  "panels": [
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_active_logs{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+              "legendFormat": "nodeID={{node_id}} logs",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(woodpecker_server_logstore_active_segments{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+              "legendFormat": "nodeID={{node_id}} segments",
+              "refId": "B"
+            }
+          ],
+          "title": "Active Logs & Segments",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_instances_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (node_id)",
+              "legendFormat": "nodeID={{node_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "LogStore Instances by Node",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_logstore_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
+              "legendFormat": "op={{operation}} status={{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "LogStore Operations Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 9
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+              "legendFormat": "op={{operation}} P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+              "legendFormat": "op={{operation}} P99",
+              "refId": "B"
+            }
+          ],
+          "title": "LogStore Op Latency P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 9
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_active_segment_processors{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "legendFormat": "logID={{log_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Active Segment Processors",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Engine Layer \u2014 LogStore",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 8,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 2
+          },
+          "id": 9,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "legendFormat": "{{node_id}} Buffer P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "legendFormat": "{{node_id}} Buffer P99",
+              "refId": "B"
+            }
+          ],
+          "title": "Buffer Wait Latency P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 2
+          },
+          "id": 10,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_file_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+              "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "File Operations Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 10
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "legendFormat": "{{node_id}} op={{operation}} P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "legendFormat": "{{node_id}} op={{operation}} P99",
+              "refId": "B"
+            }
+          ],
+          "title": "File Op Latency P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 12,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_file_writer{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+              "legendFormat": "{{node_id}} logID={{log_id}} writer",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(woodpecker_server_file_reader{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+              "legendFormat": "{{node_id}} logID={{log_id}} reader",
+              "refId": "B"
+            }
+          ],
+          "title": "Active File Writers & Readers",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 13,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "legendFormat": "{{node_id}} Flush P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "legendFormat": "{{node_id}} Flush P99",
+              "refId": "B"
+            }
+          ],
+          "title": "Flush Latency P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 14,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "legendFormat": "{{node_id}} ReadBatch P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "legendFormat": "{{node_id}} ReadBatch P99",
+              "refId": "B"
+            }
+          ],
+          "title": "Read Batch Latency P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 26
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "legendFormat": "{{node_id}} Compact P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "legendFormat": "{{node_id}} Compact P99",
+              "refId": "B"
+            }
+          ],
+          "title": "Compaction Latency P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 26
+          },
+          "id": 16,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_flush_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+              "legendFormat": "{{node_id}} flush",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(woodpecker_server_compact_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+              "legendFormat": "{{node_id}} compact",
+              "refId": "B"
+            }
+          ],
+          "title": "Flush/Compact Bytes Rate",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Storage Layer \u2014 File I/O & Buffer",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 17,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 3
+          },
+          "id": 18,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_object_storage_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+              "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Object Storage Ops Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 3
+          },
+          "id": 19,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "legendFormat": "{{node_id}} op={{operation}} P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "legendFormat": "{{node_id}} op={{operation}} P99",
+              "refId": "B"
+            }
+          ],
+          "title": "Object Storage Latency P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 11
+          },
+          "id": 20,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "legendFormat": "{{node_id}} op={{operation}} P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "legendFormat": "{{node_id}} op={{operation}} P99",
+              "refId": "B"
+            }
+          ],
+          "title": "Object Storage Request Size P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 11
+          },
+          "id": 21,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
+              "legendFormat": "{{node_id}} op={{operation}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Object Storage Bytes Transferred",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Object Storage Layer",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 22,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "id": 23,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_system_cpu_usage) by (node_id)",
+              "legendFormat": "nodeID={{node_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "CPU Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 24,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_system_memory_used_bytes) by (node_id)",
+              "legendFormat": "nodeID={{node_id}} used",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(woodpecker_server_system_memory_usage_ratio) by (node_id)",
+              "legendFormat": "nodeID={{node_id}} ratio",
+              "refId": "B"
+            }
+          ],
+          "title": "Memory Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 12
+          },
+          "id": 25,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_system_disk_used_bytes) by (node_id)",
+              "legendFormat": "nodeID={{node_id}} used",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(woodpecker_server_system_disk_total_bytes) by (node_id)",
+              "legendFormat": "nodeID={{node_id}} total",
+              "refId": "B"
+            }
+          ],
+          "title": "Disk Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 12
+          },
+          "id": 26,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_system_io_wait) by (node_id)",
+              "legendFormat": "nodeID={{node_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "IO Wait",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 47,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "process_open_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}} open",
+              "refId": "A"
+            }
+          ],
+          "title": "Open File Descriptors",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 48,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "rate(process_network_receive_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+              "legendFormat": "{{pod}} {{instance}} rx",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(process_network_transmit_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+              "legendFormat": "{{pod}} {{instance}} tx",
+              "refId": "B"
+            }
+          ],
+          "title": "Network Traffic",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 28
+          },
+          "id": 49,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "process_open_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"} / process_max_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "File Descriptor Usage",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 28
+          },
+          "id": 50,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "time() - process_start_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process Uptime",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 28
+          },
+          "id": 51,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "process_virtual_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process Virtual Memory",
+          "type": "timeseries"
+        }
+      ],
+      "title": "System",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 32,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 5
+          },
+          "id": 33,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (pod, instance)",
+              "legendFormat": "{{pod}} {{instance}} cpu",
+              "refId": "A"
+            }
+          ],
+          "title": "Process CPU Total by Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 5
+          },
+          "id": 34,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+              "legendFormat": "{{pod}} {{instance}} memory",
+              "refId": "A"
+            }
+          ],
+          "title": "Process Memory Total by Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 5
+          },
+          "id": 35,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+              "legendFormat": "{{pod}} {{instance}} goroutines",
+              "refId": "A"
+            }
+          ],
+          "title": "Goroutines Total by Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 13
+          },
+          "id": 36,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "rate(process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process CPU by Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 13
+          },
+          "id": 37,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Process Memory by Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 13
+          },
+          "id": 38,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Goroutines by Pod",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 21
+          },
+          "id": 39,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "go_memstats_alloc_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Go Allocated Memory",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 21
+          },
+          "id": 40,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}} in-use",
+              "refId": "A"
+            },
+            {
+              "expr": "go_memstats_heap_idle_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}} idle",
+              "refId": "B"
+            },
+            {
+              "expr": "go_memstats_heap_released_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}} released",
+              "refId": "C"
+            }
+          ],
+          "title": "Go Heap Memory",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 21
+          },
+          "id": 41,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "go_memstats_heap_objects{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Go Heap Objects",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 29
+          },
+          "id": 42,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "go_gc_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\", quantile=\"1\"}",
+              "legendFormat": "{{pod}} {{instance}} max",
+              "refId": "A"
+            }
+          ],
+          "title": "GC Max Duration",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 29
+          },
+          "id": 43,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "go_memstats_gc_cpu_fraction{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "GC CPU Fraction",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 29
+          },
+          "id": 44,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "rate(go_memstats_mallocs_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+              "legendFormat": "{{pod}} {{instance}} mallocs",
+              "refId": "A"
+            },
+            {
+              "expr": "rate(go_memstats_frees_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+              "legendFormat": "{{pod}} {{instance}} frees",
+              "refId": "B"
+            }
+          ],
+          "title": "Allocation Operations Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 37
+          },
+          "id": 45,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "rate(go_memstats_alloc_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Memory Allocation Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 37
+          },
+          "id": 46,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "go_sched_gomaxprocs_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}} GOMAXPROCS",
+              "refId": "A"
+            },
+            {
+              "expr": "go_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}} threads",
+              "refId": "B"
+            }
+          ],
+          "title": "Go Threads",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 45
+          },
+          "id": 52,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "rate(go_gc_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+              "legendFormat": "{{pod}} {{instance}} GC/s",
+              "refId": "A"
+            }
+          ],
+          "title": "GC Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 45
+          },
+          "id": 53,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "go_memstats_sys_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}} sys",
+              "refId": "A"
+            },
+            {
+              "expr": "go_memstats_stack_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}} stack",
+              "refId": "B"
+            }
+          ],
+          "title": "Go Runtime Memory",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 45
+          },
+          "id": 54,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "go_memstats_next_gc_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}} next GC",
+              "refId": "A"
+            },
+            {
+              "expr": "go_gc_gomemlimit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}} memory limit",
+              "refId": "B"
+            }
+          ],
+          "title": "Go GC Target",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Go Runtime",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 55,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 6
+          },
+          "id": 56,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "woodpecker_server_op_registry_pool_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "{{pod}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "In-flight Operations",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 6
+          },
+          "id": 57,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (signal)",
+              "legendFormat": "{{signal}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Operation Evictions Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 6
+          },
+          "id": 58,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])) by (le))",
+              "legendFormat": "P99",
+              "refId": "A"
+            }
+          ],
+          "title": "Operation Eviction Age P99",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Runtime Operations",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "id": 27,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 7
+          },
+          "id": 28,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_file_stored_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "legendFormat": "logID={{log_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Local File Stored Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 7
+          },
+          "id": 29,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_object_storage_stored_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "legendFormat": "logID={{log_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Object Storage Stored Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 15
+          },
+          "id": 30,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_file_stored_count{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "legendFormat": "logID={{log_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Local File Count",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 15
+          },
+          "id": 31,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_object_storage_stored_objects{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "legendFormat": "logID={{log_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Object Storage Object Count",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Cost",
+      "type": "row"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": [
+    "woodpecker",
+    "monitoring"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "prometheus",
+        "label": "Datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "options": [],
+        "hide": 0,
+        "refresh": 1,
+        "regex": "",
+        "includeAll": false,
+        "multi": false
+      },
+      {
+        "name": "cluster",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "query": "label_values(go_info, cluster)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "name": "namespace",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "query": "label_values(go_info{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", cluster=~\"$cluster\"}, namespace)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "includeAll": true,
+        "multi": true,
+        "name": "log_ns",
+        "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\".+\"}))",
+        "refresh": 2,
+        "regex": "/log_ns=\"([^\"]+)\"/",
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "includeAll": true,
+        "multi": true,
+        "name": "log_id",
+        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
+        "refresh": 2,
+        "regex": "/log_id=\"([^\"]+)\"/",
+        "type": "query"
+      },
+      {
+        "allValue": "woodpecker-node[0-9]+|woodpecker/woodpecker-server",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "hide": 2,
+        "includeAll": true,
+        "multi": true,
+        "name": "server_job",
+        "query": "label_values(go_goroutines{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\"}, job)",
+        "refresh": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "Woodpecker - Server (Namespace) (k8s)",
+  "uid": "woodpecker-server-k8s"
+}

--- a/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
@@ -1018,7 +1018,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_cpu_usage) by (node_id)",
+              "expr": "sum(woodpecker_server_system_cpu_usage{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -1069,12 +1069,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_memory_used_bytes) by (node_id)",
+              "expr": "sum(woodpecker_server_system_memory_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} used",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_system_memory_usage_ratio) by (node_id)",
+              "expr": "sum(woodpecker_server_system_memory_usage_ratio{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} ratio",
               "refId": "B"
             }
@@ -1125,12 +1125,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_disk_used_bytes) by (node_id)",
+              "expr": "sum(woodpecker_server_system_disk_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} used",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_system_disk_total_bytes) by (node_id)",
+              "expr": "sum(woodpecker_server_system_disk_total_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} total",
               "refId": "B"
             }
@@ -1181,7 +1181,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_io_wait) by (node_id)",
+              "expr": "sum(woodpecker_server_system_io_wait{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }

--- a/tests/k8s/monitor/k8s_monitor_cluster.go
+++ b/tests/k8s/monitor/k8s_monitor_cluster.go
@@ -1,0 +1,129 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+)
+
+// K8sMonitorCluster queries a Prometheus reachable at PromBaseURL (typically a
+// kubectl port-forward to svc/prometheus-operated in the monitoring namespace).
+type K8sMonitorCluster struct {
+	PromBaseURL string
+}
+
+func NewK8sMonitorCluster(promBaseURL string) *K8sMonitorCluster {
+	return &K8sMonitorCluster{PromBaseURL: promBaseURL}
+}
+
+type promResult struct {
+	Status string `json:"status"`
+	Data   struct {
+		Result []struct {
+			Metric map[string]string `json:"metric"`
+			Value  []interface{}     `json:"value"`
+		} `json:"result"`
+	} `json:"data"`
+}
+
+func (c *K8sMonitorCluster) WaitForPrometheusReady(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	client := &http.Client{Timeout: 5 * time.Second}
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(c.PromBaseURL + "/-/ready")
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				t.Log("Prometheus is ready")
+				return
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("Prometheus at %s not ready within %v", c.PromBaseURL, timeout)
+}
+
+func (c *K8sMonitorCluster) query(t *testing.T, q string) *promResult {
+	t.Helper()
+	reqURL := fmt.Sprintf("%s/api/v1/query?query=%s", c.PromBaseURL, url.QueryEscape(q))
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(reqURL)
+	if err != nil {
+		t.Logf("prometheus query failed: %v", err)
+		return nil
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	var r promResult
+	if err := json.Unmarshal(body, &r); err != nil {
+		t.Logf("prometheus parse failed: %v", err)
+		return nil
+	}
+	if r.Status != "success" {
+		return nil
+	}
+	return &r
+}
+
+// QueryPromQL returns the first sample value as a string.
+func (c *K8sMonitorCluster) QueryPromQL(t *testing.T, q string) (string, bool) {
+	t.Helper()
+	r := c.query(t, q)
+	if r == nil || len(r.Data.Result) == 0 || len(r.Data.Result[0].Value) < 2 {
+		return "", false
+	}
+	v, ok := r.Data.Result[0].Value[1].(string)
+	return v, ok
+}
+
+// QueryVector returns the label set of every result series.
+func (c *K8sMonitorCluster) QueryVector(t *testing.T, q string) []map[string]string {
+	t.Helper()
+	r := c.query(t, q)
+	if r == nil {
+		return nil
+	}
+	out := make([]map[string]string, 0, len(r.Data.Result))
+	for _, s := range r.Data.Result {
+		out = append(out, s.Metric)
+	}
+	return out
+}
+
+// QueryMetricHasValue reports whether the metric exists with a non-zero value.
+func (c *K8sMonitorCluster) QueryMetricHasValue(t *testing.T, metricName string) bool {
+	t.Helper()
+	r := c.query(t, metricName)
+	if r == nil {
+		return false
+	}
+	for _, s := range r.Data.Result {
+		if len(s.Value) >= 2 {
+			if vs, ok := s.Value[1].(string); ok && vs != "0" && vs != "0.0" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tests/k8s/monitor/k8s_monitor_cluster_test.go
+++ b/tests/k8s/monitor/k8s_monitor_cluster_test.go
@@ -1,3 +1,19 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package monitor
 
 import "testing"

--- a/tests/k8s/monitor/k8s_monitor_cluster_test.go
+++ b/tests/k8s/monitor/k8s_monitor_cluster_test.go
@@ -1,0 +1,10 @@
+package monitor
+
+import "testing"
+
+func TestPromBaseURL_Default(t *testing.T) {
+	c := NewK8sMonitorCluster("http://localhost:9090")
+	if c.PromBaseURL != "http://localhost:9090" {
+		t.Fatalf("got %q", c.PromBaseURL)
+	}
+}

--- a/tests/k8s/monitor/loadgen/main.go
+++ b/tests/k8s/monitor/loadgen/main.go
@@ -1,0 +1,110 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/etcd"
+	"github.com/zilliztech/woodpecker/common/metrics"
+	"github.com/zilliztech/woodpecker/woodpecker"
+	"github.com/zilliztech/woodpecker/woodpecker/log"
+)
+
+func main() {
+	configFile := flag.String("config-file", "/tmp/test-config.yaml", "woodpecker config path")
+	metricsAddr := flag.String("metrics-addr", ":29099", "Prometheus /metrics listen address")
+	logName := flag.String("log", "k8s-monitor-loadgen", "log name to write")
+	interval := flag.Duration("interval", 50*time.Millisecond, "append interval")
+	flag.Parse()
+
+	// Expose client metrics for the woodpecker-client PodMonitor to scrape.
+	metrics.RegisterClientMetricsWithRegisterer(prometheus.DefaultRegisterer)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	go func() {
+		if err := http.ListenAndServe(*metricsAddr, mux); err != nil {
+			panic(fmt.Sprintf("metrics server: %v", err))
+		}
+	}()
+
+	ctx := context.Background()
+	cfg, err := config.NewConfiguration(*configFile)
+	if err != nil {
+		panic(fmt.Sprintf("load config: %v", err))
+	}
+	etcdCli, err := etcd.GetRemoteEtcdClient(cfg.Etcd.GetEndpoints())
+	if err != nil {
+		panic(fmt.Sprintf("etcd client: %v", err))
+	}
+	cli, err := woodpecker.NewClient(ctx, cfg, etcdCli, true)
+	if err != nil {
+		panic(fmt.Sprintf("woodpecker client: %v", err))
+	}
+	defer cli.Close(ctx)
+
+	_ = cli.CreateLog(ctx, *logName) // idempotent
+	h, err := cli.OpenLog(ctx, *logName)
+	if err != nil {
+		panic(fmt.Sprintf("open log: %v", err))
+	}
+	w, err := h.OpenLogWriter(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("open writer: %v", err))
+	}
+	defer w.Close(ctx)
+
+	// Tail reader to exercise the read path (read-batch / reader metrics).
+	go func() {
+		earliest := log.EarliestLogMessageID()
+		r, err := h.OpenLogReader(ctx, &earliest, "loadgen-tail")
+		if err != nil {
+			return
+		}
+		defer r.Close(ctx)
+		for {
+			rctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+			_, _ = r.ReadNext(rctx)
+			cancel()
+		}
+	}()
+
+	fmt.Printf("loadgen: writing to %q every %s, metrics on %s\n", *logName, *interval, *metricsAddr)
+	seq := 0
+	tick := time.NewTicker(*interval)
+	defer tick.Stop()
+	for range tick.C {
+		seq++
+		wctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		res := <-w.WriteAsync(wctx, &log.WriteMessage{
+			Payload:    []byte(fmt.Sprintf("loadgen-%d", seq)),
+			Properties: map[string]string{"seq": fmt.Sprintf("%d", seq)},
+		})
+		cancel()
+		if res.Err != nil {
+			fmt.Printf("write %d err: %v\n", seq, res.Err)
+		}
+	}
+}

--- a/tests/k8s/monitor/manifests/client-loadgen.yaml
+++ b/tests/k8s/monitor/manifests/client-loadgen.yaml
@@ -10,8 +10,8 @@ metadata:
 spec:
   containers:
     - name: loadgen
-      image: golang:1.24
-      imagePullPolicy: IfNotPresent
+      image: zilliztech/woodpecker:v0.1.26
+      imagePullPolicy: Never
       command: ["/bin/bash", "-c", "sleep infinity"]
       ports:
         - name: metrics

--- a/tests/k8s/monitor/manifests/client-loadgen.yaml
+++ b/tests/k8s/monitor/manifests/client-loadgen.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: wp-loadgen
+  namespace: woodpecker
+  labels:
+    app.kubernetes.io/name: woodpecker
+    app.kubernetes.io/component: client
+    app.kubernetes.io/instance: my-woodpecker
+spec:
+  containers:
+    - name: loadgen
+      image: golang:1.24
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/bash", "-c", "sleep infinity"]
+      ports:
+        - name: metrics
+          containerPort: 29099
+      resources:
+        requests: { cpu: "500m", memory: "512Mi" }
+  restartPolicy: Never

--- a/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
+++ b/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
@@ -1,0 +1,3520 @@
+# Generated from grafana/templates/*.json — Grafana sidecar imports these.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: woodpecker-server-k8s-dashboard
+  namespace: monitoring
+  labels: { grafana_dashboard: "1" }
+data:
+  dashboard_server_k8s.json: |
+    {
+      "editable": true,
+      "panels": [
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 1
+              },
+              "id": 2,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_logstore_active_logs{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}} logs",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(woodpecker_server_logstore_active_segments{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}} segments",
+                  "refId": "B"
+                }
+              ],
+              "title": "Active Logs & Segments",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 1
+              },
+              "id": 3,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_logstore_instances_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "LogStore Instances by Node",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 1
+              },
+              "id": 4,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(woodpecker_server_logstore_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
+                  "legendFormat": "op={{operation}} status={{status}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "LogStore Operations Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ms"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 9
+              },
+              "id": 5,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+                  "legendFormat": "op={{operation}} P50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+                  "legendFormat": "op={{operation}} P99",
+                  "refId": "B"
+                }
+              ],
+              "title": "LogStore Op Latency P50/P99",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 9
+              },
+              "id": 6,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_logstore_active_segment_processors{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "legendFormat": "logID={{log_id}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Active Segment Processors",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Engine Layer \u2014 LogStore",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "id": 8,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ms"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 2
+              },
+              "id": 9,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "legendFormat": "{{node_id}} Buffer P50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "legendFormat": "{{node_id}} Buffer P99",
+                  "refId": "B"
+                }
+              ],
+              "title": "Buffer Wait Latency P50/P99",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 2
+              },
+              "id": 10,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(woodpecker_server_file_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+                  "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "File Operations Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ms"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 10
+              },
+              "id": 11,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "legendFormat": "{{node_id}} op={{operation}} P50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "legendFormat": "{{node_id}} op={{operation}} P99",
+                  "refId": "B"
+                }
+              ],
+              "title": "File Op Latency P50/P99",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 10
+              },
+              "id": 12,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_file_writer{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+                  "legendFormat": "{{node_id}} logID={{log_id}} writer",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(woodpecker_server_file_reader{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+                  "legendFormat": "{{node_id}} logID={{log_id}} reader",
+                  "refId": "B"
+                }
+              ],
+              "title": "Active File Writers & Readers",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ms"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 18
+              },
+              "id": 13,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "legendFormat": "{{node_id}} Flush P50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "legendFormat": "{{node_id}} Flush P99",
+                  "refId": "B"
+                }
+              ],
+              "title": "Flush Latency P50/P99",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ms"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 18
+              },
+              "id": 14,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "legendFormat": "{{node_id}} ReadBatch P50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "legendFormat": "{{node_id}} ReadBatch P99",
+                  "refId": "B"
+                }
+              ],
+              "title": "Read Batch Latency P50/P99",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ms"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 26
+              },
+              "id": 15,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "legendFormat": "{{node_id}} Compact P50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "legendFormat": "{{node_id}} Compact P99",
+                  "refId": "B"
+                }
+              ],
+              "title": "Compaction Latency P50/P99",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "Bps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 26
+              },
+              "id": 16,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(woodpecker_server_flush_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+                  "legendFormat": "{{node_id}} flush",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(rate(woodpecker_server_compact_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+                  "legendFormat": "{{node_id}} compact",
+                  "refId": "B"
+                }
+              ],
+              "title": "Flush/Compact Bytes Rate",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Storage Layer \u2014 File I/O & Buffer",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 2
+          },
+          "id": 17,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 3
+              },
+              "id": 18,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(woodpecker_server_object_storage_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+                  "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Object Storage Ops Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ms"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 3
+              },
+              "id": 19,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "legendFormat": "{{node_id}} op={{operation}} P50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "legendFormat": "{{node_id}} op={{operation}} P99",
+                  "refId": "B"
+                }
+              ],
+              "title": "Object Storage Latency P50/P99",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 11
+              },
+              "id": 20,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "legendFormat": "{{node_id}} op={{operation}} P50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "legendFormat": "{{node_id}} op={{operation}} P99",
+                  "refId": "B"
+                }
+              ],
+              "title": "Object Storage Request Size P50/P99",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "Bps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 11
+              },
+              "id": 21,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
+                  "legendFormat": "{{node_id}} op={{operation}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Object Storage Bytes Transferred",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Object Storage Layer",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 3
+          },
+          "id": 22,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 4
+              },
+              "id": 23,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_system_cpu_usage) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "CPU Usage",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 4
+              },
+              "id": 24,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_system_memory_used_bytes) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}} used",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(woodpecker_server_system_memory_usage_ratio) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}} ratio",
+                  "refId": "B"
+                }
+              ],
+              "title": "Memory Usage",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 12
+              },
+              "id": 25,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_system_disk_used_bytes) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}} used",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(woodpecker_server_system_disk_total_bytes) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}} total",
+                  "refId": "B"
+                }
+              ],
+              "title": "Disk Usage",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 12
+              },
+              "id": 26,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_system_io_wait) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "IO Wait",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 20
+              },
+              "id": 47,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "process_open_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}} open",
+                  "refId": "A"
+                }
+              ],
+              "title": "Open File Descriptors",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "Bps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 20
+              },
+              "id": 48,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "rate(process_network_receive_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+                  "legendFormat": "{{pod}} {{instance}} rx",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(process_network_transmit_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+                  "legendFormat": "{{pod}} {{instance}} tx",
+                  "refId": "B"
+                }
+              ],
+              "title": "Network Traffic",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 28
+              },
+              "id": 49,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "process_open_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"} / process_max_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "File Descriptor Usage",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 28
+              },
+              "id": 50,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "time() - process_start_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Process Uptime",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 28
+              },
+              "id": 51,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "process_virtual_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Process Virtual Memory",
+              "type": "timeseries"
+            }
+          ],
+          "title": "System",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 4
+          },
+          "id": 32,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 5
+              },
+              "id": 33,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (pod, instance)",
+                  "legendFormat": "{{pod}} {{instance}} cpu",
+                  "refId": "A"
+                }
+              ],
+              "title": "Process CPU Total by Pod",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 5
+              },
+              "id": 34,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+                  "legendFormat": "{{pod}} {{instance}} memory",
+                  "refId": "A"
+                }
+              ],
+              "title": "Process Memory Total by Pod",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 5
+              },
+              "id": 35,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+                  "legendFormat": "{{pod}} {{instance}} goroutines",
+                  "refId": "A"
+                }
+              ],
+              "title": "Goroutines Total by Pod",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 13
+              },
+              "id": 36,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "rate(process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Process CPU by Pod",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 13
+              },
+              "id": 37,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Process Memory by Pod",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 13
+              },
+              "id": 38,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Goroutines by Pod",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 21
+              },
+              "id": 39,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "go_memstats_alloc_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Go Allocated Memory",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 21
+              },
+              "id": 40,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}} in-use",
+                  "refId": "A"
+                },
+                {
+                  "expr": "go_memstats_heap_idle_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}} idle",
+                  "refId": "B"
+                },
+                {
+                  "expr": "go_memstats_heap_released_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}} released",
+                  "refId": "C"
+                }
+              ],
+              "title": "Go Heap Memory",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 21
+              },
+              "id": 41,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "go_memstats_heap_objects{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Go Heap Objects",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 29
+              },
+              "id": 42,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "go_gc_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\", quantile=\"1\"}",
+                  "legendFormat": "{{pod}} {{instance}} max",
+                  "refId": "A"
+                }
+              ],
+              "title": "GC Max Duration",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 29
+              },
+              "id": 43,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "go_memstats_gc_cpu_fraction{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "GC CPU Fraction",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 29
+              },
+              "id": 44,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "rate(go_memstats_mallocs_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+                  "legendFormat": "{{pod}} {{instance}} mallocs",
+                  "refId": "A"
+                },
+                {
+                  "expr": "rate(go_memstats_frees_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+                  "legendFormat": "{{pod}} {{instance}} frees",
+                  "refId": "B"
+                }
+              ],
+              "title": "Allocation Operations Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "Bps"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 37
+              },
+              "id": 45,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "rate(go_memstats_alloc_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Memory Allocation Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 37
+              },
+              "id": 46,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "go_sched_gomaxprocs_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}} GOMAXPROCS",
+                  "refId": "A"
+                },
+                {
+                  "expr": "go_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}} threads",
+                  "refId": "B"
+                }
+              ],
+              "title": "Go Threads",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 45
+              },
+              "id": 52,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "rate(go_gc_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+                  "legendFormat": "{{pod}} {{instance}} GC/s",
+                  "refId": "A"
+                }
+              ],
+              "title": "GC Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 45
+              },
+              "id": 53,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "go_memstats_sys_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}} sys",
+                  "refId": "A"
+                },
+                {
+                  "expr": "go_memstats_stack_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}} stack",
+                  "refId": "B"
+                }
+              ],
+              "title": "Go Runtime Memory",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 45
+              },
+              "id": 54,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "go_memstats_next_gc_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}} next GC",
+                  "refId": "A"
+                },
+                {
+                  "expr": "go_gc_gomemlimit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}} memory limit",
+                  "refId": "B"
+                }
+              ],
+              "title": "Go GC Target",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Go Runtime",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
+          },
+          "id": 55,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 6
+              },
+              "id": 56,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "woodpecker_server_op_registry_pool_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "legendFormat": "{{pod}} {{instance}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "In-flight Operations",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 6
+              },
+              "id": 57,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (signal)",
+                  "legendFormat": "{{signal}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Operation Evictions Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 6
+              },
+              "id": 58,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])) by (le))",
+                  "legendFormat": "P99",
+                  "refId": "A"
+                }
+              ],
+              "title": "Operation Eviction Age P99",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Runtime Operations",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 6
+          },
+          "id": 27,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 7
+              },
+              "id": 28,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_file_stored_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "legendFormat": "logID={{log_id}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Local File Stored Bytes",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 7
+              },
+              "id": 29,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_object_storage_stored_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "legendFormat": "logID={{log_id}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Object Storage Stored Bytes",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 15
+              },
+              "id": 30,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_file_stored_count{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "legendFormat": "logID={{log_id}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Local File Count",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 15
+              },
+              "id": 31,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_object_storage_stored_objects{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "legendFormat": "logID={{log_id}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Object Storage Object Count",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Cost",
+          "type": "row"
+        }
+      ],
+      "refresh": "5s",
+      "schemaVersion": 39,
+      "tags": [
+        "woodpecker",
+        "monitoring"
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "prometheus",
+            "label": "Datasource",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": {},
+            "options": [],
+            "hide": 0,
+            "refresh": 1,
+            "regex": "",
+            "includeAll": false,
+            "multi": false
+          },
+          {
+            "name": "cluster",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "query": "label_values(go_info, cluster)",
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          },
+          {
+            "name": "namespace",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "query": "label_values(go_info{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", cluster=~\"$cluster\"}, namespace)",
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "includeAll": true,
+            "multi": true,
+            "name": "log_ns",
+            "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\".+\"}))",
+            "refresh": 2,
+            "regex": "/log_ns=\"([^\"]+)\"/",
+            "type": "query"
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "includeAll": true,
+            "multi": true,
+            "name": "log_id",
+            "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
+            "refresh": 2,
+            "regex": "/log_id=\"([^\"]+)\"/",
+            "type": "query"
+          },
+          {
+            "allValue": "woodpecker-node[0-9]+|woodpecker/woodpecker-server",
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "hide": 2,
+            "includeAll": true,
+            "multi": true,
+            "name": "server_job",
+            "query": "label_values(go_goroutines{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\"}, job)",
+            "refresh": 2,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "timezone": "browser",
+      "title": "Woodpecker - Server (Namespace) (k8s)",
+      "uid": "woodpecker-server-k8s"
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: woodpecker-client-k8s-dashboard
+  namespace: monitoring
+  labels: { grafana_dashboard: "1" }
+data:
+  dashboard_client_k8s.json: |
+    {
+      "editable": true,
+      "panels": [
+        {
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "title": "Client Layer",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 1
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_append_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "legendFormat": "logID={{log_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Append Request Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 1
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "legendFormat": "logID={{log_id}} Append latency P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "legendFormat": "logID={{log_id}} Append latency P99",
+              "refId": "B"
+            }
+          ],
+          "title": "Append Latency P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 1
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "legendFormat": "logID={{log_id}} Append bytes P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "legendFormat": "logID={{log_id}} Append bytes P99",
+              "refId": "B"
+            }
+          ],
+          "title": "Append Bytes P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 9
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_read_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "legendFormat": "logID={{log_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Read Request Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 9
+          },
+          "id": 13,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "legendFormat": "logID={{log_id}} Read latency P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "legendFormat": "logID={{log_id}} Read latency P99",
+              "refId": "B"
+            }
+          ],
+          "title": "Read Latency P50/P99",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 9
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_reader_bytes_read{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "legendFormat": "logID={{log_id}} read bytes",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(woodpecker_client_writer_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "legendFormat": "logID={{log_id}} write bytes",
+              "refId": "B"
+            }
+          ],
+          "title": "Reader/Writer Bytes Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 17
+          },
+          "id": 7,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
+              "legendFormat": "op={{operation}} status={{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Etcd Meta Ops Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 17
+          },
+          "id": 12,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (log_id)",
+              "legendFormat": "logID={{log_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Pending Append Ops",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 17
+          },
+          "id": 14,
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Log ID",
+                "desc": false
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "woodpecker_client_log_name_id_mapping{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Log Name \u2192 Log ID Mapping",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true,
+                  "instance": true,
+                  "job": true,
+                  "namespace": true
+                },
+                "renameByName": {
+                  "Value": "Log ID",
+                  "log_name": "Log Name"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 25
+          },
+          "id": 15,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "woodpecker_client_segment_state{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+              "legendFormat": "logID={{log_id}} {{state}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Segment State Count by Log",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "5s",
+      "schemaVersion": 39,
+      "tags": [
+        "woodpecker",
+        "monitoring"
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "prometheus",
+            "label": "Datasource",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": {},
+            "options": [],
+            "hide": 0,
+            "refresh": 1,
+            "regex": "",
+            "includeAll": false,
+            "multi": false
+          },
+          {
+            "name": "cluster",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "query": "label_values(go_info, cluster)",
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          },
+          {
+            "name": "namespace",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "query": "label_values(woodpecker_client_append_requests_total{cluster=~\"$cluster\"}, namespace)",
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "includeAll": true,
+            "multi": true,
+            "name": "log_ns",
+            "query": "label_values(woodpecker_client_append_requests_total, log_ns)",
+            "refresh": 2,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "timezone": "browser",
+      "title": "Woodpecker - Client(Namespace) (k8s)",
+      "uid": "woodpecker-client-k8s"
+    }

--- a/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
+++ b/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
@@ -1028,7 +1028,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_cpu_usage) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_cpu_usage{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}}",
                   "refId": "A"
                 }
@@ -1079,12 +1079,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_memory_used_bytes) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_memory_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} used",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(woodpecker_server_system_memory_usage_ratio) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_memory_usage_ratio{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} ratio",
                   "refId": "B"
                 }
@@ -1135,12 +1135,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_disk_used_bytes) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_disk_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} used",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(woodpecker_server_system_disk_total_bytes) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_disk_total_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} total",
                   "refId": "B"
                 }
@@ -1191,7 +1191,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_io_wait) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_io_wait{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}}",
                   "refId": "A"
                 }

--- a/tests/k8s/monitor/manifests/kube-prometheus-values.yaml
+++ b/tests/k8s/monitor/manifests/kube-prometheus-values.yaml
@@ -1,0 +1,33 @@
+nodeExporter: { enabled: false }
+kubeStateMetrics: { enabled: false }
+alertmanager: { enabled: false }
+defaultRules: { create: false }
+kubeApiServer: { enabled: false }
+kubelet: { enabled: false }
+kubeControllerManager: { enabled: false }
+kubeScheduler: { enabled: false }
+kubeProxy: { enabled: false }
+kubeEtcd: { enabled: false }
+coreDns: { enabled: false }
+prometheus:
+  prometheusSpec:
+    externalLabels:
+      cluster: woodpecker-minikube
+    podMonitorSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    retention: 2h
+grafana:
+  adminPassword: admin
+  grafana.ini:
+    auth.anonymous:
+      enabled: true
+      org_role: Admin
+    auth:
+      disable_login_form: true
+  sidecar:
+    dashboards:
+      enabled: true
+      label: grafana_dashboard
+      labelValue: "1"
+      searchNamespace: ALL

--- a/tests/k8s/monitor/manifests/loadgen-config.yaml
+++ b/tests/k8s/monitor/manifests/loadgen-config.yaml
@@ -1,0 +1,36 @@
+woodpecker:
+  meta:
+    type: etcd
+  client:
+    segmentRollingPolicy:
+      maxSize: 1000
+    quorum:
+      replicaCount: 3
+      quorumBufferPools:
+        - name: default-region-pool
+          seeds:
+            - my-woodpecker-server-0.my-woodpecker-server-headless.woodpecker.svc:18080
+            - my-woodpecker-server-1.my-woodpecker-server-headless.woodpecker.svc:18080
+            - my-woodpecker-server-2.my-woodpecker-server-headless.woodpecker.svc:18080
+  logstore:
+    retentionPolicy:
+      ttl: 10
+  storage:
+    type: service
+    rootPath: /tmp/wp-test-data
+log:
+  level: info
+  format: json
+  stdout: true
+etcd:
+  endpoints:
+    - etcd.woodpecker.svc:2379
+  rootPath: by-dev
+minio:
+  address: minio.woodpecker.svc
+  port: 9000
+  accessKeyID: minioadmin
+  secretAccessKey: minioadmin
+  bucketName: woodpecker
+  rootPath: files
+  createBucket: true

--- a/tests/k8s/monitor/manifests/podmonitor-client.yaml
+++ b/tests/k8s/monitor/manifests/podmonitor-client.yaml
@@ -19,3 +19,6 @@ spec:
       path: /metrics
       interval: 15s
       honorLabels: true
+      relabelings:
+        - targetLabel: cluster
+          replacement: woodpecker-minikube

--- a/tests/k8s/monitor/manifests/podmonitor-client.yaml
+++ b/tests/k8s/monitor/manifests/podmonitor-client.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: woodpecker-client
+  namespace: woodpecker
+  labels:
+    app.kubernetes.io/name: woodpecker
+    app.kubernetes.io/component: client
+spec:
+  namespaceSelector:
+    matchNames: [woodpecker]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: woodpecker
+      app.kubernetes.io/component: client
+      app.kubernetes.io/instance: my-woodpecker
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      honorLabels: true

--- a/tests/k8s/monitor/manifests/podmonitor-server.yaml
+++ b/tests/k8s/monitor/manifests/podmonitor-server.yaml
@@ -1,0 +1,21 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: woodpecker-server
+  namespace: woodpecker
+  labels:
+    app.kubernetes.io/name: woodpecker
+    app.kubernetes.io/component: server
+spec:
+  namespaceSelector:
+    matchNames: [woodpecker]
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: woodpecker
+      app.kubernetes.io/component: server
+      app.kubernetes.io/instance: my-woodpecker
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 15s
+      honorLabels: true

--- a/tests/k8s/monitor/manifests/podmonitor-server.yaml
+++ b/tests/k8s/monitor/manifests/podmonitor-server.yaml
@@ -19,3 +19,6 @@ spec:
       path: /metrics
       interval: 15s
       honorLabels: true
+      relabelings:
+        - targetLabel: cluster
+          replacement: woodpecker-minikube

--- a/tests/k8s/monitor/monitor_test.go
+++ b/tests/k8s/monitor/monitor_test.go
@@ -1,0 +1,88 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitor
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// TestK8sMonitor_Metrics verifies scrape targets and the cluster/namespace/log_ns
+// label scheme against a Prometheus reachable at $WP_K8S_PROM_URL (a kubectl
+// port-forward set up by run_monitor_tests.sh). Skipped when unset so the package
+// stays `go test ./...`-safe without a live cluster.
+func TestK8sMonitor_Metrics(t *testing.T) {
+	base := os.Getenv("WP_K8S_PROM_URL")
+	if base == "" {
+		t.Skip("WP_K8S_PROM_URL unset; run via run_monitor_tests.sh")
+	}
+	c := NewK8sMonitorCluster(base)
+	c.WaitForPrometheusReady(t, 60*time.Second)
+
+	t.Run("ServerTargetUp", func(t *testing.T) {
+		if v, ok := c.QueryPromQL(t, `count(up{job="woodpecker/woodpecker-server"}==1)`); !ok || v == "0" {
+			t.Errorf("no server targets up (got %q)", v)
+		}
+	})
+	t.Run("ClientTargetUp", func(t *testing.T) {
+		if v, ok := c.QueryPromQL(t, `count(up{job="woodpecker/woodpecker-client"}==1)`); !ok || v == "0" {
+			t.Errorf("no client target up (got %q)", v)
+		}
+	})
+	t.Run("ServerMetrics", func(t *testing.T) {
+		for _, m := range []string{
+			"woodpecker_server_logstore_active_logs",
+			"woodpecker_server_logstore_operations_total",
+			"woodpecker_server_file_operations_total",
+		} {
+			if !c.QueryMetricHasValue(t, m) {
+				t.Errorf("server metric %s missing/zero", m)
+			}
+		}
+	})
+	t.Run("ClientMetrics", func(t *testing.T) {
+		for _, m := range []string{
+			"woodpecker_client_append_requests_total",
+			"woodpecker_client_log_handle_operations_total",
+		} {
+			if !c.QueryMetricHasValue(t, m) {
+				t.Errorf("client metric %s missing/zero", m)
+			}
+		}
+	})
+	t.Run("LabelScheme", func(t *testing.T) {
+		series := c.QueryVector(t, "woodpecker_server_logstore_active_logs")
+		if len(series) == 0 {
+			t.Fatal("no logstore_active_logs series")
+		}
+		for _, m := range series {
+			if m["cluster"] != "woodpecker-minikube" {
+				t.Errorf("cluster=%q, want woodpecker-minikube", m["cluster"])
+			}
+			if m["namespace"] != "woodpecker" {
+				t.Errorf("namespace=%q, want k8s namespace woodpecker", m["namespace"])
+			}
+			if m["log_ns"] == "" {
+				t.Errorf("missing log_ns label: %v", m)
+			}
+			if _, bad := m["exported_namespace"]; bad {
+				t.Errorf("unexpected exported_namespace: %v", m)
+			}
+		}
+	})
+}

--- a/tests/k8s/monitor/run_monitor_tests.sh
+++ b/tests/k8s/monitor/run_monitor_tests.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Licensed to the LF AI & Data foundation under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+export CLUSTER_NAME="${CLUSTER_NAME:-wp-monitor}"
+export CR_NAME="${CR_NAME:-my-woodpecker}"
+export NAMESPACE="${NAMESPACE:-woodpecker}"
+export REPLICAS="${REPLICAS:-3}"
+export WP_IMG="${WP_IMG:-zilliztech/woodpecker:v0.1.26}"
+export MK_CPUS="${MK_CPUS:-4}" MK_MEMORY="${MK_MEMORY:-4096}"
+MON_NS="monitoring"
+HELM_RELEASE="kps"
+NO_CLEANUP="${NO_CLEANUP:-false}"
+[ "${1:-}" = "--no-cleanup" ] && NO_CLEANUP=true
+
+source "$PROJECT_ROOT/deployments/operator/test/lib.sh"
+
+preload_image() { log "preload: $1"; docker pull "$1" || fail "docker pull $1"; minikube -p "$CLUSTER_NAME" image load "$1" || fail "image load $1"; }
+
+bringup() {
+  wp_minikube_start
+  kubectl label node "$CLUSTER_NAME" topology.kubernetes.io/zone=zone-a topology.kubernetes.io/region=region-local --overwrite
+  preload_image quay.io/coreos/etcd:v3.5.18
+  preload_image minio/minio:RELEASE.2024-06-13T22-53-53Z
+  kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+  # lib.sh applies deps/CR namespace-lessly, so pin the active namespace to $NAMESPACE
+  # (its seed DNS uses .$NAMESPACE.svc, so this keeps pods and DNS consistent).
+  kubectl config set-context --current --namespace="$NAMESPACE"
+  wp_deploy_operator; wp_build_wp_image
+  wp_deploy_deps; wp_create_cr; wp_wait_healthy
+}
+
+install_monitoring() {
+  helm repo add prometheus-community https://prometheus-community.github.io/helm-charts 2>/dev/null || true
+  helm repo update
+  log "preloading kube-prometheus-stack images"
+  helm template "$HELM_RELEASE" prometheus-community/kube-prometheus-stack -n "$MON_NS" \
+    -f "$SCRIPT_DIR/manifests/kube-prometheus-values.yaml" 2>/dev/null \
+    | grep -hoE 'image: *"?[^"[:space:]]+' | sed -E 's/image: *"?//' | sort -u \
+    | while read -r img; do [ -n "$img" ] && preload_image "$img"; done
+  helm upgrade --install "$HELM_RELEASE" prometheus-community/kube-prometheus-stack \
+    -n "$MON_NS" --create-namespace -f "$SCRIPT_DIR/manifests/kube-prometheus-values.yaml" --wait --timeout 8m
+  kubectl apply -f "$SCRIPT_DIR/manifests/podmonitor-server.yaml"
+  kubectl apply -f "$SCRIPT_DIR/manifests/podmonitor-client.yaml"
+  kubectl apply -f "$SCRIPT_DIR/manifests/dashboard-configmaps.yaml"
+}
+
+start_loadgen() {
+  kubectl apply -f "$SCRIPT_DIR/manifests/client-loadgen.yaml"
+  kubectl -n "$NAMESPACE" wait --for=condition=Ready pod/wp-loadgen --timeout=120s
+  log "building loadgen binary on host"
+  ( cd "$PROJECT_ROOT" && GOOS=linux GOARCH="$(go env GOARCH)" CGO_ENABLED=0 \
+      go build -o /tmp/wp-loadgen ./tests/k8s/monitor/loadgen ) || fail "loadgen build"
+  kubectl -n "$NAMESPACE" cp /tmp/wp-loadgen wp-loadgen:/root/wp-loadgen
+  # client config: reuse the same etcd/minio/seeds the CR uses (see README for the file)
+  kubectl -n "$NAMESPACE" cp "$SCRIPT_DIR/manifests/loadgen-config.yaml" wp-loadgen:/tmp/test-config.yaml
+  kubectl -n "$NAMESPACE" exec wp-loadgen -- bash -c 'chmod +x /root/wp-loadgen && nohup /root/wp-loadgen -config-file=/tmp/test-config.yaml >/tmp/loadgen.log 2>&1 &'
+  log "loadgen started; sleeping 45s to accumulate metrics"; sleep 45
+}
+
+run_tests() {
+  kubectl -n "$MON_NS" port-forward svc/prometheus-operated 9090:9090 >/tmp/pf-prom.log 2>&1 &
+  PF_PID=$!; trap 'kill $PF_PID 2>/dev/null || true' RETURN
+  sleep 5
+  WP_K8S_PROM_URL="http://localhost:9090" go test "$PROJECT_ROOT/tests/k8s/monitor/" -run TestK8sMonitor_Metrics -v -count=1 -timeout 300s
+}
+
+cleanup() {
+  helm uninstall "$HELM_RELEASE" -n "$MON_NS" 2>/dev/null || true
+  minikube delete -p "$CLUSTER_NAME" 2>/dev/null || true
+}
+
+main() {
+  bringup
+  install_monitoring
+  start_loadgen
+  if run_tests; then RC=0; else RC=1; fi
+  if [ "$NO_CLEANUP" = true ]; then
+    log "kept up. Grafana: $(minikube -p "$CLUSTER_NAME" service -n "$MON_NS" "$HELM_RELEASE-grafana" --url 2>/dev/null | head -1)"
+    log "Prometheus: kubectl -n $MON_NS port-forward svc/prometheus-operated 9090:9090"
+  else
+    cleanup
+  fi
+  exit $RC
+}
+main "$@"

--- a/tests/k8s/monitor/run_monitor_tests.sh
+++ b/tests/k8s/monitor/run_monitor_tests.sh
@@ -25,7 +25,7 @@ export REPLICAS="${REPLICAS:-3}"
 export WP_IMG="${WP_IMG:-zilliztech/woodpecker:v0.1.26}"
 # Dependency images for lib.sh wp_deploy_deps (it honors these env vars). Default MinIO
 # to a locally-present tag so preload_image reuses it without any registry pull.
-export ETCD_IMG="${ETCD_IMG:-quay.io/coreos/etcd:v3.5.18}"
+export ETCD_IMG="${ETCD_IMG:-quay.io/coreos/etcd:v3.5.25}"
 export MINIO_IMG="${MINIO_IMG:-minio/minio:RELEASE.2024-12-18T13-15-44Z}"
 export MK_CPUS="${MK_CPUS:-4}" MK_MEMORY="${MK_MEMORY:-4096}"
 MON_NS="monitoring"

--- a/tests/k8s/monitor/run_monitor_tests.sh
+++ b/tests/k8s/monitor/run_monitor_tests.sh
@@ -23,6 +23,10 @@ export CR_NAME="${CR_NAME:-my-woodpecker}"
 export NAMESPACE="${NAMESPACE:-woodpecker}"
 export REPLICAS="${REPLICAS:-3}"
 export WP_IMG="${WP_IMG:-zilliztech/woodpecker:v0.1.26}"
+# Dependency images for lib.sh wp_deploy_deps (it honors these env vars). Default MinIO
+# to a locally-present tag so preload_image reuses it without any registry pull.
+export ETCD_IMG="${ETCD_IMG:-quay.io/coreos/etcd:v3.5.18}"
+export MINIO_IMG="${MINIO_IMG:-minio/minio:RELEASE.2024-12-18T13-15-44Z}"
 export MK_CPUS="${MK_CPUS:-4}" MK_MEMORY="${MK_MEMORY:-4096}"
 MON_NS="monitoring"
 HELM_RELEASE="kps"
@@ -31,13 +35,20 @@ NO_CLEANUP="${NO_CLEANUP:-false}"
 
 source "$PROJECT_ROOT/deployments/operator/test/lib.sh"
 
-preload_image() { log "preload: $1"; docker pull "$1" || fail "docker pull $1"; minikube -p "$CLUSTER_NAME" image load "$1" || fail "image load $1"; }
+# Reuse a host-local image when present (skip the registry pull); otherwise pull it.
+# Either way, load it into the minikube node (which can't reach registries through the
+# host's loopback proxy).
+preload_image() {
+  log "preload: $1"
+  docker image inspect "$1" >/dev/null 2>&1 || docker pull "$1" || fail "docker pull $1"
+  minikube -p "$CLUSTER_NAME" image load "$1" || fail "image load $1"
+}
 
 bringup() {
   wp_minikube_start
   kubectl label node "$CLUSTER_NAME" topology.kubernetes.io/zone=zone-a topology.kubernetes.io/region=region-local --overwrite
-  preload_image quay.io/coreos/etcd:v3.5.18
-  preload_image minio/minio:RELEASE.2024-06-13T22-53-53Z
+  preload_image "$ETCD_IMG"
+  preload_image "$MINIO_IMG"
   kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
   # lib.sh applies deps/CR namespace-lessly, so pin the active namespace to $NAMESPACE
   # (its seed DNS uses .$NAMESPACE.svc, so this keeps pods and DNS consistent).

--- a/tests/k8s/monitor/run_monitor_tests.sh
+++ b/tests/k8s/monitor/run_monitor_tests.sh
@@ -41,7 +41,13 @@ source "$PROJECT_ROOT/deployments/operator/test/lib.sh"
 preload_image() {
   log "preload: $1"
   docker image inspect "$1" >/dev/null 2>&1 || docker pull "$1" || fail "docker pull $1"
-  minikube -p "$CLUSTER_NAME" image load "$1" || fail "image load $1"
+  # `minikube image load` (host->node via `docker save`) cannot export distroless images
+  # under Docker Desktop's containerd image store ("blobs/... not found in tar"). When the
+  # load fails, fall back to pulling on the node directly (the node has registry access).
+  if ! minikube -p "$CLUSTER_NAME" image load "$1" 2>/dev/null; then
+    warn "image load failed for $1 (containerd store / distroless?) — pulling on node instead"
+    minikube -p "$CLUSTER_NAME" image pull "$1" || fail "node pull $1"
+  fi
 }
 
 bringup() {


### PR DESCRIPTION
## Summary

Closes #193.

Woodpecker emitted its own application/logical namespace under the metric label **`namespace`**, which collides with the label every Kubernetes scrape attaches (the pod's k8s namespace). In production (`PodMonitor` + `honorLabels: true`) the app value won and the **real k8s namespace was destroyed** — you couldn't filter metrics by k8s namespace / instance.

This renames the app label to **`log_ns`** at the source, frees `namespace` for the real k8s concept, and adds a minikube monitoring E2E suite + dashboards that prove the scheme end-to-end.

## What's in here (three workstreams)

**A — source rename** (`common/metrics/`)
- `namespace` → `log_ns` in the client + service metric label sets (45 label-slice entries; values are positional so no call-site changes; `BuildMetricsNamespace` unchanged). Added a guard test asserting the label is `log_ns` and `namespace` is absent.

**B — Docker monitor dashboards** (`tests/docker/monitor/`)
- `dashboard_server.json` / `dashboard_client.json` updated to filter on `log_ns` (datasource refs preserved).

**C — new `tests/k8s/monitor/` suite** (minikube mirror of the Docker suite)
- `kube-prometheus-stack` (Operator + Prometheus + Grafana, trimmed) installed via Helm; Woodpecker scraped via two `PodMonitor`s.
- In-cluster client **load generator** (`loadgen/main.go`) drives write/read traffic and exposes client metrics.
- New **server + client k8s dashboard templates** with `prometheus / cluster / namespace (k8s) / log_ns (/ log_id / server_job)` selectors, shipped as Grafana sidecar ConfigMaps.
- `K8sMonitorCluster` Prometheus-query helper, an e2e verification test (gated on `WP_K8S_PROM_URL`), and a one-command `run_monitor_tests.sh`.
- Reuses `deployments/operator/test/lib.sh` for minikube bring-up.

## ⚠️ Breaking change

Renaming the metric label changes Woodpecker's emitted labels. After a build with this change ships, any dashboard/alert/query filtering on the app `namespace` label must move to **`log_ns`**. In-repo Docker dashboards are updated here; **production VDC dashboards are a separate follow-up**. The production `PodMonitor` needs **no** change — once the app emits `log_ns`, its existing `honorLabels: true` already yields a clean k8s `namespace` + `log_ns`.

## Validation

**Offline:** `go build ./...`, `go vet`, `go test ./common/metrics/... ./tests/k8s/monitor/... ./cmd/wpcli/...` all green (the e2e test SKIPs without a cluster); loadgen cross-compiles for linux; `bash -n` clean on the runner/lib.

**Live (minikube):** `TestK8sMonitor_Metrics` passes (server + client targets up, representative server/client metrics non-zero). A real series confirms the scheme:
```
woodpecker_server_logstore_active_logs{
  cluster="woodpecker-minikube", namespace="woodpecker" (k8s),
  log_ns="woodpecker/files" (app), log_id="1", job="woodpecker/woodpecker-server" }
```
— no `exported_namespace`; all dashboard dropdowns populate.

Design: `docs/superpowers/specs/2026-06-22-k8s-monitor-suite-design.md` · Plan: `docs/superpowers/plans/2026-06-22-k8s-monitor-log-ns.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
