### PR TITLE
feat(metrics): active-segment node metric + client dashboard panels (#197)

### DIFF
--- a/common/metrics/active_segment_node_test.go
+++ b/common/metrics/active_segment_node_test.go
@@ -1,0 +1,50 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActiveSegmentNodes_SetAndClear(t *testing.T) {
+	WpActiveSegmentNode.Reset()
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(WpActiveSegmentNode)
+
+	ns, logId, segId := "bucket/root", "42", "7"
+	nodes := []string{"10.0.0.1:8000", "10.0.0.2:8000", "10.0.0.3:8000"}
+
+	SetActiveSegmentNodes(ns, logId, segId, nodes)
+
+	count, err := testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, len(nodes), count, "one series per node after set")
+	for _, n := range nodes {
+		v := testutil.ToFloat64(WpActiveSegmentNode.WithLabelValues(ns, logId, segId, n))
+		assert.Equal(t, float64(1), v)
+	}
+
+	ClearActiveSegmentNodes(ns, logId, segId, nodes)
+	count, err = testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "series removed after clear")
+}

--- a/common/metrics/client_metrics.go
+++ b/common/metrics/client_metrics.go
@@ -240,24 +240,24 @@ func RegisterClientMetricsWithRegisterer(registerer prometheus.Registerer) {
 }
 
 // UpdateSegmentState transitions the segment state gauge: decrements the old state count
-// and increments the new state count for the given namespace and log.
-func UpdateSegmentState(namespace, logId, oldState, newState string) {
-	WpClientSegmentState.WithLabelValues(namespace, logId, oldState).Dec()
-	WpClientSegmentState.WithLabelValues(namespace, logId, newState).Inc()
+// and increments the new state count for the given logNs and log.
+func UpdateSegmentState(logNs, logId, oldState, newState string) {
+	WpClientSegmentState.WithLabelValues(logNs, logId, oldState).Dec()
+	WpClientSegmentState.WithLabelValues(logNs, logId, newState).Inc()
 }
 
 // SetActiveSegmentNodes marks each node of an active (writable) segment's quorum
 // with a value of 1 (one series per node). Call when a segment becomes writable.
-func SetActiveSegmentNodes(namespace, logId, segmentId string, nodes []string) {
+func SetActiveSegmentNodes(logNs, logId, segmentId string, nodes []string) {
 	for _, node := range nodes {
-		WpActiveSegmentNode.WithLabelValues(namespace, logId, segmentId, node).Set(1)
+		WpActiveSegmentNode.WithLabelValues(logNs, logId, segmentId, node).Set(1)
 	}
 }
 
 // ClearActiveSegmentNodes deletes the per-node series for an active segment.
 // Call when the segment leaves the writable state (completed / rolling / closed).
-func ClearActiveSegmentNodes(namespace, logId, segmentId string, nodes []string) {
+func ClearActiveSegmentNodes(logNs, logId, segmentId string, nodes []string) {
 	for _, node := range nodes {
-		WpActiveSegmentNode.DeleteLabelValues(namespace, logId, segmentId, node)
+		WpActiveSegmentNode.DeleteLabelValues(logNs, logId, segmentId, node)
 	}
 }

--- a/common/metrics/client_metrics.go
+++ b/common/metrics/client_metrics.go
@@ -156,6 +156,17 @@ var (
 		Help:      "Number of pending append operations in segment handles",
 	}, []string{"log_ns", "log_id"})
 
+	// Active (writable) segment -> quorum node membership. One series per node of
+	// the current active segment; value is always 1. Series are deleted when the
+	// segment leaves the writable state, so a query reflects only the currently
+	// active segment of each log (used to verify node switching/failover).
+	WpActiveSegmentNode = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "active_segment_node",
+		Help:      "Quorum node membership of each log's current active (writable) segment (value always 1, one series per node)",
+	}, []string{"log_ns", "log_id", "segment_id", "node"})
+
 	// Direct read metrics (client reads sealed segments directly from object storage)
 	WpClientDirectReadRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: woodpeckerNamespace,
@@ -217,6 +228,8 @@ func RegisterClientMetricsWithRegisterer(registerer prometheus.Registerer) {
 		registerer.MustRegister(WpSegmentHandleOperationsTotal)
 		registerer.MustRegister(WpSegmentHandleOperationLatency)
 		registerer.MustRegister(WpSegmentHandlePendingAppendOps)
+		// Active segment node membership
+		registerer.MustRegister(WpActiveSegmentNode)
 		// Direct read metrics
 		registerer.MustRegister(WpClientDirectReadRequestsTotal)
 		registerer.MustRegister(WpClientDirectReadLatency)
@@ -231,4 +244,20 @@ func RegisterClientMetricsWithRegisterer(registerer prometheus.Registerer) {
 func UpdateSegmentState(namespace, logId, oldState, newState string) {
 	WpClientSegmentState.WithLabelValues(namespace, logId, oldState).Dec()
 	WpClientSegmentState.WithLabelValues(namespace, logId, newState).Inc()
+}
+
+// SetActiveSegmentNodes marks each node of an active (writable) segment's quorum
+// with a value of 1 (one series per node). Call when a segment becomes writable.
+func SetActiveSegmentNodes(namespace, logId, segmentId string, nodes []string) {
+	for _, node := range nodes {
+		WpActiveSegmentNode.WithLabelValues(namespace, logId, segmentId, node).Set(1)
+	}
+}
+
+// ClearActiveSegmentNodes deletes the per-node series for an active segment.
+// Call when the segment leaves the writable state (completed / rolling / closed).
+func ClearActiveSegmentNodes(namespace, logId, segmentId string, nodes []string) {
+	for _, node := range nodes {
+		WpActiveSegmentNode.DeleteLabelValues(namespace, logId, segmentId, node)
+	}
 }

--- a/common/metrics/metrics_registration_test.go
+++ b/common/metrics/metrics_registration_test.go
@@ -28,14 +28,14 @@ import (
 
 func TestBuildMetricsNamespace(t *testing.T) {
 	t.Run("normal", func(t *testing.T) {
-		assert.Equal(t, "mybucket/myroot", BuildMetricsNamespace("mybucket", "myroot"))
+		assert.Equal(t, "mybucket/myroot", BuildLogNs("mybucket", "myroot"))
 	})
 	t.Run("empty", func(t *testing.T) {
-		assert.Equal(t, "/", BuildMetricsNamespace("", ""))
+		assert.Equal(t, "/", BuildLogNs("", ""))
 	})
 	t.Run("single_empty", func(t *testing.T) {
-		assert.Equal(t, "bucket/", BuildMetricsNamespace("bucket", ""))
-		assert.Equal(t, "/root", BuildMetricsNamespace("", "root"))
+		assert.Equal(t, "bucket/", BuildLogNs("bucket", ""))
+		assert.Equal(t, "/root", BuildLogNs("", "root"))
 	})
 }
 
@@ -116,54 +116,54 @@ func TestRegisterServerMetrics_OnlyOnce(t *testing.T) {
 
 func TestUpdateSegmentState(t *testing.T) {
 	// Initialize gauge values first
-	namespace := "test-ns"
+	logNs := "test-ns"
 	logId := "1"
 	oldState := "Active"
 	newState := "Completed"
 
 	// Set initial state
-	WpClientSegmentState.WithLabelValues(namespace, logId, oldState).Set(5)
-	WpClientSegmentState.WithLabelValues(namespace, logId, newState).Set(0)
+	WpClientSegmentState.WithLabelValues(logNs, logId, oldState).Set(5)
+	WpClientSegmentState.WithLabelValues(logNs, logId, newState).Set(0)
 
 	// Call UpdateSegmentState
-	UpdateSegmentState(namespace, logId, oldState, newState)
+	UpdateSegmentState(logNs, logId, oldState, newState)
 
 	// Read old state gauge - should be 4 (5 - 1)
 	oldMetric := &dto.Metric{}
-	WpClientSegmentState.WithLabelValues(namespace, logId, oldState).Write(oldMetric)
+	WpClientSegmentState.WithLabelValues(logNs, logId, oldState).Write(oldMetric)
 	assert.Equal(t, float64(4), oldMetric.GetGauge().GetValue())
 
 	// Read new state gauge - should be 1 (0 + 1)
 	newMetric := &dto.Metric{}
-	WpClientSegmentState.WithLabelValues(namespace, logId, newState).Write(newMetric)
+	WpClientSegmentState.WithLabelValues(logNs, logId, newState).Write(newMetric)
 	assert.Equal(t, float64(1), newMetric.GetGauge().GetValue())
 }
 
 func TestUpdateSegmentState_MultipleTransitions(t *testing.T) {
-	namespace := "test-multi"
+	logNs := "test-multi"
 	logId := "2"
 
-	WpClientSegmentState.WithLabelValues(namespace, logId, "Active").Set(10)
-	WpClientSegmentState.WithLabelValues(namespace, logId, "Completed").Set(0)
-	WpClientSegmentState.WithLabelValues(namespace, logId, "Sealed").Set(0)
+	WpClientSegmentState.WithLabelValues(logNs, logId, "Active").Set(10)
+	WpClientSegmentState.WithLabelValues(logNs, logId, "Completed").Set(0)
+	WpClientSegmentState.WithLabelValues(logNs, logId, "Sealed").Set(0)
 
 	// Active -> Completed
-	UpdateSegmentState(namespace, logId, "Active", "Completed")
+	UpdateSegmentState(logNs, logId, "Active", "Completed")
 	// Active -> Completed again
-	UpdateSegmentState(namespace, logId, "Active", "Completed")
+	UpdateSegmentState(logNs, logId, "Active", "Completed")
 	// Completed -> Sealed
-	UpdateSegmentState(namespace, logId, "Completed", "Sealed")
+	UpdateSegmentState(logNs, logId, "Completed", "Sealed")
 
 	activeMetric := &dto.Metric{}
-	WpClientSegmentState.WithLabelValues(namespace, logId, "Active").Write(activeMetric)
+	WpClientSegmentState.WithLabelValues(logNs, logId, "Active").Write(activeMetric)
 	assert.Equal(t, float64(8), activeMetric.GetGauge().GetValue())
 
 	completedMetric := &dto.Metric{}
-	WpClientSegmentState.WithLabelValues(namespace, logId, "Completed").Write(completedMetric)
+	WpClientSegmentState.WithLabelValues(logNs, logId, "Completed").Write(completedMetric)
 	assert.Equal(t, float64(1), completedMetric.GetGauge().GetValue())
 
 	sealedMetric := &dto.Metric{}
-	WpClientSegmentState.WithLabelValues(namespace, logId, "Sealed").Write(sealedMetric)
+	WpClientSegmentState.WithLabelValues(logNs, logId, "Sealed").Write(sealedMetric)
 	assert.Equal(t, float64(1), sealedMetric.GetGauge().GetValue())
 }
 

--- a/common/metrics/service_metrics.go
+++ b/common/metrics/service_metrics.go
@@ -39,8 +39,8 @@ var NodeID = func() string {
 	return "embed"
 }()
 
-// BuildMetricsNamespace returns the metrics namespace string from bucket name and root path.
-func BuildMetricsNamespace(bucketName, rootPath string) string {
+// BuildLogNs returns the metrics log_ns string from bucket name and root path.
+func BuildLogNs(bucketName, rootPath string) string {
 	return bucketName + "/" + rootPath
 }
 

--- a/common/runtime/loghealth/tracker.go
+++ b/common/runtime/loghealth/tracker.go
@@ -40,18 +40,18 @@ const (
 // Compile-time assertion that Tracker is an OpObserver.
 var _ metrics.OpObserver = (*Tracker)(nil)
 
-// namespace is woodpecker's per-tenant scope — a (bucketName, rootPath) pair,
-// the same identity metrics.BuildMetricsNamespace renders as "bucket/rootPath".
-type namespace struct {
+// logNs is woodpecker's per-tenant scope — a (bucketName, rootPath) pair,
+// the same identity metrics.BuildLogNs renders as "bucket/rootPath".
+type logNs struct {
 	bucketName string
 	rootPath   string
 }
 
-// logKey is the full per-log identity: a namespace plus the log ID. It is a
+// logKey is the full per-log identity: a logNs plus the log ID. It is a
 // comparable struct used directly as a native map key, so lookups hash it in
 // place without boxing or allocation (unlike an interface-keyed sync.Map).
 type logKey struct {
-	ns    namespace
+	ns    logNs
 	logID int64
 }
 
@@ -161,7 +161,7 @@ func (t *Tracker) OnOpEnd(op *metrics.Op, _ uint64, elapsed time.Duration, statu
 // --- internal record methods (unit-testable without metrics.Op) ---
 
 func (t *Tracker) get(bucketName, rootPath string, logID int64) *logHealth {
-	key := logKey{ns: namespace{bucketName: bucketName, rootPath: rootPath}, logID: logID}
+	key := logKey{ns: logNs{bucketName: bucketName, rootPath: rootPath}, logID: logID}
 	// Fast path: lock-free, allocation-free read of the current snapshot.
 	if lh := (*t.logs.Load())[key]; lh != nil {
 		return lh

--- a/docs/superpowers/plans/2026-06-24-active-segment-node-metric.md
+++ b/docs/superpowers/plans/2026-06-24-active-segment-node-metric.md
@@ -1,0 +1,699 @@
+# Active-Segment Node Metric Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a client-side Prometheus gauge that records which quorum nodes each log's current active (writable) segment is using, plus two Grafana panels, so node switching/failover can be verified.
+
+**Architecture:** One `GaugeVec` `woodpecker_client_active_segment_node{log_ns, log_id, segment_id, node} = 1`, one series per quorum node. Two package-level helpers in `common/metrics` (mirroring the existing `UpdateSegmentState`) set/clear the series. `segmentHandleImpl` calls *set* at the single point a segment becomes writable (`NewSegmentHandle`, `canWrite==true`) and *clear* at the single point a segment leaves the writable state (the lone `canWriteState.CompareAndSwap(true,false)` in `doCloseWritingAndUpdateMetaIfNecessaryUnsafe`). Two panels are added to the docker and k8s client dashboards.
+
+**Tech Stack:** Go, `github.com/prometheus/client_golang` (incl. `prometheus/testutil`), testify + mockery mocks, Grafana dashboard JSON.
+
+## Global Constraints
+
+- Branch: work on `issue-197-active-segment-node-metric` (already checked out). Do NOT commit to `master`.
+- No change to `proto/meta.proto`, no etcd persistence, no change to `SelectQuorum` / `woodpecker/quorum/`, no server-side change, no append hot-path instrumentation.
+- Metric naming: `Namespace: woodpeckerNamespace` (`"woodpecker"`), `Subsystem: clientRole` (`"client"`) → full name `woodpecker_client_active_segment_node`. Label set EXACTLY `[]string{"log_ns", "log_id", "segment_id", "node"}`.
+- `log_ns` value on the client is `s.metricsNamespace` (= `metrics.BuildMetricsNamespace(cfg.Minio.BucketName, cfg.Minio.RootPath)`); `log_id`/`segment_id` are `strconv.FormatInt(..., 10)`. Reuse these — do not invent a new derivation.
+- Dashboards: docker panels use datasource `__DATASOURCE_UID__` and `{log_ns=~"$log_ns"}`; k8s panels use datasource `${prometheus}` and `{cluster=~"$cluster", namespace=~"$namespace", log_ns=~"$log_ns"}`. Do NOT add new template variables. The k8s file must never contain `__DATASOURCE_UID__`.
+- Commit messages end with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+## File Structure
+
+- `common/metrics/client_metrics.go` (modify) — add `WpActiveSegmentNode` gauge, register it, add `SetActiveSegmentNodes` / `ClearActiveSegmentNodes` helpers.
+- `common/metrics/active_segment_node_test.go` (create) — unit test for the metric + helpers.
+- `woodpecker/segment/segment_handle.go` (modify) — call set in `NewSegmentHandle` (`canWrite` branch); call clear in `doCloseWritingAndUpdateMetaIfNecessaryUnsafe` after the CAS.
+- `woodpecker/segment/segment_handle_active_node_test.go` (create) — test that a writable handle publishes the series and that closing it removes them.
+- `tests/docker/monitor/grafana/templates/dashboard_client.json` (modify) — add Panel 1 (table, id 16) + Panel 2 (timeseries, id 17).
+- `tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json` (modify) — add the same two panels with the k8s datasource/labels.
+
+---
+
+### Task 1: Metric definition + set/clear helpers (`common/metrics`)
+
+**Files:**
+- Modify: `common/metrics/client_metrics.go` (var block near line 157; registration near line 219; helpers after `UpdateSegmentState` at end of file ~line 234)
+- Test: `common/metrics/active_segment_node_test.go` (create)
+
+**Interfaces:**
+- Produces:
+  - `var WpActiveSegmentNode *prometheus.GaugeVec` — labels `[]string{"log_ns","log_id","segment_id","node"}`.
+  - `func SetActiveSegmentNodes(namespace, logId, segmentId string, nodes []string)`
+  - `func ClearActiveSegmentNodes(namespace, logId, segmentId string, nodes []string)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `common/metrics/active_segment_node_test.go`:
+
+```go
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestActiveSegmentNodes_SetAndClear(t *testing.T) {
+	WpActiveSegmentNode.Reset()
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(WpActiveSegmentNode)
+
+	ns, logId, segId := "bucket/root", "42", "7"
+	nodes := []string{"10.0.0.1:8000", "10.0.0.2:8000", "10.0.0.3:8000"}
+
+	SetActiveSegmentNodes(ns, logId, segId, nodes)
+
+	count, err := testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, len(nodes), count, "one series per node after set")
+	for _, n := range nodes {
+		v := testutil.ToFloat64(WpActiveSegmentNode.WithLabelValues(ns, logId, segId, n))
+		assert.Equal(t, float64(1), v)
+	}
+
+	ClearActiveSegmentNodes(ns, logId, segId, nodes)
+	count, err = testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "series removed after clear")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./common/metrics/ -run TestActiveSegmentNodes_SetAndClear -v`
+Expected: COMPILE FAILURE — `undefined: WpActiveSegmentNode`, `undefined: SetActiveSegmentNodes`, `undefined: ClearActiveSegmentNodes`.
+
+- [ ] **Step 3: Add the metric var**
+
+In `common/metrics/client_metrics.go`, immediately after the `WpSegmentHandlePendingAppendOps` definition (the block ending `}, []string{"log_ns", "log_id"})` at ~line 157), add:
+
+```go
+	// Active (writable) segment -> quorum node membership. One series per node of
+	// the current active segment; value is always 1. Series are deleted when the
+	// segment leaves the writable state, so a query reflects only the currently
+	// active segment of each log (used to verify node switching/failover).
+	WpActiveSegmentNode = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "active_segment_node",
+		Help:      "Quorum node membership of each log's current active (writable) segment (value always 1, one series per node)",
+	}, []string{"log_ns", "log_id", "segment_id", "node"})
+```
+
+- [ ] **Step 4: Register the metric**
+
+In `RegisterClientMetricsWithRegisterer`, immediately after `registerer.MustRegister(WpSegmentHandlePendingAppendOps)` (~line 219), add:
+
+```go
+		// Active segment node membership
+		registerer.MustRegister(WpActiveSegmentNode)
+```
+
+- [ ] **Step 5: Add the helpers**
+
+At the end of `common/metrics/client_metrics.go` (after the `UpdateSegmentState` function), add:
+
+```go
+// SetActiveSegmentNodes marks each node of an active (writable) segment's quorum
+// with a value of 1 (one series per node). Call when a segment becomes writable.
+func SetActiveSegmentNodes(namespace, logId, segmentId string, nodes []string) {
+	for _, node := range nodes {
+		WpActiveSegmentNode.WithLabelValues(namespace, logId, segmentId, node).Set(1)
+	}
+}
+
+// ClearActiveSegmentNodes deletes the per-node series for an active segment.
+// Call when the segment leaves the writable state (completed / rolling / closed).
+func ClearActiveSegmentNodes(namespace, logId, segmentId string, nodes []string) {
+	for _, node := range nodes {
+		WpActiveSegmentNode.DeleteLabelValues(namespace, logId, segmentId, node)
+	}
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `go test ./common/metrics/ -run TestActiveSegmentNodes_SetAndClear -v`
+Expected: PASS.
+
+- [ ] **Step 7: Verify the whole metrics package still builds/tests**
+
+Run: `go test ./common/metrics/...`
+Expected: PASS (no regressions in existing metrics tests).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add common/metrics/client_metrics.go common/metrics/active_segment_node_test.go
+git commit -m "feat(metrics): add woodpecker_client_active_segment_node gauge + set/clear helpers
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire set/clear into the segment handle lifecycle
+
+**Files:**
+- Modify: `woodpecker/segment/segment_handle.go` (set in `NewSegmentHandle` `canWrite` branch ~line 127; clear in `doCloseWritingAndUpdateMetaIfNecessaryUnsafe` right after the CAS ~line 854)
+- Test: `woodpecker/segment/segment_handle_active_node_test.go` (create)
+
+**Interfaces:**
+- Consumes: `metrics.SetActiveSegmentNodes`, `metrics.ClearActiveSegmentNodes` (Task 1).
+- Relies on existing struct fields: `s.metricsNamespace string`, `s.logId int64`, `s.segmentId int64`, `s.quorumInfo *proto.QuorumInfo`. Imports `strconv`, `common/metrics`, `proto` are already present in this file.
+
+> Lifecycle rationale: across the whole file `canWriteState` is set true only in the constructor, and the ONLY true→false transition is the single `CompareAndSwap(true,false)` in `doCloseWritingAndUpdateMetaIfNecessaryUnsafe`. All completion/rolling/fence/log-close paths funnel through it (`ForceCompleteAndClose` → completion → doClose; `FenceAndComplete` → complete → doClose; `logHandleImpl.Close` → `completeAllSegmentHandlesUnsafe` → `ForceCompleteAndClose`). So set-on-construct + clear-after-CAS fires exactly once each per segment.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `woodpecker/segment/segment_handle_active_node_test.go`:
+
+```go
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/metrics"
+	"github.com/zilliztech/woodpecker/meta"
+	"github.com/zilliztech/woodpecker/mocks/mocks_meta"
+	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_logstore_client"
+	"github.com/zilliztech/woodpecker/proto"
+)
+
+func TestSegmentHandle_ActiveSegmentNodeMetric_SetAndClear(t *testing.T) {
+	metrics.WpActiveSegmentNode.Reset()
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(metrics.WpActiveSegmentNode)
+
+	mockMetadata := mocks_meta.NewMetadataProvider(t)
+	mockMetadata.EXPECT().UpdateSegmentMetadata(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil).Maybe()
+
+	cfg := &config.Configuration{
+		Woodpecker: config.WoodpeckerConfig{
+			Client: config.ClientConfig{
+				SegmentAppend: config.SegmentAppendConfig{QueueSize: 10, MaxRetries: 2},
+			},
+		},
+	}
+
+	segmentMeta := &meta.SegmentMeta{
+		Metadata: &proto.SegmentMetadata{
+			SegNo:       7,
+			State:       proto.SegmentState_Active,
+			LastEntryId: -1,
+			Quorum: &proto.QuorumInfo{
+				Id: 1, Aq: 1, Es: 3, Wq: 3,
+				Nodes: []string{"10.0.0.1:8000", "10.0.0.2:8000", "10.0.0.3:8000"},
+			},
+		},
+		Revision: 1,
+	}
+
+	sh := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, true, nil).(*segmentHandleImpl)
+
+	count, err := testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, count, "writable segment should publish one series per quorum node")
+
+	// Transition out of writable; clear must fire exactly once (CAS true->false).
+	err = sh.doCloseWritingAndUpdateMetaIfNecessaryUnsafe(context.Background(), -1)
+	assert.NoError(t, err)
+
+	count, err = testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "series removed after segment leaves writable state")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./woodpecker/segment/ -run TestSegmentHandle_ActiveSegmentNodeMetric_SetAndClear -v`
+Expected: FAIL — first assertion `assert.Equal(t, 3, count)` fails with `0 != 3` (no set wired yet).
+
+- [ ] **Step 3: Wire the set call**
+
+In `woodpecker/segment/segment_handle.go`, inside `NewSegmentHandle`, replace the `if canWrite {` block:
+
+```go
+	if canWrite {
+		segmentHandle.canWriteState.Store(true)
+		segmentHandle.executor.Start(ctx)
+		segmentHandle.completionMgr = newCompletionManager(segmentHandle)
+		segmentHandle.completionMgr.Start(context.Background())
+	}
+```
+
+with:
+
+```go
+	if canWrite {
+		segmentHandle.canWriteState.Store(true)
+		metrics.SetActiveSegmentNodes(
+			segmentHandle.metricsNamespace,
+			strconv.FormatInt(segmentHandle.logId, 10),
+			strconv.FormatInt(segmentHandle.segmentId, 10),
+			segmentHandle.quorumInfo.GetNodes(),
+		)
+		segmentHandle.executor.Start(ctx)
+		segmentHandle.completionMgr = newCompletionManager(segmentHandle)
+		segmentHandle.completionMgr.Start(context.Background())
+	}
+```
+
+- [ ] **Step 4: Wire the clear call**
+
+In `doCloseWritingAndUpdateMetaIfNecessaryUnsafe`, replace:
+
+```go
+	if !s.canWriteState.CompareAndSwap(true, false) {
+		return nil
+	}
+
+	start := time.Now()
+```
+
+with:
+
+```go
+	if !s.canWriteState.CompareAndSwap(true, false) {
+		return nil
+	}
+	// Segment is leaving the writable state -- drop its active-segment node series
+	// so the metric only ever reflects the current active segment of each log.
+	metrics.ClearActiveSegmentNodes(
+		s.metricsNamespace,
+		strconv.FormatInt(s.logId, 10),
+		strconv.FormatInt(s.segmentId, 10),
+		s.quorumInfo.GetNodes(),
+	)
+
+	start := time.Now()
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./woodpecker/segment/ -run TestSegmentHandle_ActiveSegmentNodeMetric_SetAndClear -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the segment package + build to check for regressions**
+
+Run: `go build ./... && go test ./woodpecker/segment/...`
+Expected: build OK; segment tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add woodpecker/segment/segment_handle.go woodpecker/segment/segment_handle_active_node_test.go
+git commit -m "feat(segment): publish active_segment_node metric on writable set/clear
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Add the two panels to the docker client dashboard
+
+**Files:**
+- Modify: `tests/docker/monitor/grafana/templates/dashboard_client.json` (last panel is id 15 "Segment State Count by Log"; the panels array closes right after it)
+
+**Interfaces:**
+- Consumes: metric `woodpecker_client_active_segment_node` (Task 1).
+
+- [ ] **Step 1: Insert the two panels**
+
+In `tests/docker/monitor/grafana/templates/dashboard_client.json`, find the end of panel id 15 and the panels-array close:
+
+```json
+      "title": "Segment State Count by Log",
+      "type": "timeseries"
+    }
+  ],
+```
+
+Replace it with (note the new `,` after the first `}`):
+
+```json
+      "title": "Segment State Count by Log",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 16,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Log ID",
+            "desc": false
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "woodpecker_client_active_segment_node{log_ns=~\"$log_ns\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Segment → Nodes (by Log)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "Value": true
+            },
+            "renameByName": {
+              "log_id": "Log ID",
+              "segment_id": "Segment ID",
+              "node": "Node"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count by (node) (woodpecker_client_active_segment_node{log_ns=~\"$log_ns\"})",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Segments per Node",
+      "type": "timeseries"
+    }
+  ],
+```
+
+- [ ] **Step 2: Validate JSON + presence**
+
+Run:
+```bash
+jq . tests/docker/monitor/grafana/templates/dashboard_client.json >/dev/null && echo "JSON OK"
+jq -r '.panels[].title' tests/docker/monitor/grafana/templates/dashboard_client.json | grep -E "Active Segment|Active Segments per Node"
+```
+Expected: `JSON OK`, and both new titles printed.
+
+- [ ] **Step 3: Confirm docker monitor test still compiles**
+
+Run: `go vet ./tests/docker/monitor/`
+Expected: no errors (the docker integration test does not statically validate panels; dashboard import is non-fatal — this just guards the package compiles).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/docker/monitor/grafana/templates/dashboard_client.json
+git commit -m "feat(monitor/docker): add active-segment node panels to client dashboard
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Add the two panels to the k8s client dashboard
+
+**Files:**
+- Modify: `tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json` (last panel is id 15 "Segment State Count by Log")
+
+**Interfaces:**
+- Consumes: metric `woodpecker_client_active_segment_node` (Task 1).
+
+- [ ] **Step 1: Insert the two panels**
+
+In `tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json`, find:
+
+```json
+      "title": "Segment State Count by Log",
+      "type": "timeseries"
+    }
+  ],
+```
+
+Replace it with:
+
+```json
+      "title": "Segment State Count by Log",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 16,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Log ID",
+            "desc": false
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "woodpecker_client_active_segment_node{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Segment → Nodes (by Log)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "cluster": true,
+              "Value": true
+            },
+            "renameByName": {
+              "log_id": "Log ID",
+              "segment_id": "Segment ID",
+              "node": "Node"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count by (node) (woodpecker_client_active_segment_node{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"})",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Segments per Node",
+      "type": "timeseries"
+    }
+  ],
+```
+
+- [ ] **Step 2: Validate JSON + presence + no stray placeholder**
+
+Run:
+```bash
+jq . tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json >/dev/null && echo "JSON OK"
+jq -r '.panels[].title' tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json | grep -E "Active Segment|Active Segments per Node"
+grep -c "__DATASOURCE_UID__" tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
+```
+Expected: `JSON OK`; both titles printed; the grep count is `0`.
+
+- [ ] **Step 3: Run the k8s dashboard validation test**
+
+Run: `go test ./tests/k8s/monitor/ -run TestK8sDashboards_Valid -v`
+Expected: PASS (valid JSON, no `__DATASOURCE_UID__`, has `${prometheus}`, template vars `prometheus/cluster/namespace/log_ns` unchanged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
+git commit -m "feat(monitor/k8s): add active-segment node panels to client dashboard
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Notes / Optional follow-ups (not required for this plan)
+
+- The docker comprehensive monitor integration test (`TestMonitor_ComprehensiveMetricsVerification`, requires docker + ~3.5 min run) could later add `assertMetricExists(t, cluster, "woodpecker_client_active_segment_node")` under its `ClientMetrics` subtest. Left out of the per-task gates because it needs the full docker stack.
+- The test-only constructor `NewSegmentHandleWithAppendOpsQueueWithWritable` deliberately keeps a placeholder quorum and is NOT wired to the metric; no change needed.
+
+## Self-Review
+
+- **Spec coverage:** Core metric (§2 of spec) → Tasks 1–2. Lifecycle event-driven set/clear (§2.2) → Task 2 (set in `NewSegmentHandle`, clear after CAS; funnel argument documented). Dashboard panels for docker + k8s (§3) → Tasks 3–4. Non-goals (no proto/etcd/SelectQuorum/server) → enforced by Global Constraints; nothing in any task touches them. Test-pass-through for `dashboards_test.go` / docker monitor test (§3.3) → Task 3 Step 3, Task 4 Step 3.
+- **Placeholder scan:** No TBD/TODO; every code/JSON step contains the full literal content and exact run commands with expected output.
+- **Type consistency:** Helper names `SetActiveSegmentNodes` / `ClearActiveSegmentNodes` and metric var `WpActiveSegmentNode` are used identically in Tasks 1 and 2. Label order `log_ns, log_id, segment_id, node` matches between the metric definition, the helpers, and the dashboard `renameByName`/queries. `s.quorumInfo.GetNodes()` is the nil-safe proto getter.

--- a/docs/superpowers/specs/2026-06-24-active-segment-node-metric-design.md
+++ b/docs/superpowers/specs/2026-06-24-active-segment-node-metric-design.md
@@ -1,0 +1,115 @@
+# Issue #197 Design: active-segment node metric + client dashboard panels
+
+- Date: 2026-06-24
+- Status: design agreed, pending review
+- Scope: woodpecker client-side observability. No proto change, no server change, no change to the quorum selection path (`SelectQuorum`), nothing persisted to etcd.
+
+## 1. Background & Goal
+
+In woodpecker, a log (`logHandleImpl`) has **at most one active (writable) segment** at any moment (`WritableSegmentId`), and **that segment's quorum node set is immutable for its lifetime**. A node "switch" (failover / rolling) is, in essence: the current active segment turns `Completed` (e.g. after append failures), and the log selects a fresh set of nodes to create a **new active segment**.
+
+There is currently no direct observation point to answer: **"After a switch, have all these logs' active segments actually moved onto the newly switched-to nodes?"** The existing metrics (`woodpecker_client_*`) only cover request rate / latency / pending counts, etc. — they don't show "which nodes the current active segment sits on".
+
+This design adds client-side observability:
+
+1. **Core metric**: record the quorum nodes the current active segment of each log is using (keyed by `log_ns` / `log_id` / `segment_id` / `node`).
+2. **Dashboard**: add panels to the client dashboard (both the docker and k8s templates) that, for a selected `log_ns`, show which nodes these logs' active segments write to, and let you visually watch old nodes drop to zero and new nodes come up during a switch.
+
+### Non-goals
+
+- No change to `proto/meta.proto`, nothing persisted to etcd. Pure client in-process state + Prometheus exposition.
+- No change to server-side metrics / dashboard.
+- No new instrumentation on the append hot path.
+- **No seed-pool / pool-dimension metric.** Which pool a node belongs to is inferable from the node name, and the client's own pool config changes are already a static record (the source of truth for reverse lookup); changing the `SelectQuorum` signature just for this is not worth it. Revisit the pool dimension only if a concrete PromQL aggregation need arises.
+
+## 2. Metric definition: active segment → nodes
+
+### 2.1 Definition
+
+File: `common/metrics/client_metrics.go` (follows the client-side `clientRole` subsystem and the `log_ns` label convention).
+
+```
+woodpecker_client_active_segment_node{log_ns, log_id, segment_id, node} = 1
+```
+
+- Type: `GaugeVec`, value is always `1` — a "membership" indicator gauge.
+- Semantics: **one series per node** in the current active (writable) segment's quorum. One active segment occupies `Wq` series (typically 3).
+- Cardinality: because an old segment's series are deleted on switch, the total series count at any time is ≈ `open logs × Wq`, and does not grow unbounded over time. Although `segment_id` increases monotonically, the series for stale ids have already been deleted, so they don't accumulate.
+- Registration: registered in `RegisterClientMetricsWithRegisterer()` (following the existing `sync.Once` registration pattern).
+
+### 2.2 Lifecycle (event-driven + close fallback)
+
+The owner is `segmentHandleImpl` (which holds `quorumInfo.Nodes` and the read/write state), driven by `logHandleImpl` at the writable-segment switch points. Within a segment's lifetime the **set and the clear each happen exactly once** (the node set is immutable), keeping the logic clean.
+
+- **Set (=1)**: when a segment handle becomes writable and its quorum is known — i.e. after `logHandleImpl.GetOrCreateWritableSegmentHandle` → `createNewSegmentMetaWithID` successfully obtains the quorum — call `WpActiveSegmentNode.WithLabelValues(logNs, logId, segId, node).Set(1)` for each node in `quorumInfo.Nodes`.
+- **Clear (Delete)**: when the segment leaves the writable state, call `DeleteLabelValues(...)` for each of its nodes, at:
+  - the Active→Completed completion path (the completion section in `segment_handle.go`, segment turns `Completed`);
+  - rolling / `NotifyWriterInvalidation` (the switch trigger point);
+  - **close fallback**: on `segmentHandleImpl` / `logHandleImpl` shutdown, uniformly clean up the active-segment series owned by this handle, so a missed path can't leave stale series behind.
+
+Implementation note: add two helpers on `segmentHandleImpl` (`setActiveSegmentNodeMetrics()` / `clearActiveSegmentNodeMetrics()`) that loop over `quorumInfo.Nodes`, called from the state-transition points and from close. Derive `log_ns` the same way the existing client metrics do (consistent with `WpSegmentHandlePendingAppendOps` etc.).
+
+> Trade-off note: compared with a "periodic reconcile" approach, event-driven is instantly accurate and needs no extra goroutine; the missed-delete risk is bounded by the close fallback plus "only two events per segment".
+
+## 3. Dashboard panels (client dashboard, both docker and k8s)
+
+Key differences between the two templates (which dictate how each panel is written):
+
+| | docker `dashboard_client.json` | k8s `dashboard_client_k8s.json` |
+|---|---|---|
+| datasource | `__DATASOURCE_UID__` | `${prometheus}` |
+| template vars | `log_ns` | `prometheus` / `cluster` / `namespace` / `log_ns` |
+| query label filter | `{log_ns=~"$log_ns"}` | `{cluster=~"$cluster", namespace=~"$namespace", log_ns=~"$log_ns"}` |
+
+Each new panel follows its own template's datasource and label conventions. Ready-made reference: the id-14 "Log Name → Log ID Mapping" table panel.
+
+### 3.1 Panel 1 — "Active Segment → Nodes (by Log)" (table)
+
+- Type `table`, target `format:"table"`, `instant:true`.
+- Query: `woodpecker_client_active_segment_node{log_ns=~"$log_ns"}` (the k8s version adds `cluster/namespace` filters).
+- `organize` transformation: hide `Time` / `__name__` / `instance` / `job` / `namespace` / `Value`; rename columns `log_id→Log ID`, `segment_id→Segment ID`, `node→Node`; sort by Log ID.
+- Effect: for the selected `log_ns`, list one row per (log, active segment, node) — i.e. "which nodes each log's active segment is currently writing to".
+
+### 3.2 Panel 2 — "Active Segments per Node" (aggregate timeseries)
+
+- Type `timeseries`.
+- Query: `count by (node) (woodpecker_client_active_segment_node{log_ns=~"$log_ns"})` (the k8s version adds `cluster/namespace`), `legendFormat: "{{node}}"`.
+- Effect: when a switch happens, the old node's line drops to 0 and the new node's line rises — the most direct way to confirm "everything has moved over".
+
+### 3.3 Common constraints
+
+- Each new panel gets a unique `id`; place `gridPos` at the end of each dashboard. **Do not add new template variables** (`dashboards_test.go` asserts on the template-variable set, so keep it unchanged).
+- The existing validation tests for both dashboards must keep passing:
+  - k8s: `tests/k8s/monitor/dashboards_test.go` (asserts valid JSON, no leftover `__DATASOURCE_UID__`, contains `${prometheus}`, and template vars include `prometheus/cluster/namespace/log_ns`). The new k8s panel must use the `${prometheus}` datasource and **must not** contain `__DATASOURCE_UID__`.
+  - docker: `tests/docker/monitor/monitor_test.go` must keep passing; docker panels keep the `__DATASOURCE_UID__` placeholder.
+
+## 4. Typical usage (switch verification)
+
+- Has the old node been drained: `count(woodpecker_client_active_segment_node{node="10.0.0.5:8000"})` → should be 0 after the switch; non-zero means some active segments haven't moved off.
+- Which logs haven't moved yet: `woodpecker_client_active_segment_node{node=~"<old nodes>"}` lists the `log_id`s directly.
+- Current global distribution: `count by (node) (woodpecker_client_active_segment_node)`.
+- Whether a switch happened: a change in `segment_id` for the same `log_id` marks one switch.
+- Which pool a node belongs to: inferred from the node name (or by cross-referencing the static pool config); this metric does not provide it directly.
+
+## 5. Files to change
+
+Code:
+
+1. `common/metrics/client_metrics.go` — add one `GaugeVec` `WpActiveSegmentNode` and register it in `RegisterClientMetricsWithRegisterer()`.
+2. `woodpecker/segment/segment_handle.go` — `setActiveSegmentNodeMetrics()` / `clearActiveSegmentNodeMetrics()` helpers; call the clear at Active→Completed, rolling / `NotifyWriterInvalidation`, and close.
+3. `woodpecker/log/log_handle.go` — trigger the set after `GetOrCreateWritableSegmentHandle` / `createNewSegmentMetaWithID` successfully obtains the quorum; clean up as a close fallback.
+
+Dashboard:
+
+4. `tests/docker/monitor/grafana/templates/dashboard_client.json` — add Panel 1/2 (`__DATASOURCE_UID__`, `log_ns` filter only).
+5. `tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json` — add Panel 1/2 (`${prometheus}`, `cluster/namespace/log_ns` filters).
+
+Tests:
+
+6. Keep `tests/k8s/monitor/dashboards_test.go` and `tests/docker/monitor/monitor_test.go` passing; optionally add assertions that the new metric name / new panel titles are present.
+
+## 6. To pin down during implementation
+
+- The exact `log_ns` derivation on the client side (aligned with how existing client metrics do it).
+- The precise choke-point lines for set/clear (pinned during implementation, ensuring full coverage of the rolling / invalidation / close exit paths).
+- The contents of `quorumInfo.Nodes` in cross-region / custom-placement scenarios (node endpoint format), so the `node` label matches the dashboard queries.

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/google/gops v0.3.28
 	github.com/google/uuid v1.6.0
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.8
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/memberlist v0.5.3
 	github.com/jonboulle/clockwork v0.2.2
@@ -90,7 +91,6 @@ require (
 	github.com/google/btree v1.1.2 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
-	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/meta/metadata_etcd.go
+++ b/meta/metadata_etcd.go
@@ -93,7 +93,7 @@ type metadataProviderEtcd struct {
 	sync.Mutex
 	client           *clientv3.Client
 	requestTimeout   time.Duration
-	metricsNamespace string // for metrics label
+	logNs            string // for metrics label
 	configuredPrefix string
 	effectivePrefix  string
 	keyBuilder       *KeyBuilder
@@ -116,7 +116,7 @@ func NewMetadataProvider(ctx context.Context, client *clientv3.Client, cfg *conf
 	return &metadataProviderEtcd{
 		client:           client,
 		requestTimeout:   timeoutDuration,
-		metricsNamespace: metrics.BuildMetricsNamespace(cfg.Minio.BucketName, cfg.Minio.RootPath),
+		logNs:            metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath),
 		configuredPrefix: configuredPrefix,
 		effectivePrefix:  effectivePrefix,
 		keyBuilder:       NewKeyBuilder(effectivePrefix),
@@ -216,8 +216,8 @@ func (e *metadataProviderEtcd) InitIfNecessary(ctx context.Context) error {
 	log := logger.Ctx(ctx)
 	resp, err := e.client.Txn(ctx1).If().Then(ops...).Commit()
 	if err != nil || !resp.Succeeded {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "init_if_necessary", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "init_if_necessary", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "init_if_necessary", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "init_if_necessary", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		log.Warn("init service metadata failed", zap.Error(err))
 		return werr.ErrMetadataRead.WithCauseErr(err)
 	}
@@ -237,8 +237,8 @@ func (e *metadataProviderEtcd) InitIfNecessary(ctx context.Context) error {
 				}
 				data, encodeErr := pb.Marshal(v)
 				if encodeErr != nil {
-					metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "init_if_necessary", "error").Inc()
-					metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "init_if_necessary", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+					metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "init_if_necessary", "error").Inc()
+					metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "init_if_necessary", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 					log.Warn("encode version failed", zap.Error(encodeErr))
 					return werr.ErrMetadataEncode.WithCauseErr(encodeErr)
 				}
@@ -257,8 +257,8 @@ func (e *metadataProviderEtcd) InitIfNecessary(ctx context.Context) error {
 	} else if len(initOps) != len(keys) {
 		// cluster already initialized partially, but not all
 		err = werr.ErrMetadataInit.WithCauseErrMsg("some keys already exists")
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "init_if_necessary", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "init_if_necessary", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "init_if_necessary", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "init_if_necessary", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		log.Warn("init operation failed, some keys already exists", zap.Error(err))
 		return err
 	}
@@ -268,16 +268,16 @@ func (e *metadataProviderEtcd) InitIfNecessary(ctx context.Context) error {
 	initResp, initErr := e.client.Txn(ctx2).If().Then(initOps...).Commit()
 	if initErr != nil || !initResp.Succeeded {
 		err = werr.ErrMetadataInit.WithCauseErr(initErr)
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "init_if_necessary", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "init_if_necessary", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "init_if_necessary", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "init_if_necessary", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		log.Warn("init operation failed", zap.Error(err))
 		return err
 	}
 	sp.AddEvent("InitServiceMetaCompleted", trace.WithAttributes(attribute.Int64("elapsedTime", time.Since(startTime).Milliseconds())))
 	// cluster initialized successfully
 	log.Info("cluster initialized successfully")
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "init_if_necessary", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "init_if_necessary", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "init_if_necessary", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "init_if_necessary", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -287,27 +287,27 @@ func (e *metadataProviderEtcd) GetVersionInfo(ctx context.Context) (*proto.Versi
 	defer cancel()
 	getResp, getErr := e.client.Get(ctx1, e.keyBuilder.VersionKey())
 	if getErr != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_version_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_version_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_version_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_version_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get version info failed", zap.Error(getErr))
 		return nil, werr.ErrMetadataRead.WithCauseErr(getErr)
 	}
 	if len(getResp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_version_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_version_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_version_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_version_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("version not found")
 		return nil, werr.ErrMetadataRead.WithCauseErrMsg("version not found")
 	}
 	expectedVersion := &proto.Version{}
 	decodedErr := pb.Unmarshal(getResp.Kvs[0].Value, expectedVersion)
 	if decodedErr != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_version_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_version_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_version_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_version_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("decode version info failed", zap.Error(decodedErr))
 		return nil, werr.ErrMetadataDecode.WithCauseErr(decodedErr)
 	}
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_version_info", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_version_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_version_info", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_version_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return expectedVersion, nil
 }
 
@@ -324,15 +324,15 @@ func (e *metadataProviderEtcd) CreateLog(ctx context.Context, logName string) er
 	resp, err := e.client.Get(ctx1, e.keyBuilder.LogIdGeneratorKey())
 	sp.AddEvent("GetIdGen", trace.WithAttributes(attribute.Int64("elapsedTime", time.Since(startTime).Milliseconds())))
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_log", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_log", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get log id generator failed", zap.Error(err))
 		return werr.ErrMetadataCreateLog.WithCauseErr(err)
 	}
 
 	if len(resp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_log", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_log", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("log id generator key not found", zap.String("key", e.keyBuilder.LogIdGeneratorKey()))
 		return werr.ErrMetadataCreateLog.WithCauseErrMsg(fmt.Sprintf("%s key not found", e.keyBuilder.LogIdGeneratorKey()))
 	}
@@ -341,14 +341,14 @@ func (e *metadataProviderEtcd) CreateLog(ctx context.Context, logName string) er
 	exists, err := e.CheckExists(ctx, logName)
 	sp.AddEvent("CheckExists", trace.WithAttributes(attribute.Int64("elapsedTime", time.Since(startTime).Milliseconds())))
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_log", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_log", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("check log exists failed", zap.Error(err))
 		return werr.ErrMetadataCreateLog.WithCauseErr(err)
 	}
 	if exists {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_log", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_log", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("log already exists", zap.String("logName", logName))
 		return werr.ErrMetadataCreateLogAlreadyExists.WithCauseErrMsg(fmt.Sprintf("%s already exists", logName))
 	}
@@ -357,8 +357,8 @@ func (e *metadataProviderEtcd) CreateLog(ctx context.Context, logName string) er
 	currentIdStr := string(resp.Kvs[0].Value)
 	currentID, err := atoi(currentIdStr)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_log", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_log", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("parse log id failed", zap.Error(err))
 		return werr.ErrMetadataCreateLog.WithCauseErr(err)
 	}
@@ -378,8 +378,8 @@ func (e *metadataProviderEtcd) CreateLog(ctx context.Context, logName string) er
 	// Serialize to binary
 	logMetaValue, err := pb.Marshal(logMeta)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_log", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_log", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("marshal log meta failed", zap.Error(err))
 		return werr.ErrMetadataCreateLog.WithCauseErr(err)
 	}
@@ -398,21 +398,21 @@ func (e *metadataProviderEtcd) CreateLog(ctx context.Context, logName string) er
 	).Commit()
 	sp.AddEvent("Committed", trace.WithAttributes(attribute.Int64("elapsedTime", time.Since(startTime).Milliseconds())))
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_log", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_log", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("create log transaction failed", zap.Error(err))
 		return werr.ErrMetadataCreateLog.WithCauseErr(err)
 	}
 
 	if !txnResp.Succeeded {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_log", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_log", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("create log transaction failed due to idgen mismatch")
 		return werr.ErrMetadataCreateLogTxn.WithCauseErrMsg("transaction failed due to idgen mismatch, please try again")
 	}
 	logger.Ctx(ctx).Info("log created successfully", zap.String("logName", logName), zap.Int64("logId", logMeta.LogId))
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_log", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_log", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_log", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_log", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -435,27 +435,27 @@ func (e *metadataProviderEtcd) GetLogMeta(ctx context.Context, logName string) (
 	defer cancel()
 	logResp, err := e.client.Get(ctx1, e.keyBuilder.BuildLogKey(logName))
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_log_meta", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_log_meta", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get log meta failed", zap.Error(err))
 		return nil, werr.ErrMetadataRead.WithCauseErr(err)
 	}
 	if len(logResp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_log_meta", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_log_meta", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("log not found", zap.String("logName", logName))
 		return nil, werr.ErrMetadataRead.WithCauseErrMsg(fmt.Sprintf("log not found: %s", logName))
 	}
 	revision := logResp.Kvs[0].ModRevision
 	logMeta := &proto.LogMeta{}
 	if err = pb.Unmarshal(logResp.Kvs[0].Value, logMeta); err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_log_meta", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_log_meta", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("unmarshal log meta failed", zap.Error(err))
 		return nil, werr.ErrMetadataDecode.WithCauseErr(err)
 	}
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_log_meta", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_log_meta", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_log_meta", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_log_meta", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return &LogMeta{
 		Metadata: logMeta,
 		Revision: revision,
@@ -469,8 +469,8 @@ func (e *metadataProviderEtcd) UpdateLogMeta(ctx context.Context, logName string
 	logKey := e.keyBuilder.BuildLogKey(logName)
 	logMetaValue, err := pb.Marshal(logMeta.Metadata)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_log_meta", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_log_meta", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("marshal log meta failed", zap.Error(err))
 		return werr.ErrMetadataEncode.WithCauseErr(err)
 	}
@@ -489,21 +489,21 @@ func (e *metadataProviderEtcd) UpdateLogMeta(ctx context.Context, logName string
 		clientv3.OpPut(logKey, string(logMetaValue)),
 	).Commit()
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_log_meta", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_log_meta", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("update log meta transaction failed", zap.Error(err))
 		return werr.ErrMetadataRead.WithCauseErr(err)
 	}
 
 	if !txnResp.Succeeded {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_log_meta", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_log_meta", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_log_meta", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("log metadata revision is invalid or outdated", zap.String("logName", logName))
 		return werr.ErrMetadataRevisionInvalid.WithCauseErrMsg(fmt.Sprintf("log metadata revision is invalid or outdated: %s", logName))
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_log_meta", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_log_meta", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_log_meta", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_log_meta", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -518,8 +518,8 @@ func (e *metadataProviderEtcd) OpenLog(ctx context.Context, logName string) (*Lo
 	logMeta, err := e.GetLogMeta(ctx1, logName)
 	sp.AddEvent("GetLogMeta", trace.WithAttributes(attribute.Int64("elapsedTime", time.Since(startTime).Milliseconds())))
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "open_log", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "open_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "open_log", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "open_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		return nil, nil, err
 	}
 
@@ -527,14 +527,14 @@ func (e *metadataProviderEtcd) OpenLog(ctx context.Context, logName string) (*Lo
 	segmentMetaList, err := e.GetAllSegmentMetadata(ctx, logName)
 	sp.AddEvent("GetAllSegmentMetadata", trace.WithAttributes(attribute.Int64("elapsedTime", time.Since(startTime).Milliseconds())))
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "open_log", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "open_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "open_log", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "open_log", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		return nil, nil, err
 	}
 
 	logger.Ctx(ctx).Info("log opened successfully", zap.String("logName", logName), zap.Int64("logId", logMeta.Metadata.LogId))
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "open_log", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "open_log", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "open_log", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "open_log", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return logMeta, segmentMetaList, nil
 }
 
@@ -547,13 +547,13 @@ func (e *metadataProviderEtcd) CheckExists(ctx context.Context, logName string) 
 	// Get log meta for the path = logs/<logName>
 	logResp, err := e.client.Get(ctx1, e.keyBuilder.BuildLogKey(logName))
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "check_exists", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "check_exists", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "check_exists", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "check_exists", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("check log exists failed", zap.Error(err))
 		return false, werr.ErrMetadataRead.WithCauseErr(err)
 	}
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "check_exists", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "check_exists", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "check_exists", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "check_exists", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	if len(logResp.Kvs) == 0 {
 		return false, nil
 	}
@@ -569,12 +569,12 @@ func (e *metadataProviderEtcd) ListLogs(ctx context.Context) ([]string, error) {
 	defer cancel()
 	list, err := e.ListLogsWithPrefix(ctx1, "")
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "ListLogs", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "ListLogs", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "ListLogs", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "ListLogs", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		return nil, err
 	}
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "ListLogs", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "ListLogs", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "ListLogs", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "ListLogs", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return list, err
 }
 
@@ -586,22 +586,22 @@ func (e *metadataProviderEtcd) ListLogsWithPrefix(ctx context.Context, logNamePr
 	defer cancel()
 	logResp, err := e.client.Get(ctx1, e.keyBuilder.BuildLogKey(logNamePrefix), clientv3.WithPrefix())
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "list_logs_with_prefix", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "list_logs_with_prefix", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "list_logs_with_prefix", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "list_logs_with_prefix", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("list logs with prefix failed", zap.Error(err))
 		return nil, werr.ErrMetadataRead.WithCauseErr(err)
 	}
 	if len(logResp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "list_logs_with_prefix", "success").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "list_logs_with_prefix", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "list_logs_with_prefix", "success").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "list_logs_with_prefix", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 		return []string{}, nil
 	}
 	logs := make(map[string]int)
 	for _, path := range logResp.Kvs {
 		logName, extractErr := e.extractLogName(string(path.Key))
 		if extractErr != nil {
-			metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "list_logs_with_prefix", "error").Inc()
-			metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "list_logs_with_prefix", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+			metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "list_logs_with_prefix", "error").Inc()
+			metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "list_logs_with_prefix", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 			logger.Ctx(ctx).Warn("extract log name failed", zap.Error(extractErr))
 			return nil, werr.ErrMetadataRead.WithCauseErr(extractErr)
 		}
@@ -611,8 +611,8 @@ func (e *metadataProviderEtcd) ListLogsWithPrefix(ctx context.Context, logNamePr
 	for logName := range logs {
 		logNames = append(logNames, logName)
 	}
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "list_logs_with_prefix", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "list_logs_with_prefix", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "list_logs_with_prefix", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "list_logs_with_prefix", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return logNames, nil
 }
 
@@ -654,8 +654,8 @@ func (e *metadataProviderEtcd) AcquireLogWriterLock(ctx context.Context, logName
 			err := existingLock.mutex.TryLock(ctx1)
 			if err == nil {
 				// Lock is still valid and can be acquired, return it
-				metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "acquire_log_writer_lock", "success").Inc()
-				metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "acquire_log_writer_lock", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+				metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "acquire_log_writer_lock", "success").Inc()
+				metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "acquire_log_writer_lock", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 				return existingLock, nil
 			}
 			// TryLock failed, mark as invalid and create new
@@ -677,8 +677,8 @@ func (e *metadataProviderEtcd) AcquireLogWriterLock(ctx context.Context, logName
 	// Create a new session specifically for this lock with TTL
 	newSession, err := concurrency.NewSession(e.client, concurrency.WithTTL(15))
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "acquire_log_writer_lock", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "acquire_log_writer_lock", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "acquire_log_writer_lock", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "acquire_log_writer_lock", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		return nil, fmt.Errorf("failed to create session for lock: %w", err)
 	}
 
@@ -691,8 +691,8 @@ func (e *metadataProviderEtcd) AcquireLogWriterLock(ctx context.Context, logName
 	if err != nil {
 		// If we can't acquire the lock, clean up the session
 		_ = newSession.Close()
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "acquire_log_writer_lock", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "acquire_log_writer_lock", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "acquire_log_writer_lock", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "acquire_log_writer_lock", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		return nil, fmt.Errorf("failed to acquire lock: %w", err)
 	}
 
@@ -704,8 +704,8 @@ func (e *metadataProviderEtcd) AcquireLogWriterLock(ctx context.Context, logName
 	sessionLock.valid.Store(true)
 	e.logWriterLocks.Store(logName, sessionLock)
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "acquire_log_writer_lock", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "acquire_log_writer_lock", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "acquire_log_writer_lock", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "acquire_log_writer_lock", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return sessionLock, nil
 }
 
@@ -720,8 +720,8 @@ func (e *metadataProviderEtcd) ReleaseLogWriterLock(ctx context.Context, logName
 	// Load and delete atomically using sync.Map
 	lockValue, exists := e.logWriterLocks.LoadAndDelete(logName)
 	if !exists {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "release_log_writer_lock", "success").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "release_log_writer_lock", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "release_log_writer_lock", "success").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "release_log_writer_lock", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 		return nil
 	}
 
@@ -730,8 +730,8 @@ func (e *metadataProviderEtcd) ReleaseLogWriterLock(ctx context.Context, logName
 	// First unlock the mutex
 	err := sessionLock.mutex.Unlock(ctx1)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "release_log_writer_lock", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "release_log_writer_lock", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "release_log_writer_lock", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "release_log_writer_lock", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("Failed to unlock writer lock", zap.String("logName", logName), zap.Error(err))
 	}
 
@@ -739,14 +739,14 @@ func (e *metadataProviderEtcd) ReleaseLogWriterLock(ctx context.Context, logName
 	if sessionLock.session != nil {
 		closeErr := sessionLock.session.Close()
 		if closeErr != nil {
-			metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "release_log_writer_lock", "error").Inc()
-			metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "release_log_writer_lock", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+			metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "release_log_writer_lock", "error").Inc()
+			metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "release_log_writer_lock", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 			logger.Ctx(ctx).Warn("Failed to close lock session", zap.String("logName", logName), zap.Error(closeErr))
 		}
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "release_log_writer_lock", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "release_log_writer_lock", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "release_log_writer_lock", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "release_log_writer_lock", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -759,8 +759,8 @@ func (e *metadataProviderEtcd) StoreSegmentMetadata(ctx context.Context, logName
 	segmentKey := e.keyBuilder.BuildSegmentInstanceKey(logName, fmt.Sprintf("%d", segmentMeta.Metadata.GetSegNo()))
 	segmentMetadata, err := pb.Marshal(segmentMeta.Metadata)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("marshal segment metadata failed", zap.Error(err))
 		return werr.ErrMetadataEncode.WithCauseErr(err)
 	}
@@ -778,26 +778,26 @@ func (e *metadataProviderEtcd) StoreSegmentMetadata(ctx context.Context, logName
 		clientv3.OpPut(segmentKey, string(segmentMetadata)),
 	).Commit()
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("store segment metadata transaction failed", zap.Error(err))
 		return werr.ErrMetadataCreateSegment.WithCauseErr(err)
 	}
 
 	if !txnResp.Succeeded {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("segment metadata already exists", zap.String("logName", logName), zap.Int64("segmentId", segmentMeta.Metadata.GetSegNo()))
 		return werr.ErrMetadataSegmentAlreadyExists.WithCauseErrMsg(
 			fmt.Sprintf("segment metadata already exists for logName:%s segmentId:%d", logName, segmentMeta.Metadata.GetSegNo()))
 	}
 	// update revision
 	segmentMeta.Revision = txnResp.Header.Revision
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_segment_metadata", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_segment_metadata", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	// Update segment state metric: new segment created
 	logIdStr := strconv.FormatInt(logId, 10)
-	metrics.WpClientSegmentState.WithLabelValues(e.metricsNamespace, logIdStr, segmentMeta.Metadata.State.String()).Inc()
+	metrics.WpClientSegmentState.WithLabelValues(e.logNs, logIdStr, segmentMeta.Metadata.State.String()).Inc()
 	return nil
 }
 
@@ -810,8 +810,8 @@ func (e *metadataProviderEtcd) UpdateSegmentMetadata(ctx context.Context, logNam
 	segmentKey := e.keyBuilder.BuildSegmentInstanceKey(logName, fmt.Sprintf("%d", segmentMeta.Metadata.GetSegNo()))
 	segmentMetadata, err := pb.Marshal(segmentMeta.Metadata)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("marshal segment metadata failed", zap.Error(err))
 		return werr.ErrMetadataEncode.WithCauseErr(err)
 	}
@@ -829,26 +829,26 @@ func (e *metadataProviderEtcd) UpdateSegmentMetadata(ctx context.Context, logNam
 		clientv3.OpPut(segmentKey, string(segmentMetadata)),
 	).Commit()
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("update segment metadata transaction failed", zap.Error(err))
 		return err
 	}
 
 	if !txnResp.Succeeded {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("segment metadata revision is invalid or outdated", zap.String("logName", logName), zap.Int64("segmentId", segmentMeta.Metadata.GetSegNo()))
 		return werr.ErrMetadataRevisionInvalid.WithCauseErrMsg(
 			fmt.Sprintf("segment metadata revision is invalid or outdated for logName:%s segmentId:%d", logName, segmentMeta.Metadata.GetSegNo()))
 	}
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_segment_metadata", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_segment_metadata", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	// Update segment state metric if state changed
 	newState := segmentMeta.Metadata.State
 	if oldState != newState {
 		logIdStr := strconv.FormatInt(logId, 10)
-		metrics.UpdateSegmentState(e.metricsNamespace, logIdStr, oldState.String(), newState.String())
+		metrics.UpdateSegmentState(e.logNs, logIdStr, oldState.String(), newState.String())
 	}
 	return nil
 }
@@ -862,28 +862,28 @@ func (e *metadataProviderEtcd) GetSegmentMetadata(ctx context.Context, logName s
 	defer cancel()
 	getResp, getErr := e.client.Get(ctx1, segmentKey)
 	if getErr != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get segment metadata failed", zap.Error(getErr))
 		return nil, getErr
 	}
 	if len(getResp.Kvs) == 0 {
 		logger.Ctx(ctx).Warn("segment meta not found", zap.String("logName", logName), zap.Int64("segmentId", segmentId))
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		return nil, werr.ErrSegmentNotFound.WithCauseErrMsg(
 			fmt.Sprintf("segment meta not found for log:%s segment:%d", logName, segmentId))
 	}
 	revision := getResp.Kvs[0].ModRevision
 	segmentMetadata := &proto.SegmentMetadata{}
 	if err := pb.Unmarshal(getResp.Kvs[0].Value, segmentMetadata); err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("unmarshal segment metadata failed", zap.Error(err))
 		return nil, werr.ErrMetadataDecode.WithCauseErr(err)
 	}
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_segment_metadata", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_segment_metadata", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return &SegmentMeta{
 		Metadata: segmentMetadata,
 		Revision: revision,
@@ -899,16 +899,16 @@ func (e *metadataProviderEtcd) GetAllSegmentMetadata(ctx context.Context, logNam
 	defer cancel()
 	getResp, getErr := e.client.Get(ctx1, segmentKey, clientv3.WithPrefix())
 	if getErr != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_all_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_all_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_all_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_all_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get all segment metadata failed", zap.Error(getErr))
 		return nil, getErr
 	}
 
 	segmentMetaMap := make(map[int64]*SegmentMeta)
 	if len(getResp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_all_segment_metadata", "success").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_all_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_all_segment_metadata", "success").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_all_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 		return segmentMetaMap, nil
 	}
 
@@ -916,8 +916,8 @@ func (e *metadataProviderEtcd) GetAllSegmentMetadata(ctx context.Context, logNam
 	for _, kv := range getResp.Kvs {
 		metadata := &proto.SegmentMetadata{}
 		if err := pb.Unmarshal(kv.Value, metadata); err != nil {
-			metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_all_segment_metadata", "error").Inc()
-			metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_all_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+			metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_all_segment_metadata", "error").Inc()
+			metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_all_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 			logger.Ctx(ctx).Warn("unmarshal segment metadata failed", zap.Error(err))
 			return nil, werr.ErrMetadataDecode.WithCauseErr(err)
 		}
@@ -929,8 +929,8 @@ func (e *metadataProviderEtcd) GetAllSegmentMetadata(ctx context.Context, logNam
 		segIds = append(segIds, metadata.SegNo)
 	}
 	logger.Ctx(ctx).Debug("GetAllSegmentMetadata", zap.String("logName", logName), zap.Int("segmentCount", len(segmentMetaMap)), zap.Int64s("segmentIds", segIds))
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_all_segment_metadata", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_all_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_all_segment_metadata", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_all_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return segmentMetaMap, nil
 }
 
@@ -942,13 +942,13 @@ func (e *metadataProviderEtcd) CheckSegmentExists(ctx context.Context, logName s
 	defer cancel()
 	segmentResp, err := e.client.Get(ctx1, e.keyBuilder.BuildSegmentInstanceKey(logName, fmt.Sprintf("%d", segmentId)))
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "check_segment_exists", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "check_segment_exists", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "check_segment_exists", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "check_segment_exists", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("check segment exists failed", zap.Error(err))
 		return false, err
 	}
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "check_segment_exists", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "check_segment_exists", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "check_segment_exists", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "check_segment_exists", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	if len(segmentResp.Kvs) == 0 {
 		return false, nil
 	}
@@ -979,15 +979,15 @@ func (e *metadataProviderEtcd) DeleteSegmentMetadata(ctx context.Context, logNam
 		clientv3.OpDelete(segmentKey),
 	).Commit()
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "delete_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "delete_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "delete_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "delete_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("delete segment metadata transaction failed", zap.Error(err))
 		return werr.ErrMetadataWrite.WithCauseErr(err)
 	}
 
 	if !txnResp.Succeeded {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "delete_segment_metadata", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "delete_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "delete_segment_metadata", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "delete_segment_metadata", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("segment not found for deletion", zap.String("logName", logName), zap.Int64("segmentId", segmentId))
 		return werr.ErrSegmentNotFound.WithCauseErrMsg(
 			fmt.Sprintf("segment not found for logName:%s segmentId:%d", logName, segmentId))
@@ -997,11 +997,11 @@ func (e *metadataProviderEtcd) DeleteSegmentMetadata(ctx context.Context, logNam
 		zap.String("logName", logName),
 		zap.Int64("segmentId", segmentId))
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "delete_segment_metadata", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "delete_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "delete_segment_metadata", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "delete_segment_metadata", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	// Update segment state metric: decrement old state count
 	logIdStr := strconv.FormatInt(logId, 10)
-	metrics.WpClientSegmentState.WithLabelValues(e.metricsNamespace, logIdStr, oldState.String()).Dec()
+	metrics.WpClientSegmentState.WithLabelValues(e.logNs, logIdStr, oldState.String()).Dec()
 	return nil
 }
 
@@ -1012,8 +1012,8 @@ func (e *metadataProviderEtcd) StoreQuorumInfo(ctx context.Context, info *proto.
 	quorumKey := e.keyBuilder.BuildQuorumInfoKey(fmt.Sprintf("%d", info.Id))
 	quorumInfoValue, err := pb.Marshal(info)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_quorum_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_quorum_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("marshal quorum info failed", zap.Error(err))
 		return werr.ErrMetadataEncode.WithCauseErr(err)
 	}
@@ -1031,22 +1031,22 @@ func (e *metadataProviderEtcd) StoreQuorumInfo(ctx context.Context, info *proto.
 		clientv3.OpPut(quorumKey, string(quorumInfoValue)),
 	).Commit()
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_quorum_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_quorum_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("store quorum info transaction failed", zap.Error(err))
 		return werr.ErrMetadataUpdateQuorum.WithCauseErr(err)
 	}
 
 	if !txnResp.Succeeded {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_quorum_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_quorum_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("quorum info already exists", zap.Int64("quorumId", info.Id))
 		return werr.ErrMetadataUpdateQuorum.WithCauseErrMsg(
 			fmt.Sprintf("quorum info already exists for id:%d", info.Id))
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_quorum_info", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_quorum_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_quorum_info", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_quorum_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1059,27 +1059,27 @@ func (e *metadataProviderEtcd) GetQuorumInfo(ctx context.Context, quorumId int64
 	defer cancel()
 	getResp, getErr := e.client.Get(ctx1, quorumKey)
 	if getErr != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_quorum_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_quorum_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get quorum info failed", zap.Error(getErr))
 		return nil, werr.ErrMetadataRead.WithCauseErr(getErr)
 	}
 	if len(getResp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_quorum_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_quorum_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("quorum info not found", zap.Int64("quorumId", quorumId))
 		return nil, werr.ErrMetadataRead.WithCauseErrMsg(fmt.Sprintf("quorum info not found for id:%d", quorumId))
 	}
 
 	quorumInfo := &proto.QuorumInfo{}
 	if err := pb.Unmarshal(getResp.Kvs[0].Value, quorumInfo); err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_quorum_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_quorum_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_quorum_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("unmarshal quorum info failed", zap.Error(err))
 		return nil, werr.ErrMetadataDecode.WithCauseErr(err)
 	}
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_quorum_info", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_quorum_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_quorum_info", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_quorum_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return quorumInfo, nil
 }
 
@@ -1106,8 +1106,8 @@ func (e *metadataProviderEtcd) CreateReaderTempInfo(ctx context.Context, readerN
 	// Serialize to binary
 	readerInfoValue, err := pb.Marshal(readerInfo)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("marshal reader temp info failed", zap.Error(err))
 		return werr.ErrMetadataEncode.WithCauseErr(err)
 	}
@@ -1117,8 +1117,8 @@ func (e *metadataProviderEtcd) CreateReaderTempInfo(ctx context.Context, readerN
 	// Create a lease with TTL of 60 seconds
 	lease, err := e.client.Grant(ctx1, 60)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("grant lease failed", zap.Error(err))
 		return werr.ErrMetadataWrite.WithCauseErr(err)
 	}
@@ -1126,8 +1126,8 @@ func (e *metadataProviderEtcd) CreateReaderTempInfo(ctx context.Context, readerN
 	// Put reader info in etcd with the lease
 	_, err = e.client.Put(ctx1, readerKey, string(readerInfoValue), clientv3.WithLease(lease.ID))
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("put reader temp info failed", zap.Error(err))
 		return werr.ErrMetadataWrite.WithCauseErr(err)
 	}
@@ -1140,8 +1140,8 @@ func (e *metadataProviderEtcd) CreateReaderTempInfo(ctx context.Context, readerN
 		zap.Int64("leaseTTL", 60),
 		zap.Int64("leaseID", int64(lease.ID)))
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_reader_temp_info", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_reader_temp_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_reader_temp_info", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_reader_temp_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1157,16 +1157,16 @@ func (e *metadataProviderEtcd) GetReaderTempInfo(ctx context.Context, logId int6
 	// Get reader info from etcd
 	resp, err := e.client.Get(ctx1, readerKey)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get reader temp info failed", zap.Error(err))
 		return nil, werr.ErrMetadataRead.WithCauseErr(err)
 	}
 
 	// Check if reader info exists
 	if len(resp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("reader temp info not found", zap.Int64("logId", logId), zap.String("readerName", readerName))
 		return nil, werr.ErrMetadataRead.WithCauseErrMsg(fmt.Sprintf("reader temp info not found for logId:%d readerName:%s", logId, readerName))
 	}
@@ -1174,14 +1174,14 @@ func (e *metadataProviderEtcd) GetReaderTempInfo(ctx context.Context, logId int6
 	// Decode reader info
 	readerInfo := &proto.ReaderTempInfo{}
 	if err := pb.Unmarshal(resp.Kvs[0].Value, readerInfo); err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("unmarshal reader temp info failed", zap.Error(err))
 		return nil, werr.ErrMetadataDecode.WithCauseErr(err)
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_reader_temp_info", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_reader_temp_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_reader_temp_info", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_reader_temp_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return readerInfo, nil
 }
 
@@ -1198,8 +1198,8 @@ func (e *metadataProviderEtcd) GetAllReaderTempInfoForLog(ctx context.Context, l
 	// Get all reader infos with this prefix
 	resp, err := e.client.Get(ctx1, readerPrefix, clientv3.WithPrefix())
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_all_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_all_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_all_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_all_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get all reader temp info failed", zap.Error(err))
 		return nil, werr.ErrMetadataRead.WithCauseErr(err)
 	}
@@ -1219,8 +1219,8 @@ func (e *metadataProviderEtcd) GetAllReaderTempInfoForLog(ctx context.Context, l
 		readers = append(readers, readerInfo)
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_all_reader_temp_info", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_all_reader_temp_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_all_reader_temp_info", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_all_reader_temp_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return readers, nil
 }
 
@@ -1237,14 +1237,14 @@ func (e *metadataProviderEtcd) UpdateReaderTempInfo(ctx context.Context, logId i
 	// Get the current reader info
 	resp, err := e.client.Get(ctx1, readerKey)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get reader temp info failed", zap.Error(err))
 		return werr.ErrMetadataRead.WithCauseErr(err)
 	}
 	if len(resp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("reader temp info not found", zap.Int64("logId", logId), zap.String("readerName", readerName))
 		return werr.ErrMetadataRead.WithCauseErrMsg(fmt.Sprintf("reader temp info not found for logId:%d readerName:%s", logId, readerName))
 	}
@@ -1252,8 +1252,8 @@ func (e *metadataProviderEtcd) UpdateReaderTempInfo(ctx context.Context, logId i
 	// Decode reader info
 	readerInfo := &proto.ReaderTempInfo{}
 	if err := pb.Unmarshal(resp.Kvs[0].Value, readerInfo); err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("unmarshal reader temp info failed", zap.Error(err))
 		return werr.ErrMetadataDecode.WithCauseErr(err)
 	}
@@ -1266,8 +1266,8 @@ func (e *metadataProviderEtcd) UpdateReaderTempInfo(ctx context.Context, logId i
 	// Marshal the updated reader info
 	bytes, err := pb.Marshal(readerInfo)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("marshal reader temp info failed", zap.Error(err))
 		return werr.ErrMetadataEncode.WithCauseErr(err)
 	}
@@ -1284,8 +1284,8 @@ func (e *metadataProviderEtcd) UpdateReaderTempInfo(ctx context.Context, logId i
 	}
 
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("update reader temp info failed", zap.Error(err))
 		return werr.ErrMetadataWrite.WithCauseErr(err)
 	}
@@ -1296,8 +1296,8 @@ func (e *metadataProviderEtcd) UpdateReaderTempInfo(ctx context.Context, logId i
 		zap.Int64("recentReadSegmentId", recentReadSegmentId),
 		zap.Int64("recentReadEntryId", recentReadEntryId))
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_reader_temp_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_reader_temp_info", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_reader_temp_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1314,8 +1314,8 @@ func (e *metadataProviderEtcd) DeleteReaderTempInfo(ctx context.Context, logId i
 	// Delete the reader information
 	resp, err := e.client.Delete(ctx1, readerKey)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "delete_reader_temp_info", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "delete_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "delete_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "delete_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("delete reader temp info failed", zap.Error(err))
 		return werr.ErrMetadataWrite.WithCauseErr(err)
 	}
@@ -1332,8 +1332,8 @@ func (e *metadataProviderEtcd) DeleteReaderTempInfo(ctx context.Context, logId i
 			zap.Int64("logId", logId))
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "delete_reader_temp_info", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "delete_reader_temp_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "delete_reader_temp_info", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "delete_reader_temp_info", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1395,8 +1395,8 @@ func (e *metadataProviderEtcd) Close() error {
 		return true
 	})
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "close", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "close", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "close", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "close", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1408,8 +1408,8 @@ func (e *metadataProviderEtcd) CreateSegmentCleanupStatus(ctx context.Context, s
 	key := e.keyBuilder.BuildSegmentCleanupStatusKey(status.LogId, status.SegmentId)
 	bytes, err := proto.MarshalSegmentCleanupStatus(status)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_segment_cleanup_status", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_segment_cleanup_status", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("marshal segment cleanup status failed", zap.Error(err))
 		return fmt.Errorf("failed to marshal segment cleanup status: %w", err)
 	}
@@ -1425,21 +1425,21 @@ func (e *metadataProviderEtcd) CreateSegmentCleanupStatus(ctx context.Context, s
 
 	resp, err := txn.If(cmp).Then(put).Commit()
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_segment_cleanup_status", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_segment_cleanup_status", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("create segment cleanup status transaction failed", zap.Error(err))
 		return fmt.Errorf("failed to create segment cleanup status: %w", err)
 	}
 
 	if !resp.Succeeded {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_segment_cleanup_status", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_segment_cleanup_status", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("segment cleanup status already exists", zap.String("key", key))
 		return fmt.Errorf("segment cleanup status already exists: %s", key)
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "create_segment_cleanup_status", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "create_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_segment_cleanup_status", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1451,8 +1451,8 @@ func (e *metadataProviderEtcd) UpdateSegmentCleanupStatus(ctx context.Context, s
 	key := e.keyBuilder.BuildSegmentCleanupStatusKey(status.LogId, status.SegmentId)
 	bytes, err := proto.MarshalSegmentCleanupStatus(status)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_segment_cleanup_status", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_segment_cleanup_status", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("marshal segment cleanup status failed", zap.Error(err))
 		return fmt.Errorf("failed to marshal segment cleanup status: %w", err)
 	}
@@ -1468,21 +1468,21 @@ func (e *metadataProviderEtcd) UpdateSegmentCleanupStatus(ctx context.Context, s
 
 	resp, err := txn.If(cmp).Then(put).Commit()
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_segment_cleanup_status", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_segment_cleanup_status", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("update segment cleanup status transaction failed", zap.Error(err))
 		return fmt.Errorf("failed to update segment cleanup status: %w", err)
 	}
 
 	if !resp.Succeeded {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_segment_cleanup_status", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_segment_cleanup_status", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("segment cleanup status does not exist", zap.String("key", key))
 		return fmt.Errorf("segment cleanup status does not exist: %s", key)
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "update_segment_cleanup_status", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "update_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "update_segment_cleanup_status", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "update_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1497,29 +1497,29 @@ func (e *metadataProviderEtcd) GetSegmentCleanupStatus(ctx context.Context, logI
 	defer cancel()
 	resp, err := e.client.Get(ctx1, key)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_segment_cleanup_status", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_segment_cleanup_status", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get segment cleanup status failed", zap.Error(err))
 		return nil, fmt.Errorf("failed to get segment cleanup status: %w", err)
 	}
 
 	if len(resp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_segment_cleanup_status", "success").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_segment_cleanup_status", "success").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 		return nil, nil
 	}
 
 	status := &proto.SegmentCleanupStatus{}
 	err = proto.UnmarshalSegmentCleanupStatus(resp.Kvs[0].Value, status)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_segment_cleanup_status", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_segment_cleanup_status", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("unmarshal segment cleanup status failed", zap.Error(err))
 		return nil, fmt.Errorf("failed to unmarshal segment cleanup status: %w", err)
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_segment_cleanup_status", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_segment_cleanup_status", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return status, nil
 }
 
@@ -1534,14 +1534,14 @@ func (e *metadataProviderEtcd) DeleteSegmentCleanupStatus(ctx context.Context, l
 	defer cancel()
 	_, err := e.client.Delete(ctx1, key)
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "delete_segment_cleanup_status", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "delete_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "delete_segment_cleanup_status", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "delete_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("delete segment cleanup status failed", zap.Error(err))
 		return fmt.Errorf("failed to delete segment cleanup status: %w", err)
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "delete_segment_cleanup_status", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "delete_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "delete_segment_cleanup_status", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "delete_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1557,15 +1557,15 @@ func (e *metadataProviderEtcd) ListSegmentCleanupStatus(ctx context.Context, log
 	defer cancel()
 	resp, err := e.client.Get(ctx1, prefix, clientv3.WithPrefix())
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "list_segment_cleanup_status", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "list_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "list_segment_cleanup_status", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "list_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("list segment cleanup statuses failed", zap.Error(err))
 		return nil, fmt.Errorf("failed to list segment cleanup statuses: %w", err)
 	}
 
 	if len(resp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "list_segment_cleanup_status", "success").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "list_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "list_segment_cleanup_status", "success").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "list_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 		return []*proto.SegmentCleanupStatus{}, nil
 	}
 
@@ -1574,16 +1574,16 @@ func (e *metadataProviderEtcd) ListSegmentCleanupStatus(ctx context.Context, log
 		status := &proto.SegmentCleanupStatus{}
 		err = proto.UnmarshalSegmentCleanupStatus(kv.Value, status)
 		if err != nil {
-			metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "list_segment_cleanup_status", "error").Inc()
-			metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "list_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+			metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "list_segment_cleanup_status", "error").Inc()
+			metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "list_segment_cleanup_status", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 			logger.Ctx(ctx).Warn("unmarshal segment cleanup status failed", zap.Error(err))
 			return nil, fmt.Errorf("failed to unmarshal segment cleanup status: %w", err)
 		}
 		statuses = append(statuses, status)
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "list_segment_cleanup_status", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "list_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "list_segment_cleanup_status", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "list_segment_cleanup_status", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return statuses, nil
 }
 
@@ -1619,24 +1619,24 @@ func (e *metadataProviderEtcd) StoreOrGetConditionWriteResult(ctx context.Contex
 		clientv3.OpGet(e.keyBuilder.ConditionWriteKey()),
 	).Commit()
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_or_get_condition_write", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_or_get_condition_write", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_or_get_condition_write", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_or_get_condition_write", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("store or get condition write result failed", zap.Error(err))
 		return false, werr.ErrMetadataWrite.WithCauseErr(err)
 	}
 
 	if txnResp.Succeeded {
 		// We successfully stored our value, return it
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_or_get_condition_write", "success").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_or_get_condition_write", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_or_get_condition_write", "success").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_or_get_condition_write", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Info("stored condition write result as first node", zap.Bool("detected", detected))
 		return detected, nil
 	}
 
 	// Key already exists, parse the existing value from Else operation
 	if len(txnResp.Responses) == 0 || len(txnResp.Responses[0].GetResponseRange().Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_or_get_condition_write", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_or_get_condition_write", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_or_get_condition_write", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_or_get_condition_write", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("condition write key exists but failed to retrieve value")
 		return false, werr.ErrMetadataRead.WithCauseErrMsg("condition write key exists but no value retrieved")
 	}
@@ -1644,8 +1644,8 @@ func (e *metadataProviderEtcd) StoreOrGetConditionWriteResult(ctx context.Contex
 	existingValue := string(txnResp.Responses[0].GetResponseRange().Kvs[0].Value)
 	result := existingValue == "true"
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_or_get_condition_write", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_or_get_condition_write", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_or_get_condition_write", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_or_get_condition_write", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	logger.Ctx(ctx).Info("retrieved existing condition write result from another node",
 		zap.Bool("ourDetection", detected),
 		zap.Bool("agreedResult", result))
@@ -1668,14 +1668,14 @@ func (e *metadataProviderEtcd) StoreConditionWriteEnabled(ctx context.Context) e
 
 	_, err := e.client.Put(ctx1, e.keyBuilder.ConditionWriteKey(), "true")
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_condition_write_enabled", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_condition_write_enabled", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_condition_write_enabled", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_condition_write_enabled", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("store condition write enabled result failed", zap.Error(err))
 		return werr.ErrMetadataWrite.WithCauseErr(err)
 	}
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "store_condition_write_enabled", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "store_condition_write_enabled", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "store_condition_write_enabled", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "store_condition_write_enabled", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	logger.Ctx(ctx).Info("stored condition write result as enabled")
 	return nil
 }
@@ -1694,16 +1694,16 @@ func (e *metadataProviderEtcd) GetConditionWriteResult(ctx context.Context) (boo
 	// Get the condition write key from etcd
 	resp, err := e.client.Get(ctx1, e.keyBuilder.ConditionWriteKey())
 	if err != nil {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_condition_write", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_condition_write", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_condition_write", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_condition_write", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("get condition write result failed", zap.Error(err))
 		return false, werr.ErrMetadataRead.WithCauseErr(err)
 	}
 
 	// Check if key exists
 	if len(resp.Kvs) == 0 {
-		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_condition_write", "error").Inc()
-		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_condition_write", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_condition_write", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_condition_write", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Warn("condition write key does not exist")
 		return false, werr.ErrMetadataKeyNotExists
 	}
@@ -1712,8 +1712,8 @@ func (e *metadataProviderEtcd) GetConditionWriteResult(ctx context.Context) (boo
 	value := string(resp.Kvs[0].Value)
 	result := value == "true"
 
-	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.metricsNamespace, "get_condition_write", "success").Inc()
-	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.metricsNamespace, "get_condition_write", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "get_condition_write", "success").Inc()
+	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "get_condition_write", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	logger.Ctx(ctx).Info("retrieved condition write result", zap.Bool("result", result))
 
 	return result, nil

--- a/server/service.go
+++ b/server/service.go
@@ -191,6 +191,13 @@ func (s *Server) init() error {
 	return err
 }
 
+// grpcMetricsOnce ensures the process-global go-grpc-prometheus server metrics
+// are configured exactly once, even when multiple servers start concurrently in
+// a single process (e.g. integration/e2e in-process mini-clusters). The
+// underlying EnableHandlingTimeHistogram/Register mutate a package-global
+// singleton and are not safe to call from concurrent startGrpcLoop goroutines.
+var grpcMetricsOnce sync.Once
+
 // start grpc server loop
 func (s *Server) startGrpcLoop() {
 	defer s.grpcWG.Done()
@@ -212,8 +219,10 @@ func (s *Server) startGrpcLoop() {
 	}
 	s.grpcServer = grpc.NewServer(grpcOpts...)
 	proto.RegisterLogStoreServer(s.grpcServer, s)
-	grpc_prometheus.EnableHandlingTimeHistogram()
-	grpc_prometheus.Register(s.grpcServer)
+	grpcMetricsOnce.Do(func() {
+		grpc_prometheus.EnableHandlingTimeHistogram()
+		grpc_prometheus.Register(s.grpcServer)
+	})
 	funcutil.CheckGrpcReady(s.ctx, s.grpcErrChan)
 	logger.Ctx(s.ctx).Info("start grpc server", zap.String("nodeID", s.serverConfig.NodeID), zap.String("address", s.listener.Addr().String()))
 	if err := s.grpcServer.Serve(s.listener); err != nil {

--- a/server/service.go
+++ b/server/service.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -195,6 +196,7 @@ func (s *Server) startGrpcLoop() {
 	defer s.grpcWG.Done()
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		s.shutdownUnaryInterceptor(),
+		grpc_prometheus.UnaryServerInterceptor,
 		otelgrpc.UnaryServerInterceptor(),
 	}
 	unaryInterceptors = append(unaryInterceptors, s.grpcExtraInterceptors...)
@@ -204,11 +206,14 @@ func (s *Server) startGrpcLoop() {
 		grpc.ChainUnaryInterceptor(unaryInterceptors...),
 		grpc.ChainStreamInterceptor(
 			s.shutdownStreamInterceptor(),
+			grpc_prometheus.StreamServerInterceptor,
 			otelgrpc.StreamServerInterceptor(),
 		),
 	}
 	s.grpcServer = grpc.NewServer(grpcOpts...)
 	proto.RegisterLogStoreServer(s.grpcServer, s)
+	grpc_prometheus.EnableHandlingTimeHistogram()
+	grpc_prometheus.Register(s.grpcServer)
 	funcutil.CheckGrpcReady(s.ctx, s.grpcErrChan)
 	logger.Ctx(s.ctx).Info("start grpc server", zap.String("nodeID", s.serverConfig.NodeID), zap.String("address", s.listener.Addr().String()))
 	if err := s.grpcServer.Serve(s.listener); err != nil {

--- a/server/storage/cache/sequential_buffer.go
+++ b/server/storage/cache/sequential_buffer.go
@@ -47,7 +47,7 @@ type SequentialBuffer struct {
 	logId     int64
 	segmentId int64
 	logIdStr  string // for metrics only
-	nsStr     string // for metrics only
+	logNs     string // for metrics only
 
 	Entries                 []*BufferEntry // entries with data and notification channels
 	MaxEntries              int64          // max amount of entries
@@ -63,7 +63,7 @@ func NewSequentialBuffer(logId int64, segmentId int64, startEntryId int64, maxEn
 		logId:        logId,
 		segmentId:    segmentId,
 		logIdStr:     strconv.FormatInt(logId, 10),
-		nsStr:        operatingNamespace,
+		logNs:        operatingNamespace,
 		Entries:      make([]*BufferEntry, maxEntries),
 		MaxEntries:   maxEntries,
 		FirstEntryId: startEntryId,
@@ -83,7 +83,7 @@ func NewSequentialBufferWithData(logId int64, segmentId int64, startEntryId int6
 		logId:        logId,
 		segmentId:    segmentId,
 		logIdStr:     strconv.FormatInt(logId, 10),
-		nsStr:        operatingNamespace,
+		logNs:        operatingNamespace,
 		Entries:      entries,
 		MaxEntries:   maxEntries,
 		FirstEntryId: startEntryId,
@@ -196,7 +196,7 @@ func (b *SequentialBuffer) NotifyEntriesInRange(ctx context.Context, startEntryI
 		if entry != nil && entry.NotifyChan != nil {
 			// Track buffer wait latency
 			if !entry.EnqueueTime.IsZero() {
-				metrics.WpServerBufferWaitLatency.WithLabelValues(metrics.NodeID, b.nsStr, b.logIdStr).
+				metrics.WpServerBufferWaitLatency.WithLabelValues(metrics.NodeID, b.logNs, b.logIdStr).
 					Observe(float64(time.Since(entry.EnqueueTime).Milliseconds()))
 			}
 
@@ -254,7 +254,7 @@ func (b *SequentialBuffer) NotifyAllPendingEntries(ctx context.Context, result i
 		if entry != nil && entry.NotifyChan != nil {
 			// Track buffer wait latency
 			if !entry.EnqueueTime.IsZero() {
-				metrics.WpServerBufferWaitLatency.WithLabelValues(metrics.NodeID, b.nsStr, b.logIdStr).
+				metrics.WpServerBufferWaitLatency.WithLabelValues(metrics.NodeID, b.logNs, b.logIdStr).
 					Observe(float64(time.Since(entry.EnqueueTime).Milliseconds()))
 			}
 
@@ -403,10 +403,10 @@ func (b *SequentialBuffer) notifyAllPendingEntriesUnsafe(ctx context.Context, re
 // NotifyPendingEntryDirectly notifies a single entry directly with the specified result
 // For successful entries (result >= 0), the entry receives the entryId
 // For failed entries (result < 0), the entry receives the error result
-func NotifyPendingEntryDirectly(ctx context.Context, logId, segId, entryId int64, notifyChan channel.ResultChannel, result int64, resultErr error, nsStr string, enqueueTime time.Time) {
+func NotifyPendingEntryDirectly(ctx context.Context, logId, segId, entryId int64, notifyChan channel.ResultChannel, result int64, resultErr error, logNs string, enqueueTime time.Time) {
 	// Track buffer wait latency
-	if !enqueueTime.IsZero() && nsStr != "" {
-		metrics.WpServerBufferWaitLatency.WithLabelValues(metrics.NodeID, nsStr, strconv.FormatInt(logId, 10)).
+	if !enqueueTime.IsZero() && logNs != "" {
+		metrics.WpServerBufferWaitLatency.WithLabelValues(metrics.NodeID, logNs, strconv.FormatInt(logId, 10)).
 			Observe(float64(time.Since(enqueueTime).Milliseconds()))
 	}
 

--- a/server/storage/disk/reader_impl.go
+++ b/server/storage/disk/reader_impl.go
@@ -47,7 +47,7 @@ type LocalFileReaderAdv struct {
 	logId        int64
 	segId        int64
 	logIdStr     string // for metrics only
-	nsStr        string // for metrics only
+	logNs        string // for metrics only
 	filePath     string
 	maxBatchSize int64
 
@@ -119,7 +119,7 @@ func NewLocalFileReaderAdv(ctx context.Context, baseDir string, logId int64, seg
 		logId:        logId,
 		segId:        segId,
 		logIdStr:     strconv.FormatInt(logId, 10),
-		nsStr:        baseDir,
+		logNs:        baseDir,
 		filePath:     filePath,
 		maxBatchSize: maxBatchSize,
 		file:         file,
@@ -140,7 +140,7 @@ func NewLocalFileReaderAdv(ctx context.Context, baseDir string, logId int64, seg
 		return nil, fmt.Errorf("try parse footer and indexes: %w", parseFooterErr)
 	}
 
-	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, reader.nsStr, reader.logIdStr).Inc()
+	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, reader.logNs, reader.logIdStr).Inc()
 	logger.Ctx(ctx).Debug("local file readerAdv created successfully",
 		zap.String("filePath", filePath),
 		zap.Int64("currentFileSize", currentSize),
@@ -611,8 +611,8 @@ func (r *LocalFileReaderAdv) scanForAllBlockInfoUnsafe(ctx context.Context) erro
 		zap.Int64("fileSize", currentFileSize),
 		zap.Int64("scannedOffset", currentOffset))
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr, "loadAll", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr, "loadAll", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr, "loadAll", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr, "loadAll", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -764,7 +764,7 @@ func (r *LocalFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stora
 	}
 
 	if len(entries) == 0 {
-		metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Debug("no entry extracted",
 			zap.String("filePath", r.filePath),
 			zap.Int64("startEntryId", opt.StartEntryID),
@@ -790,8 +790,8 @@ func (r *LocalFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stora
 			zap.Any("lastBlockInfo", lastBlockInfo))
 	}
 
-	metrics.WpFileReadBatchBytes.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr).Add(float64(readBytes))
-	metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileReadBatchBytes.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr).Add(float64(readBytes))
+	metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
 
 	// Create batch with proper error handling for nil lastBlockInfo
 	var lastReadState *proto.LastReadState
@@ -900,7 +900,7 @@ func (r *LocalFileReaderAdv) Close(ctx context.Context) error {
 		}
 		r.file = nil
 	}
-	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr).Dec()
+	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr).Dec()
 	logger.Ctx(ctx).Info("segment reader closed", zap.Int64("logId", r.logId), zap.Int64("segId", r.segId))
 	return nil
 }

--- a/server/storage/disk/segment_impl.go
+++ b/server/storage/disk/segment_impl.go
@@ -48,7 +48,7 @@ type DiskSegmentImpl struct {
 	segmentId       int64
 	segmentDir      string
 	segmentFilePath string
-	nsStr           string // for metrics only
+	logNs           string // for metrics only
 	logIdStr        string // for metrics only
 }
 
@@ -63,7 +63,7 @@ func NewDiskSegmentImpl(ctx context.Context, baseDir string, logId int64, segId 
 		segmentId:       segId,
 		segmentDir:      segmentDir,
 		segmentFilePath: filePath,
-		nsStr:           baseDir,
+		logNs:           baseDir,
 		logIdStr:        strconv.FormatInt(logId, 10),
 	}
 	return segmentImpl
@@ -116,11 +116,11 @@ func (rs *DiskSegmentImpl) DeleteFileData(ctx context.Context, flag int) (int, e
 
 	// Update metrics
 	if len(deleteErrors) > 0 {
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr, "delete_segment", "error").Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr, "delete_segment", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr, "delete_segment", "error").Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr, "delete_segment", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 	} else {
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr, "delete_segment", "success").Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr, "delete_segment", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr, "delete_segment", "success").Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr, "delete_segment", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	}
 
 	logger.Ctx(ctx).Info("Completed fragment deletion",

--- a/server/storage/disk/writer_impl.go
+++ b/server/storage/disk/writer_impl.go
@@ -63,7 +63,7 @@ type LocalFileWriter struct {
 	segmentId       int64
 	file            *os.File
 	logIdStr        string // for metrics only
-	nsStr           string // for metrics only
+	logNs           string // for metrics only
 
 	// Configuration
 	maxFlushSize     int64 // Max buffer size before triggering sync
@@ -157,7 +157,7 @@ func NewLocalFileWriterWithMode(ctx context.Context, baseDir string, logId int64
 		logId:            logId,
 		segmentId:        segmentId,
 		logIdStr:         strconv.FormatInt(logId, 10),
-		nsStr:            baseDir,
+		logNs:            baseDir,
 		blockIndexes:     make([]*codec.IndexRecord, 0),
 		writtenBytes:     0,
 		maxFlushSize:     blockSize,
@@ -282,7 +282,7 @@ func (w *LocalFileWriter) run() {
 	ticker := time.NewTicker(time.Duration(w.maxIntervalMs) * time.Millisecond)
 	defer ticker.Stop()
 
-	metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Inc()
+	metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Inc()
 
 	logger.Ctx(w.runCtx).Debug("LocalFileWriter run goroutine started",
 		zap.Int64("logId", w.logId),
@@ -293,21 +293,21 @@ func (w *LocalFileWriter) run() {
 		case <-w.runCtx.Done():
 			// Context cancelled, exit
 			logger.Ctx(w.runCtx).Debug("LocalFileWriter run goroutine stopping due to context cancellation")
-			metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Dec()
+			metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Dec()
 			return
 		case flushTask, ok := <-w.flushTaskChan:
 			// Process flush tasks with higher priority
 			if !ok {
 				// Channel closed, exit
 				logger.Ctx(w.runCtx).Debug("LocalFileWriter run goroutine stopping due to channel close")
-				metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Dec()
+				metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Dec()
 				return
 			}
 			if flushTask.entries == nil {
 				logger.Ctx(context.TODO()).Debug("received termination signal, marking all upload tasks as done",
 					zap.String("segmentFilePath", w.segmentFilePath))
 				w.allUploadingTaskDone.Store(true)
-				metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Dec()
+				metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Dec()
 				return
 			}
 			// Process flush task synchronously
@@ -369,8 +369,8 @@ func (w *LocalFileWriter) Sync(ctx context.Context) error {
 		w.rollBufferAndSubmitFlushTaskUnsafe(ctx)
 	}
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "sync", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "sync", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "sync", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "sync", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 
 	return nil
 }
@@ -414,7 +414,7 @@ func (w *LocalFileWriter) rollBufferAndSubmitFlushTaskUnsafe(ctx context.Context
 		return
 	}
 	restDataFirstEntryId := expectedNextEntryId
-	newBuffer := cache.NewSequentialBufferWithData(w.logId, w.segmentId, restDataFirstEntryId, w.maxBufferEntries, restData, w.nsStr)
+	newBuffer := cache.NewSequentialBufferWithData(w.logId, w.segmentId, restDataFirstEntryId, w.maxBufferEntries, restData, w.logNs)
 
 	// Submit flush task
 	logger.Ctx(ctx).Debug("Submitting flush task to channel",
@@ -449,8 +449,8 @@ func (w *LocalFileWriter) rollBufferAndSubmitFlushTaskUnsafe(ctx context.Context
 		w.notifyFlushError(ctx, flushTask.entries, werr.ErrFileWriterAlreadyClosed)
 	}
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "rollBuffer", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "rollBuffer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "rollBuffer", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "rollBuffer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 }
 
 // processFlushTask processes a flush task by writing data to disk
@@ -469,8 +469,8 @@ func (w *LocalFileWriter) processFlushTask(ctx context.Context, task *blockFlush
 	defer func() {
 		op.End(status)
 		if status == "success" {
-			metrics.WpFileFlushBytesWritten.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Add(float64(actualDataSize))
-			metrics.WpFileFlushLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Observe(float64(time.Since(op.StartedAt()).Milliseconds()))
+			metrics.WpFileFlushBytesWritten.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Add(float64(actualDataSize))
+			metrics.WpFileFlushLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Observe(float64(time.Since(op.StartedAt()).Milliseconds()))
 		}
 	}()
 
@@ -690,7 +690,7 @@ func (w *LocalFileWriter) notifyFlushError(ctx context.Context, entries []*cache
 	// Notify all pending entries result channels in sequential order
 	for _, entry := range entries {
 		if entry.NotifyChan != nil {
-			cache.NotifyPendingEntryDirectly(ctx, w.logId, w.segmentId, entry.EntryId, entry.NotifyChan, entry.EntryId, err, w.nsStr, entry.EnqueueTime)
+			cache.NotifyPendingEntryDirectly(ctx, w.logId, w.segmentId, entry.EntryId, entry.NotifyChan, entry.EntryId, err, w.logNs, entry.EnqueueTime)
 		}
 	}
 }
@@ -700,7 +700,7 @@ func (w *LocalFileWriter) notifyFlushSuccess(ctx context.Context, entries []*cac
 	// Notify all pending entries result channels in sequential order
 	for _, entry := range entries {
 		if entry.NotifyChan != nil {
-			cache.NotifyPendingEntryDirectly(ctx, w.logId, w.segmentId, entry.EntryId, entry.NotifyChan, entry.EntryId, nil, w.nsStr, entry.EnqueueTime)
+			cache.NotifyPendingEntryDirectly(ctx, w.logId, w.segmentId, entry.EntryId, entry.NotifyChan, entry.EntryId, nil, w.logNs, entry.EnqueueTime)
 		}
 	}
 }
@@ -877,8 +877,8 @@ func (w *LocalFileWriter) Finalize(ctx context.Context, lac int64 /*not used, ca
 		if retErr != nil {
 			status = "error"
 		}
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "finalize", status).Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "finalize", status).Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "finalize", status).Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "finalize", status).Observe(float64(time.Since(startTime).Milliseconds()))
 	}()
 
 	w.finalizeMu.Lock()
@@ -1025,13 +1025,13 @@ func (w *LocalFileWriter) Close(ctx context.Context) error {
 		logger.Ctx(ctx).Warn("wait flush error before close",
 			zap.String("segmentFilePath", w.segmentFilePath),
 			zap.Error(waitErr))
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "close", "error").Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "close", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "close", "error").Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "close", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		return waitErr
 	}
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "close", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "close", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "close", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "close", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1045,8 +1045,8 @@ func (w *LocalFileWriter) Fence(ctx context.Context) (_ int64, retErr error) {
 		if retErr != nil {
 			status = "error"
 		}
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "fence", status).Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "fence", status).Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "fence", status).Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "fence", status).Observe(float64(time.Since(startTime).Milliseconds()))
 	}()
 
 	// Mark as fenced first to reject new AppendAsync calls (idempotent)
@@ -1279,8 +1279,8 @@ func (w *LocalFileWriter) recoverBlocksFromFooterUnsafe(ctx context.Context, fil
 		zap.Int64("firstEntryID", w.firstEntryID.Load()),
 		zap.Int64("lastEntryID", w.lastEntryID.Load()))
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "recover_footer", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "recover_footer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_footer", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_footer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 
 	w.recovered.Store(true)
 	return nil
@@ -1421,8 +1421,8 @@ func (w *LocalFileWriter) recoverBlocksFromFullScanUnsafe(ctx context.Context, f
 	}
 
 	// update metrics
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "recover_raw", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "recover_raw", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_raw", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_raw", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 
 	return nil
 }

--- a/server/storage/disk/writer_impl_test.go
+++ b/server/storage/disk/writer_impl_test.go
@@ -1139,7 +1139,7 @@ func TestLocalFileWriter_RecoverFromExisting_StatError(t *testing.T) {
 		logId:           1,
 		segmentId:       0,
 		logIdStr:        "1",
-		nsStr:           dir,
+		logNs:           dir,
 		blockIndexes:    make([]*codec.IndexRecord, 0),
 		flushTaskChan:   make(chan *blockFlushTask, 10),
 		runCtx:          runCtx,

--- a/server/storage/objectstorage/reader_impl.go
+++ b/server/storage/objectstorage/reader_impl.go
@@ -52,7 +52,7 @@ type MinioFileReaderAdv struct {
 	logId          int64
 	segmentId      int64
 	logIdStr       string // for metrics only
-	nsStr          string // for metrics namespace label
+	logNs          string // for metrics log_ns label
 
 	// file access
 	mu     sync.RWMutex
@@ -86,7 +86,7 @@ func NewMinioFileReaderAdv(ctx context.Context, bucket string, baseDir string, l
 		logId:          logId,
 		segmentId:      segId,
 		logIdStr:       strconv.FormatInt(logId, 10),
-		nsStr:          bucket + "/" + baseDir,
+		logNs:          bucket + "/" + baseDir,
 		client:         client,
 		bucket:         bucket,
 		segmentFileKey: segmentFileKey,
@@ -111,7 +111,7 @@ func NewMinioFileReaderAdv(ctx context.Context, bucket string, baseDir string, l
 		return nil, readFooterErr
 	}
 
-	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, reader.nsStr, reader.logIdStr).Inc()
+	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, reader.logNs, reader.logIdStr).Inc()
 	logger.Ctx(ctx).Info("create new minio file readerAdv finish", zap.String("segmentFileKey", segmentFileKey), zap.Int64("logId", logId), zap.Int64("segId", segId), zap.Int64("maxBatchSize", maxBatchSize), zap.Int("maxFetchThreads", maxFetchThreads))
 	return reader, nil
 }
@@ -128,7 +128,7 @@ func (f *MinioFileReaderAdv) readFooterAndIndexUnsafe(ctx context.Context) (*Foo
 	defer sp.End()
 	// Check if footer.blk exists
 	footerKey := getFooterBlockKey(f.segmentFileKey)
-	statSize, _, err := f.client.StatObject(ctx, f.bucket, footerKey, f.nsStr, f.logIdStr)
+	statSize, _, err := f.client.StatObject(ctx, f.bucket, footerKey, f.logNs, f.logIdStr)
 	if err != nil {
 		if f.client.IsObjectNotExistsError(err) {
 			// no footer blk yet
@@ -138,13 +138,13 @@ func (f *MinioFileReaderAdv) readFooterAndIndexUnsafe(ctx context.Context) (*Foo
 	}
 
 	// Read the entire footer.blk file
-	footerObj, err := f.client.GetObject(ctx, f.bucket, footerKey, 0, statSize, f.nsStr, f.logIdStr)
+	footerObj, err := f.client.GetObject(ctx, f.bucket, footerKey, 0, statSize, f.logNs, f.logIdStr)
 	if err != nil {
 		return nil, err
 	}
 	defer footerObj.Close()
 
-	footerBlkData, err := minioHandler.ReadObjectFull(ctx, footerObj, statSize, f.nsStr, f.logIdStr)
+	footerBlkData, err := minioHandler.ReadObjectFull(ctx, footerObj, statSize, f.logNs, f.logIdStr)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func (f *MinioFileReaderAdv) prefetchIncrementalBlockInfoUnsafe(ctx context.Cont
 		blockKey := getBlockKey(f.segmentFileKey, blockID)
 
 		// check if the block exists in object storage
-		blockSize, isFenced, err := f.client.StatObject(ctx, f.bucket, blockKey, f.nsStr, f.logIdStr)
+		blockSize, isFenced, err := f.client.StatObject(ctx, f.bucket, blockKey, f.logNs, f.logIdStr)
 		if err != nil && f.client.IsObjectNotExistsError(err) {
 			break
 		}
@@ -323,8 +323,8 @@ func (f *MinioFileReaderAdv) prefetchIncrementalBlockInfoUnsafe(ctx context.Cont
 	}
 
 	logger.Ctx(ctx).Debug("prefetch block infos", zap.String("segmentFileKey", f.segmentFileKey), zap.Int("blocks", len(f.blocks)), zap.Int64("lastBlockID", blockID-1))
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "loadIncr", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "loadIncr", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "loadIncr", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "loadIncr", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return existsNewBlock, fetchedLastBlock, nil
 }
 
@@ -340,7 +340,7 @@ func (f *MinioFileReaderAdv) getBlockHeaderRecord(ctx context.Context, blockID i
 	}
 
 	// get block header record from the beginning of the block
-	headerRecordObj, getErr := f.client.GetObject(ctx, f.bucket, blockKey, 0, readSize, f.nsStr, f.logIdStr)
+	headerRecordObj, getErr := f.client.GetObject(ctx, f.bucket, blockKey, 0, readSize, f.logNs, f.logIdStr)
 	if getErr != nil {
 		logger.Ctx(ctx).Warn("Error getting block header record",
 			zap.String("segmentFileKey", f.segmentFileKey),
@@ -350,7 +350,7 @@ func (f *MinioFileReaderAdv) getBlockHeaderRecord(ctx context.Context, blockID i
 	}
 	defer headerRecordObj.Close()
 
-	data, err := minioHandler.ReadObjectFull(ctx, headerRecordObj, readSize, f.nsStr, f.logIdStr)
+	data, err := minioHandler.ReadObjectFull(ctx, headerRecordObj, readSize, f.logNs, f.logIdStr)
 	if err != nil {
 		logger.Ctx(ctx).Warn("Error reading block header record",
 			zap.String("segmentFileKey", f.segmentFileKey),
@@ -494,7 +494,7 @@ func (f *MinioFileReaderAdv) Close(ctx context.Context) error {
 	if f.pool != nil {
 		f.pool.Release()
 	}
-	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Dec()
+	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Dec()
 	logger.Ctx(ctx).Info("segment reader closed", zap.Int64("logId", f.logId), zap.Int64("segId", f.segmentId))
 	return nil
 }
@@ -630,7 +630,7 @@ func (f *MinioFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stora
 
 	// Check final results
 	if len(allEntries) == 0 {
-		metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
 
 		// If no data read error (or error is compaction-related), determine if it is EOF
 		if !hasDataReadError {
@@ -655,8 +655,8 @@ func (f *MinioFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stora
 		zap.Int64("totalCollectedSize", totalCollectedSize),
 		zap.Any("lastBlockInfo", lastBlockInfo))
 
-	metrics.WpFileReadBatchBytes.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Add(float64(totalReadBytes))
-	metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileReadBatchBytes.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Add(float64(totalReadBytes))
+	metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
 
 	// Create batch with proper error handling for nil lastBlockInfo
 	var lastReadState *proto.LastReadState
@@ -687,7 +687,7 @@ func (f *MinioFileReaderAdv) fetchAndProcessBlock(ctx context.Context, block Blo
 	}
 
 	// Get the object
-	blockObj, getErr := f.client.GetObject(ctx, f.bucket, block.objKey, 0, block.size, f.nsStr, f.logIdStr)
+	blockObj, getErr := f.client.GetObject(ctx, f.bucket, block.objKey, 0, block.size, f.logNs, f.logIdStr)
 	if getErr != nil {
 		// Check if block not found - use centralized handling
 		if f.client.IsObjectNotExistsError(getErr) {
@@ -703,7 +703,7 @@ func (f *MinioFileReaderAdv) fetchAndProcessBlock(ctx context.Context, block Blo
 	}
 
 	// Read the full object data
-	blockData, err := minioHandler.ReadObjectFull(ctx, blockObj, block.size, f.nsStr, f.logIdStr)
+	blockData, err := minioHandler.ReadObjectFull(ctx, blockObj, block.size, f.logNs, f.logIdStr)
 	blockObj.Close() // release immediately after reading
 	if err != nil {
 		result.err = err
@@ -810,7 +810,7 @@ func (f *MinioFileReaderAdv) isFooterExists(ctx context.Context) bool {
 	defer sp.End()
 	// Check if footer.blk exists
 	footerKey := getFooterBlockKey(f.segmentFileKey)
-	statSize, _, err := f.client.StatObject(ctx, f.bucket, footerKey, f.nsStr, f.logIdStr)
+	statSize, _, err := f.client.StatObject(ctx, f.bucket, footerKey, f.logNs, f.logIdStr)
 	if err != nil {
 		if f.client.IsObjectNotExistsError(err) {
 			// no footer blk yet
@@ -874,7 +874,7 @@ func (f *MinioFileReaderAdv) readBlockBatchUnsafe(ctx context.Context, startBloc
 		blockObjKey := f.getBlockObjectKey(currentBlockID)
 
 		// StatObject to get size (very fast: 1-5ms)
-		objSize, isFenced, statErr := f.client.StatObject(ctx, f.bucket, blockObjKey, f.nsStr, f.logIdStr)
+		objSize, isFenced, statErr := f.client.StatObject(ctx, f.bucket, blockObjKey, f.logNs, f.logIdStr)
 		if statErr != nil {
 			if f.client.IsObjectNotExistsError(statErr) {
 				// Use centralized block-not-found handling

--- a/server/storage/objectstorage/reader_impl_test.go
+++ b/server/storage/objectstorage/reader_impl_test.go
@@ -602,7 +602,7 @@ func newTestReader(mockClient *mocks_objectstorage.ObjectStorage) *MinioFileRead
 		logId:          logId,
 		segmentId:      segId,
 		logIdStr:       strconv.FormatInt(logId, 10),
-		nsStr:          "test-bucket/test-base",
+		logNs:          "test-bucket/test-base",
 		client:         mockClient,
 		bucket:         "test-bucket",
 		segmentFileKey: "test-base/1/0",
@@ -1745,7 +1745,7 @@ func TestNewMinioFileReaderAdv_Success_NoFooter(t *testing.T) {
 	assert.Equal(t, int64(0), reader.segmentId)
 	assert.Equal(t, "base/1/0", reader.segmentFileKey)
 	assert.Equal(t, "test-bucket", reader.bucket)
-	assert.Equal(t, "test-bucket/base", reader.nsStr)
+	assert.Equal(t, "test-bucket/base", reader.logNs)
 	assert.Equal(t, "1", reader.logIdStr)
 	assert.False(t, reader.closed.Load())
 	assert.False(t, reader.isCompleted.Load())

--- a/server/storage/objectstorage/segment_impl.go
+++ b/server/storage/objectstorage/segment_impl.go
@@ -48,7 +48,7 @@ type SegmentImpl struct {
 	segmentId      int64
 	segmentFileKey string
 	logIdStr       string // for metrics label only
-	nsStr          string // for metrics namespace label
+	logNs          string // for metrics log_ns label
 }
 
 // NewSegmentImpl is used to create a new Segment, which is used to write data to object storage
@@ -63,7 +63,7 @@ func NewSegmentImpl(ctx context.Context, bucket string, baseDir string, logId in
 		segmentFileKey: segmentFileKey,
 		bucket:         bucket,
 		logIdStr:       strconv.FormatInt(logId, 10),
-		nsStr:          bucket + "/" + baseDir,
+		logNs:          bucket + "/" + baseDir,
 	}
 	return segmentImpl
 }
@@ -127,7 +127,7 @@ func (s *SegmentImpl) DeleteFileData(ctx context.Context, flag int) (int, error)
 			objectsToDelete = append(objectsToDelete, objectToDelete{path: objInfo.FilePath, size: objInfo.Size})
 		}
 		return true // continue walking
-	}, s.nsStr, s.logIdStr)
+	}, s.logNs, s.logIdStr)
 	if walkErr != nil {
 		logger.Ctx(ctx).Warn("error listing blocks during deletion",
 			zap.String("segmentFileKey", s.segmentFileKey),
@@ -142,7 +142,7 @@ func (s *SegmentImpl) DeleteFileData(ctx context.Context, flag int) (int, error)
 
 	// Delete objects
 	for _, obj := range objectsToDelete {
-		err := s.client.RemoveObject(ctx, s.bucket, obj.path, s.nsStr, s.logIdStr)
+		err := s.client.RemoveObject(ctx, s.bucket, obj.path, s.logNs, s.logIdStr)
 		if err != nil {
 			// Log error but continue with other deletions
 			logger.Ctx(ctx).Warn("failed to delete block",
@@ -155,8 +155,8 @@ func (s *SegmentImpl) DeleteFileData(ctx context.Context, flag int) (int, error)
 				zap.String("segmentFileKey", s.segmentFileKey),
 				zap.String("objectKey", obj.path))
 			deletedCount++
-			metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, s.nsStr, s.logIdStr).Sub(float64(obj.size))
-			metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, s.nsStr, s.logIdStr).Dec()
+			metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, s.logNs, s.logIdStr).Sub(float64(obj.size))
+			metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, s.logNs, s.logIdStr).Dec()
 		}
 	}
 

--- a/server/storage/objectstorage/writer_impl.go
+++ b/server/storage/objectstorage/writer_impl.go
@@ -65,7 +65,7 @@ type MinioFileWriter struct {
 	segmentId      int64
 	logIdStr       string // for metrics label only
 	segmentIdStr   string // for metrics label only
-	nsStr          string // for metrics namespace label
+	logNs          string // for metrics log_ns label
 
 	// configuration
 	maxBufferSize       int64 // Max buffer size to sync buffer to object storage
@@ -126,7 +126,7 @@ func NewMinioFileWriterWithMode(ctx context.Context, bucket string, baseDir stri
 		segmentId:      segId,
 		logIdStr:       strconv.FormatInt(logId, 10),
 		segmentIdStr:   strconv.FormatInt(segId, 10),
-		nsStr:          bucket + "/" + baseDir,
+		logNs:          bucket + "/" + baseDir,
 		client:         objectCli,
 		segmentFileKey: segmentFileKey,
 		bucket:         bucket,
@@ -170,15 +170,15 @@ func NewMinioFileWriterWithMode(ctx context.Context, bucket string, baseDir stri
 		}
 		lastEntryID := segmentFileWriter.GetLastEntryId(ctx)
 		if lastEntryID != -1 {
-			newBuffer := cache.NewSequentialBuffer(logId, segId, lastEntryID+1, maxBufferEntries, segmentFileWriter.nsStr)
+			newBuffer := cache.NewSequentialBuffer(logId, segId, lastEntryID+1, maxBufferEntries, segmentFileWriter.logNs)
 			segmentFileWriter.buffer.Store(newBuffer)
 		} else {
 			// If no existing data found, start from entry ID 0
-			newBuffer := cache.NewSequentialBuffer(logId, segId, 0, maxBufferEntries, segmentFileWriter.nsStr)
+			newBuffer := cache.NewSequentialBuffer(logId, segId, 0, maxBufferEntries, segmentFileWriter.logNs)
 			segmentFileWriter.buffer.Store(newBuffer)
 		}
 	} else {
-		newBuffer := cache.NewSequentialBuffer(logId, segId, 0, maxBufferEntries, segmentFileWriter.nsStr)
+		newBuffer := cache.NewSequentialBuffer(logId, segId, 0, maxBufferEntries, segmentFileWriter.logNs)
 		segmentFileWriter.buffer.Store(newBuffer)
 
 		// Create segment file writer lock object
@@ -204,7 +204,7 @@ func (f *MinioFileWriter) recoverFromStorageUnsafe(ctx context.Context) error {
 		zap.String("segmentFileKey", f.segmentFileKey))
 
 	footerBlockKey := getFooterBlockKey(f.segmentFileKey)
-	footerBlockSize, _, err := f.client.StatObject(ctx, f.bucket, footerBlockKey, f.nsStr, f.logIdStr)
+	footerBlockSize, _, err := f.client.StatObject(ctx, f.bucket, footerBlockKey, f.logNs, f.logIdStr)
 	if err != nil {
 		if f.client.IsObjectNotExistsError(err) {
 			return f.recoverFromFullListing(ctx)
@@ -221,14 +221,14 @@ func (f *MinioFileWriter) recoverFromFooter(ctx context.Context, footerBlockKey 
 	defer sp.End()
 	startTime := time.Now()
 	// Read the entire footer.blk file
-	footerObj, err := f.client.GetObject(ctx, f.bucket, footerBlockKey, 0, footerBlockSize, f.nsStr, f.logIdStr)
+	footerObj, err := f.client.GetObject(ctx, f.bucket, footerBlockKey, 0, footerBlockSize, f.logNs, f.logIdStr)
 	if err != nil {
 		return err
 	}
 	defer footerObj.Close()
 	f.lastModifiedTime.Store(time.Now().UnixMilli()) // Use current time since we don't have LastModified info
 
-	footerBlkData, err := minioHandler.ReadObjectFull(ctx, footerObj, footerBlockSize, f.nsStr, f.logIdStr)
+	footerBlkData, err := minioHandler.ReadObjectFull(ctx, footerObj, footerBlockSize, f.logNs, f.logIdStr)
 	if err != nil {
 		return err
 	}
@@ -344,8 +344,8 @@ func (f *MinioFileWriter) recoverFromFooter(ctx context.Context, footerBlockKey 
 		zap.Int64("recoveredFirstEntryID", firstEntryID),
 		zap.Int64("recoveredLastEntryID", lastEntryID),
 		zap.Int64("recoveredLastBlockID", maxBlockID))
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "recover_footer", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "recover_footer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "recover_footer", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "recover_footer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 
 	return nil
 }
@@ -373,7 +373,7 @@ func (f *MinioFileWriter) recoverFromFullListing(ctx context.Context) error {
 		blockKey := getBlockKey(f.segmentFileKey, blockID)
 
 		// Try to get object info first to check if it exists
-		objSize, isFenced, stateErr := f.client.StatObject(ctx, f.bucket, blockKey, f.nsStr, f.logIdStr)
+		objSize, isFenced, stateErr := f.client.StatObject(ctx, f.bucket, blockKey, f.logNs, f.logIdStr)
 		if stateErr != nil {
 			if f.client.IsObjectNotExistsError(stateErr) {
 				// Block doesn't exist, we've reached the end of continuous sequence
@@ -451,8 +451,8 @@ func (f *MinioFileWriter) recoverFromFullListing(ctx context.Context) error {
 	if len(tempIndexRecords) == 0 {
 		logger.Ctx(ctx).Info("no existing data objects found, recover completed",
 			zap.String("segmentFileKey", f.segmentFileKey))
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "recover_raw", "success").Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "recover_raw", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "recover_raw", "success").Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "recover_raw", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 		return nil
 	}
 
@@ -484,8 +484,8 @@ func (f *MinioFileWriter) recoverFromFullListing(ctx context.Context) error {
 		zap.Int64("lastEntryID", lastEntryID),
 		zap.Int64("lastBlockID", maxBlockID))
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "recover_raw", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "recover_raw", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "recover_raw", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "recover_raw", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 
 	return nil
 }
@@ -503,7 +503,7 @@ func (f *MinioFileWriter) parseBlockHeaderRecord(ctx context.Context, blockID in
 	}
 
 	// get block header record from the beginning of the block
-	headerRecordObj, getErr := f.client.GetObject(ctx, f.bucket, blockKey, 0, readSize, f.nsStr, f.logIdStr)
+	headerRecordObj, getErr := f.client.GetObject(ctx, f.bucket, blockKey, 0, readSize, f.logNs, f.logIdStr)
 	if getErr != nil {
 		logger.Ctx(ctx).Warn("Error getting block header record",
 			zap.String("blockKey", blockKey),
@@ -511,7 +511,7 @@ func (f *MinioFileWriter) parseBlockHeaderRecord(ctx context.Context, blockID in
 		return nil, getErr
 	}
 	defer headerRecordObj.Close()
-	data, readErr := minioHandler.ReadObjectFull(ctx, headerRecordObj, readSize, f.nsStr, f.logIdStr)
+	data, readErr := minioHandler.ReadObjectFull(ctx, headerRecordObj, readSize, f.logNs, f.logIdStr)
 	if readErr != nil {
 		logger.Ctx(ctx).Warn("failed to read object data during prefetch, please retry later",
 			zap.String("blockKey", blockKey),
@@ -572,8 +572,8 @@ func (f *MinioFileWriter) run() {
 	defer ticker.Stop()
 	f.lastSyncTimestamp.Store(time.Now().UnixMilli())
 	logIdStr := strconv.FormatInt(f.logId, 10)
-	nsStr := f.nsStr
-	metrics.WpFileWriters.WithLabelValues(metrics.NodeID, nsStr, logIdStr).Inc()
+	logNs := f.logNs
+	metrics.WpFileWriters.WithLabelValues(metrics.NodeID, logNs, logIdStr).Inc()
 	logger.Ctx(context.TODO()).Debug("writer start", zap.String("segmentFileKey", f.segmentFileKey), zap.Int("maxIntervalMs", f.maxIntervalMs), zap.String("SegmentImplInst", fmt.Sprintf("%p", f)))
 	for {
 		select {
@@ -600,7 +600,7 @@ func (f *MinioFileWriter) run() {
 			ticker.Reset(time.Duration(f.maxIntervalMs * int(time.Millisecond)))
 		case <-f.fileClose:
 			logger.Ctx(context.TODO()).Debug("close segment file writer", zap.String("segmentFileKey", f.segmentFileKey), zap.String("SegmentImplInst", fmt.Sprintf("%p", f)))
-			metrics.WpFileWriters.WithLabelValues(metrics.NodeID, nsStr, logIdStr).Dec()
+			metrics.WpFileWriters.WithLabelValues(metrics.NodeID, logNs, logIdStr).Dec()
 			return
 		}
 	}
@@ -646,8 +646,8 @@ func (f *MinioFileWriter) ack() {
 				// flush success ack
 				f.fastFlushSuccessUnsafe(context.TODO(), task.flushFuture.Value().block, task.flushData)
 				f.lastModifiedTime.Store(time.Now().UnixMilli())
-				metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Add(float64(task.flushFuture.Value().block.Size))
-				metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Inc()
+				metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Add(float64(task.flushFuture.Value().block.Size))
+				metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Inc()
 			}
 		} else {
 			// flush fail, trigger mark storage not writable
@@ -865,8 +865,8 @@ func (f *MinioFileWriter) Compact(ctx context.Context) (_ int64, retErr error) {
 		}
 		op.End(status)
 		elapsed := float64(time.Since(op.StartedAt()).Milliseconds())
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "compact", status).Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "compact", status).Observe(elapsed)
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "compact", status).Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "compact", status).Observe(elapsed)
 	}()
 
 	f.mu.Lock()
@@ -941,7 +941,7 @@ func (f *MinioFileWriter) Compact(ctx context.Context) (_ int64, retErr error) {
 
 	// Upload new footer
 	footerKey := getFooterBlockKey(f.segmentFileKey)
-	putErr := f.client.PutObject(ctx, f.bucket, footerKey, bytes.NewReader(footerData), int64(len(footerData)), f.nsStr, f.logIdStr)
+	putErr := f.client.PutObject(ctx, f.bucket, footerKey, bytes.NewReader(footerData), int64(len(footerData)), f.logNs, f.logIdStr)
 	if putErr != nil {
 		logger.Ctx(ctx).Warn("failed to upload compacted footer",
 			zap.String("segmentFileKey", f.segmentFileKey),
@@ -950,7 +950,7 @@ func (f *MinioFileWriter) Compact(ctx context.Context) (_ int64, retErr error) {
 	}
 	// Footer object is overwritten (same key), adjust stored-bytes gauge by the size delta.
 	// Object count stays the same since the key already existed.
-	metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Add(float64(int64(len(footerData)) - oldFooterObjSize))
+	metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Add(float64(int64(len(footerData)) - oldFooterObjSize))
 
 	// Clean up original block files after successful compaction
 	originalBlockIndexes := f.blockIndexes // Save original blocks before updating
@@ -982,8 +982,8 @@ func (f *MinioFileWriter) Compact(ctx context.Context) (_ int64, retErr error) {
 		for _, idx := range originalBlockIndexes {
 			totalOriginalSize += int64(idx.BlockSize)
 		}
-		metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Sub(float64(totalOriginalSize))
-		metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Sub(float64(len(originalBlockIndexes)))
+		metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Sub(float64(totalOriginalSize))
+		metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Sub(float64(len(originalBlockIndexes)))
 	}
 
 	logger.Ctx(ctx).Info("successfully compacted segment",
@@ -1005,8 +1005,8 @@ func (f *MinioFileWriter) Sync(ctx context.Context) (retErr error) {
 		if retErr != nil {
 			status = "error"
 		}
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "sync", status).Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "sync", status).Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "sync", status).Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "sync", status).Observe(float64(time.Since(startTime).Milliseconds()))
 	}()
 	f.syncMu.Lock() // ensure only one sync operation is running at a time
 	defer f.syncMu.Unlock()
@@ -1101,17 +1101,17 @@ func (f *MinioFileWriter) rollBufferUnsafe(ctx context.Context) (*cache.Sequenti
 		return currentBuffer, nil, -1, err
 	}
 	restDataFirstEntryId := expectedNextEntryId
-	newBuffer := cache.NewSequentialBufferWithData(f.logId, f.segmentId, restDataFirstEntryId, int64(f.syncPolicyConfig.MaxEntries), restData, f.nsStr)
+	newBuffer := cache.NewSequentialBufferWithData(f.logId, f.segmentId, restDataFirstEntryId, int64(f.syncPolicyConfig.MaxEntries), restData, f.logNs)
 	f.buffer.Store(newBuffer)
 	logger.Ctx(ctx).Debug("start roll buffer", zap.String("segmentFileKey", f.segmentFileKey), zap.Int64("toFlushDataFirstEntryId", toFlushDataFirstEntryId), zap.Int("count", len(toFlushData)), zap.String("bufInst", fmt.Sprintf("%p", currentBuffer)), zap.String("newBufInst", fmt.Sprintf("%p", newBuffer)))
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "rollBuffer", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "rollBuffer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "rollBuffer", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "rollBuffer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return currentBuffer, toFlushData, toFlushDataFirstEntryId, nil
 }
 
 func (f *MinioFileWriter) fastFlushFailUnsafe(ctx context.Context, blockData []*cache.BufferEntry, resultErr error) {
 	for _, item := range blockData {
-		cache.NotifyPendingEntryDirectly(ctx, f.logId, f.segmentId, item.EntryId, item.NotifyChan, -1, resultErr, f.nsStr, item.EnqueueTime)
+		cache.NotifyPendingEntryDirectly(ctx, f.logId, f.segmentId, item.EntryId, item.NotifyChan, -1, resultErr, f.logNs, item.EnqueueTime)
 	}
 }
 
@@ -1131,7 +1131,7 @@ func (f *MinioFileWriter) fastFlushSuccessUnsafe(ctx context.Context, blockInfo 
 		LastEntryID:  blockInfo.LastEntryID,
 	})
 	for _, item := range blockData {
-		cache.NotifyPendingEntryDirectly(ctx, f.logId, f.segmentId, item.EntryId, item.NotifyChan, item.EntryId, nil, f.nsStr, item.EnqueueTime)
+		cache.NotifyPendingEntryDirectly(ctx, f.logId, f.segmentId, item.EntryId, item.NotifyChan, item.EntryId, nil, f.logNs, item.EnqueueTime)
 	}
 }
 
@@ -1185,9 +1185,9 @@ func (f *MinioFileWriter) submitBlockFlushTaskUnsafe(ctx context.Context, curren
 			var actualDataSize int64
 			defer func() {
 				op.End(status)
-				metrics.WpFileFlushLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Observe(float64(time.Since(op.StartedAt()).Milliseconds()))
+				metrics.WpFileFlushLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Observe(float64(time.Since(op.StartedAt()).Milliseconds()))
 				if status == "success" {
-					metrics.WpFileFlushBytesWritten.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Add(float64(actualDataSize))
+					metrics.WpFileFlushBytesWritten.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Add(float64(actualDataSize))
 				}
 			}()
 			logger.Ctx(ctx).Debug("start flush one block", zap.String("segmentFileKey", f.segmentFileKey), zap.Int64("blockId", blockId), zap.Int("count", len(blockDataBuff)), zap.Int64("blockSize", blockSize))
@@ -1197,7 +1197,7 @@ func (f *MinioFileWriter) submitBlockFlushTaskUnsafe(ctx context.Context, curren
 			logger.Ctx(ctx).Debug("serialized block data", zap.String("segmentFileKey", f.segmentFileKey), zap.Int64("blockId", blockId), zap.Int64("originalBlockSize", blockSize), zap.Int64("actualDataSize", actualDataSize))
 			flushErr := retry.Do(ctx,
 				func() error {
-					putErr := f.client.PutObjectIfNoneMatch(ctx, f.bucket, blockKey, bytes.NewReader(blockRawData), actualDataSize, f.nsStr, f.logIdStr)
+					putErr := f.client.PutObjectIfNoneMatch(ctx, f.bucket, blockKey, bytes.NewReader(blockRawData), actualDataSize, f.logNs, f.logIdStr)
 					if putErr != nil && werr.ErrObjectAlreadyExists.Is(putErr) {
 						// idempotent flush success
 						return nil
@@ -1359,8 +1359,8 @@ func (f *MinioFileWriter) Finalize(ctx context.Context, lac int64 /*not used, ca
 		if retErr != nil {
 			status = "error"
 		}
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "finalize", status).Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "finalize", status).Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "finalize", status).Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "finalize", status).Observe(float64(time.Since(startTime).Milliseconds()))
 	}()
 
 	f.finalizeMu.Lock()
@@ -1414,7 +1414,7 @@ func (f *MinioFileWriter) Finalize(ctx context.Context, lac int64 /*not used, ca
 		zap.String("segmentFileKey", f.segmentFileKey),
 		zap.Int("footerBlockRawData", len(footerBlockRawData)))
 
-	putErr := f.client.PutObjectIfNoneMatch(ctx, f.bucket, footerBlockKey, bytes.NewReader(footerBlockRawData), int64(len(footerBlockRawData)), f.nsStr, f.logIdStr)
+	putErr := f.client.PutObjectIfNoneMatch(ctx, f.bucket, footerBlockKey, bytes.NewReader(footerBlockRawData), int64(len(footerBlockRawData)), f.logNs, f.logIdStr)
 	if putErr != nil && !werr.ErrObjectAlreadyExists.Is(putErr) { // if ErrObjectAlreadyExists, means idempotent finalize success
 		logger.Ctx(ctx).Warn("failed to put finalization object",
 			zap.String("segmentFileKey", f.segmentFileKey),
@@ -1422,8 +1422,8 @@ func (f *MinioFileWriter) Finalize(ctx context.Context, lac int64 /*not used, ca
 			zap.Error(putErr))
 		return -1, fmt.Errorf("failed to put object: %w", putErr)
 	}
-	metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Add(float64(len(footerBlockRawData)))
-	metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Inc()
+	metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Add(float64(len(footerBlockRawData)))
+	metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Inc()
 	f.footerRecord = footer
 	logger.Ctx(ctx).Info("successfully finalized segment",
 		zap.String("segmentFileKey", f.segmentFileKey),
@@ -1471,13 +1471,13 @@ func (f *MinioFileWriter) Close(ctx context.Context) error {
 		logger.Ctx(ctx).Warn("wait flush error before close",
 			zap.String("segmentFileKey", f.segmentFileKey),
 			zap.Error(waitErr))
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "close", "error").Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "close", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "close", "error").Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "close", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		return waitErr
 	}
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "close", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "close", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "close", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "close", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1494,8 +1494,8 @@ func (f *MinioFileWriter) Fence(ctx context.Context) (_ int64, retErr error) {
 		if retErr != nil {
 			status = "error"
 		}
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "fence", status).Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "fence", status).Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "fence", status).Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "fence", status).Observe(float64(time.Since(startTime).Milliseconds()))
 	}()
 	logger.Ctx(ctx).Info("start to fence segment", zap.String("segmentFileKey", f.segmentFileKey))
 	f.mu.Lock()
@@ -1548,7 +1548,7 @@ func (f *MinioFileWriter) Fence(ctx context.Context) (_ int64, retErr error) {
 			fenceBlockKey = getBlockKey(f.segmentFileKey, fenceBlockId)
 
 			// Try to create fence object
-			putErr := f.client.PutFencedObject(ctx, f.bucket, fenceBlockKey, f.nsStr, f.logIdStr)
+			putErr := f.client.PutFencedObject(ctx, f.bucket, fenceBlockKey, f.logNs, f.logIdStr)
 			if putErr != nil {
 				if werr.ErrObjectAlreadyExists.Is(putErr) {
 					// Block already exists, this might be normal during concurrent operations
@@ -1685,7 +1685,7 @@ func (f *MinioFileWriter) createSegmentLock(ctx context.Context) error {
 		f.logId, f.segmentId, os.Getpid(), time.Now().Unix(), getHostname())
 
 	// Use PutObjectIfNoneMatch to atomically create lock object
-	err := f.client.PutObjectIfNoneMatch(ctx, f.bucket, f.lockObjectKey, strings.NewReader(lockInfo), int64(len(lockInfo)), f.nsStr, f.logIdStr)
+	err := f.client.PutObjectIfNoneMatch(ctx, f.bucket, f.lockObjectKey, strings.NewReader(lockInfo), int64(len(lockInfo)), f.logNs, f.logIdStr)
 	if err != nil {
 		if werr.ErrObjectAlreadyExists.Is(err) {
 			logger.Ctx(ctx).Warn("Lock object already exists - segment is already locked by another process",
@@ -1717,7 +1717,7 @@ func (f *MinioFileWriter) releaseSegmentLock(ctx context.Context) error {
 	}
 
 	// Remove the lock object
-	err := f.client.RemoveObject(ctx, f.bucket, f.lockObjectKey, f.nsStr, f.logIdStr)
+	err := f.client.RemoveObject(ctx, f.bucket, f.lockObjectKey, f.logNs, f.logIdStr)
 	if err != nil {
 		// Check if object doesn't exist (already removed)
 		if f.client.IsObjectNotExistsError(err) {
@@ -1746,7 +1746,7 @@ func (f *MinioFileWriter) isSegmentLocked(ctx context.Context) (bool, error) {
 
 	lockKey := getSegmentLockKey(f.segmentFileKey)
 
-	_, _, err := f.client.StatObject(ctx, f.bucket, lockKey, f.nsStr, f.logIdStr)
+	_, _, err := f.client.StatObject(ctx, f.bucket, lockKey, f.logNs, f.logIdStr)
 	if err != nil {
 		if f.client.IsObjectNotExistsError(err) {
 			return false, nil
@@ -2077,10 +2077,10 @@ func (f *MinioFileWriter) processMergeBlockTask(ctx context.Context, blocks []*c
 
 	// Update metrics
 	totalTime := time.Since(startTime)
-	metrics.WpFileCompactLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Observe(float64(totalTime.Milliseconds()))
-	metrics.WpFileCompactBytesWritten.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Add(float64(blockSize))
-	metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Add(float64(blockSize))
-	metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr).Inc()
+	metrics.WpFileCompactLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Observe(float64(totalTime.Milliseconds()))
+	metrics.WpFileCompactBytesWritten.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Add(float64(blockSize))
+	metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Add(float64(blockSize))
+	metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr).Inc()
 
 	logger.Ctx(ctx).Debug("completed merge block task",
 		zap.String("segmentFileKey", f.segmentFileKey),
@@ -2102,17 +2102,17 @@ func (f *MinioFileWriter) readBlockData(ctx context.Context, blockKey string) ([
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, SegmentWriterScope, "readBlockData")
 	defer sp.End()
 	// Get object size first, then read full object
-	objSize, _, err := f.client.StatObject(ctx, f.bucket, blockKey, f.nsStr, f.logIdStr)
+	objSize, _, err := f.client.StatObject(ctx, f.bucket, blockKey, f.logNs, f.logIdStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to stat object %s: %w", blockKey, err)
 	}
-	obj, err := f.client.GetObject(ctx, f.bucket, blockKey, 0, objSize, f.nsStr, f.logIdStr)
+	obj, err := f.client.GetObject(ctx, f.bucket, blockKey, 0, objSize, f.logNs, f.logIdStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get object %s: %w", blockKey, err)
 	}
 	defer obj.Close()
 
-	data, err := minioHandler.ReadObjectFull(ctx, obj, objSize, f.nsStr, f.logIdStr)
+	data, err := minioHandler.ReadObjectFull(ctx, obj, objSize, f.logNs, f.logIdStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read object data %s: %w", blockKey, err)
 	}
@@ -2169,7 +2169,7 @@ func (f *MinioFileWriter) uploadSingleMergedBlock(ctx context.Context, mergedBlo
 	// Upload merged block with m_ prefix (use PutObject for idempotent overwrites)
 	mergedBlockKey := getMergedBlockKey(f.segmentFileKey, mergedBlockID)
 	putErr := f.client.PutObject(ctx, f.bucket, mergedBlockKey,
-		bytes.NewReader(completeBlockData), int64(len(completeBlockData)), f.nsStr, f.logIdStr)
+		bytes.NewReader(completeBlockData), int64(len(completeBlockData)), f.logNs, f.logIdStr)
 	if putErr != nil {
 		logger.Ctx(ctx).Warn("failed to upload merged block",
 			zap.String("segmentFileKey", f.segmentFileKey),
@@ -2273,7 +2273,7 @@ func (f *MinioFileWriter) listOriginalBlockFiles(ctx context.Context) ([]string,
 			originalBlockKeys = append(originalBlockKeys, info.FilePath)
 		}
 		return true // continue walking
-	}, f.nsStr, f.logIdStr)
+	}, f.logNs, f.logIdStr)
 	if err != nil {
 		return nil, err
 	}
@@ -2349,7 +2349,7 @@ func (f *MinioFileWriter) deleteOriginalBlocksByKeys(ctx context.Context, blockK
 	for _, blockKey := range blockKeys {
 		key := blockKey // Capture for closure
 		future := deletePool.Submit(func() (*deleteByKeyResult, error) {
-			err := f.client.RemoveObject(ctx, f.bucket, key, f.nsStr, f.logIdStr)
+			err := f.client.RemoveObject(ctx, f.bucket, key, f.logNs, f.logIdStr)
 
 			result := &deleteByKeyResult{
 				blockKey: key,
@@ -2404,8 +2404,8 @@ func (f *MinioFileWriter) deleteOriginalBlocksByKeys(ctx context.Context, blockK
 		zap.Int64("deletionTimeMs", deletionDuration.Milliseconds()))
 
 	// Update metrics
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "compact_recovery_cleanup", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.nsStr, f.logIdStr, "compact_recovery_cleanup", "success").Observe(float64(deletionDuration.Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "compact_recovery_cleanup", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, f.logNs, f.logIdStr, "compact_recovery_cleanup", "success").Observe(float64(deletionDuration.Milliseconds()))
 
 	// Return error if there were any failed deletions
 	if len(failedDeletions) > 0 {

--- a/server/storage/objectstorage/writer_impl_test.go
+++ b/server/storage/objectstorage/writer_impl_test.go
@@ -85,7 +85,7 @@ func newTestMinioFileWriter() *MinioFileWriter {
 		segmentId:           0,
 		logIdStr:            "1",
 		segmentIdStr:        "0",
-		nsStr:               "test-bucket/test-base",
+		logNs:               "test-bucket/test-base",
 		segmentFileKey:      "test-base/1/0",
 		bucket:              "test-bucket",
 		maxBufferSize:       syncPolicyConfig.MaxBytes.Int64(),
@@ -115,7 +115,7 @@ func newTestMinioFileWriter() *MinioFileWriter {
 	w.lastSyncTimestamp.Store(time.Now().UnixMilli())
 	w.lastModifiedTime.Store(time.Now().UnixMilli())
 
-	newBuffer := cache.NewSequentialBuffer(1, 0, 0, maxBufferEntries, w.nsStr)
+	newBuffer := cache.NewSequentialBuffer(1, 0, 0, maxBufferEntries, w.logNs)
 	w.buffer.Store(newBuffer)
 
 	return w
@@ -1865,7 +1865,7 @@ func TestMinioFileWriter_Compact_MetricsAccuracy(t *testing.T) {
 
 	// Read gauge values before compaction
 	getGauge := func(gv *prometheus.GaugeVec) float64 {
-		g, _ := gv.GetMetricWithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr)
+		g, _ := gv.GetMetricWithLabelValues(metrics.NodeID, w.logNs, w.logIdStr)
 		m := &dto.Metric{}
 		_ = g.Write(m)
 		return m.GetGauge().GetValue()
@@ -2522,7 +2522,7 @@ func TestMinioFileWriter_WriteDataAsync_BufferFullTriggerSync(t *testing.T) {
 	w.maxBufferEntries = 3
 
 	// Create a new buffer with MaxEntries=3
-	newBuffer := cache.NewSequentialBuffer(1, 0, 0, 3, w.nsStr)
+	newBuffer := cache.NewSequentialBuffer(1, 0, 0, 3, w.logNs)
 	w.buffer.Store(newBuffer)
 
 	ch := newMockResultChannel()
@@ -2550,7 +2550,7 @@ func TestMinioFileWriter_WriteDataAsync_BufferFullSyncError(t *testing.T) {
 	w := newTestMinioFileWriter()
 	w.maxBufferEntries = 3
 
-	newBuffer := cache.NewSequentialBuffer(1, 0, 0, 3, w.nsStr)
+	newBuffer := cache.NewSequentialBuffer(1, 0, 0, 3, w.logNs)
 	w.buffer.Store(newBuffer)
 
 	ch := newMockResultChannel()

--- a/server/storage/stagedstorage/reader_impl.go
+++ b/server/storage/stagedstorage/reader_impl.go
@@ -53,7 +53,7 @@ type StagedFileReaderAdv struct {
 	logId    int64
 	segId    int64
 	logIdStr string // for metrics only
-	nsStr    string // for metrics only
+	logNs    string // for metrics only
 	filePath string
 
 	// object access, only used for compacted object access
@@ -140,7 +140,7 @@ func NewStagedFileReaderAdv(ctx context.Context, bucket string, rootPath string,
 		logId:           logId,
 		segId:           segId,
 		logIdStr:        strconv.FormatInt(logId, 10),
-		nsStr:           bucket + "/" + rootPath,
+		logNs:           bucket + "/" + rootPath,
 		filePath:        filePath,
 		maxBatchSize:    maxBatchSize,
 		file:            file,
@@ -167,7 +167,7 @@ func NewStagedFileReaderAdv(ctx context.Context, bucket string, rootPath string,
 		return nil, fmt.Errorf("try parse footer and indexes: %w", parseFooterErr)
 	}
 
-	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, reader.nsStr, reader.logIdStr).Inc()
+	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, reader.logNs, reader.logIdStr).Inc()
 	logger.Ctx(ctx).Debug("staged file reader created successfully",
 		zap.String("filePath", filePath),
 		zap.Int64("currentFileSize", currentSize),
@@ -230,7 +230,7 @@ func (r *StagedFileReaderAdv) tryParseMinioFooterUnsafe(ctx context.Context) err
 		zap.String("footerKey", footerKey))
 
 	// Check if footer exists
-	objSize, _, err := r.storageCli.StatObject(ctx, r.bucket, footerKey, r.nsStr, r.logIdStr)
+	objSize, _, err := r.storageCli.StatObject(ctx, r.bucket, footerKey, r.logNs, r.logIdStr)
 	if err != nil {
 		if minioHandler.IsObjectNotExists(err) {
 			logger.Ctx(ctx).Debug("no compacted footer found in minio",
@@ -244,7 +244,7 @@ func (r *StagedFileReaderAdv) tryParseMinioFooterUnsafe(ctx context.Context) err
 	}
 
 	// Read the entire footer file
-	reader, err := r.storageCli.GetObject(ctx, r.bucket, footerKey, 0, objSize, r.nsStr, r.logIdStr)
+	reader, err := r.storageCli.GetObject(ctx, r.bucket, footerKey, 0, objSize, r.logNs, r.logIdStr)
 	if err != nil {
 		logger.Ctx(ctx).Warn("failed to get footer object from minio",
 			zap.String("footerKey", footerKey),
@@ -853,8 +853,8 @@ func (r *StagedFileReaderAdv) scanForAllBlockInfoUnsafe(ctx context.Context) err
 		zap.Int64("fileSize", currentFileSize),
 		zap.Int64("scannedOffset", currentOffset))
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr, "loadAll", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr, "loadAll", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr, "loadAll", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr, "loadAll", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1044,7 +1044,7 @@ func (r *StagedFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stor
 	}
 
 	if len(entries) == 0 {
-		metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
 		logger.Ctx(ctx).Debug("no entry extracted",
 			zap.String("filePath", r.filePath),
 			zap.Int64("startEntryId", opt.StartEntryID),
@@ -1081,8 +1081,8 @@ func (r *StagedFileReaderAdv) readDataBlocksUnsafe(ctx context.Context, opt stor
 			zap.Any("lastBlockInfo", lastBlockInfo))
 	}
 
-	metrics.WpFileReadBatchBytes.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr).Add(float64(readBytes))
-	metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileReadBatchBytes.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr).Add(float64(readBytes))
+	metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
 
 	// Create batch with proper error handling for nil lastBlockInfo
 	var lastReadState *proto.LastReadState
@@ -1196,7 +1196,7 @@ func (r *StagedFileReaderAdv) Close(ctx context.Context) error {
 	if r.pool != nil {
 		r.pool.Release()
 	}
-	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr).Dec()
+	metrics.WpFileReaders.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr).Dec()
 	logger.Ctx(ctx).Info("segment reader closed", zap.Int64("logId", r.logId), zap.Int64("segId", r.segId))
 	return nil
 }
@@ -1353,8 +1353,8 @@ func (r *StagedFileReaderAdv) readCompactedDataFromMinio(ctx context.Context, op
 		LastReadState: lastReadState,
 	}
 
-	metrics.WpFileReadBatchBytes.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr).Add(float64(readBytes))
-	metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, r.nsStr, r.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileReadBatchBytes.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr).Add(float64(readBytes))
+	metrics.WpFileReadBatchLatency.WithLabelValues(metrics.NodeID, r.logNs, r.logIdStr).Observe(float64(time.Since(startTime).Milliseconds()))
 
 	logger.Ctx(ctx).Info("completed concurrent reading compacted data from minio",
 		zap.Int("entriesCount", len(entries)),
@@ -1445,14 +1445,14 @@ func (r *StagedFileReaderAdv) readBlockFromMinioByKey(ctx context.Context, objKe
 		zap.String("objKey", objKey))
 
 	// Read the block object
-	reader, err := r.storageCli.GetObject(ctx, r.bucket, objKey, 0, objSize, r.nsStr, r.logIdStr)
+	reader, err := r.storageCli.GetObject(ctx, r.bucket, objKey, 0, objSize, r.logNs, r.logIdStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get block object: %w", err)
 	}
 	defer reader.Close()
 
 	// Read all data using ReadObjectFull to ensure consistent metrics tracking
-	blockData, err := minioHandler.ReadObjectFull(ctx, reader, objSize, r.nsStr, r.logIdStr)
+	blockData, err := minioHandler.ReadObjectFull(ctx, reader, objSize, r.logNs, r.logIdStr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read block data: %w", err)
 	}

--- a/server/storage/stagedstorage/segment_impl.go
+++ b/server/storage/stagedstorage/segment_impl.go
@@ -58,7 +58,7 @@ type StagedSegmentImpl struct {
 	segmentFileKey string
 	client         objectstorage.ObjectStorage
 	logIdStr       string // for metrics label only
-	nsStr          string // for metrics namespace label
+	logNs          string // for metrics log_ns label
 }
 
 // NewStagedSegmentImpl is used to create a new Segment, which is used to write data to both local and object storage
@@ -84,7 +84,7 @@ func NewStagedSegmentImpl(ctx context.Context, bucket string, rootPath string, l
 		segmentFileKey:  segmentFileKey,
 		client:          storageCli,
 		logIdStr:        strconv.FormatInt(logId, 10),
-		nsStr:           bucket + "/" + rootPath,
+		logNs:           bucket + "/" + rootPath,
 	}
 	return segmentImpl
 }
@@ -130,11 +130,11 @@ func (rs *StagedSegmentImpl) DeleteFileData(ctx context.Context, flag int) (int,
 
 	// Update metrics
 	if len(allErrors) > 0 {
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr, "delete_segment", "error").Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr, "delete_segment", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr, "delete_segment", "error").Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr, "delete_segment", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 	} else {
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr, "delete_segment", "success").Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr, "delete_segment", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr, "delete_segment", "success").Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr, "delete_segment", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	}
 
 	logger.Ctx(ctx).Info("Completed quorum segment deletion",
@@ -201,7 +201,7 @@ func (rs *StagedSegmentImpl) deleteMinioObjects(ctx context.Context, flag int) (
 			objectsToDelete = append(objectsToDelete, objectToDelete{path: objInfo.FilePath, size: objInfo.Size})
 		}
 		return true // continue walking
-	}, rs.nsStr, rs.logIdStr)
+	}, rs.logNs, rs.logIdStr)
 	if walkErr != nil {
 		logger.Ctx(ctx).Warn("error listing blocks during deletion",
 			zap.String("segmentFileKey", rs.segmentFileKey),
@@ -216,7 +216,7 @@ func (rs *StagedSegmentImpl) deleteMinioObjects(ctx context.Context, flag int) (
 
 	// Delete objects
 	for _, obj := range objectsToDelete {
-		err := rs.client.RemoveObject(ctx, rs.bucket, obj.path, rs.nsStr, rs.logIdStr)
+		err := rs.client.RemoveObject(ctx, rs.bucket, obj.path, rs.logNs, rs.logIdStr)
 		if err != nil {
 			// Log error but continue with other deletions
 			logger.Ctx(ctx).Warn("failed to delete block",
@@ -229,8 +229,8 @@ func (rs *StagedSegmentImpl) deleteMinioObjects(ctx context.Context, flag int) (
 				zap.String("segmentFileKey", rs.segmentFileKey),
 				zap.String("objectKey", obj.path))
 			deletedCount++
-			metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr).Sub(float64(obj.size))
-			metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr).Dec()
+			metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr).Sub(float64(obj.size))
+			metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr).Dec()
 		}
 	}
 
@@ -317,8 +317,8 @@ func (rs *StagedSegmentImpl) deleteLocalFiles(ctx context.Context, flag int) (in
 					zap.String("filePath", filePath))
 				deletedCount++
 				if isDataFile {
-					metrics.WpFileStoredBytes.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr).Sub(float64(fileSize))
-					metrics.WpFileStoredCount.WithLabelValues(metrics.NodeID, rs.nsStr, rs.logIdStr).Dec()
+					metrics.WpFileStoredBytes.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr).Sub(float64(fileSize))
+					metrics.WpFileStoredCount.WithLabelValues(metrics.NodeID, rs.logNs, rs.logIdStr).Dec()
 				}
 			}
 		}

--- a/server/storage/stagedstorage/writer_impl.go
+++ b/server/storage/stagedstorage/writer_impl.go
@@ -72,7 +72,7 @@ type StagedFileWriter struct {
 	segmentId       int64
 	file            *os.File
 	logIdStr        string // for metrics only
-	nsStr           string // for metrics only
+	logNs           string // for metrics only
 
 	// Configuration
 	maxFlushSize     int64 // Max buffer size before triggering sync
@@ -179,7 +179,7 @@ func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath st
 		logId:               logId,
 		segmentId:           segmentId,
 		logIdStr:            strconv.FormatInt(logId, 10),
-		nsStr:               bucket + "/" + rootPath,
+		logNs:               bucket + "/" + rootPath,
 		bucket:              bucket,
 		rootPath:            rootPath,
 		storageCli:          storageCli,
@@ -259,11 +259,11 @@ func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath st
 		logger.Ctx(ctx).Debug("opening file for writing (truncate mode)")
 		file, err = os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 		if err == nil {
-			metrics.WpFileStoredCount.WithLabelValues(metrics.NodeID, writer.nsStr, writer.logIdStr).Inc()
+			metrics.WpFileStoredCount.WithLabelValues(metrics.NodeID, writer.logNs, writer.logIdStr).Inc()
 		}
 	}
 
-	initialBuffer := cache.NewSequentialBuffer(logId, segmentId, startEntryId, writer.maxBufferEntries, writer.nsStr)
+	initialBuffer := cache.NewSequentialBuffer(logId, segmentId, startEntryId, writer.maxBufferEntries, writer.logNs)
 	writer.buffer.Store(initialBuffer)
 
 	if err != nil {
@@ -294,7 +294,7 @@ func NewStagedFileWriterWithMode(ctx context.Context, bucket string, rootPath st
 		zap.Int64("maxBufferEntries", writer.maxBufferEntries),
 		zap.String("bufferInstance", fmt.Sprintf("%p", initialBuffer)))
 
-	metrics.WpFileWriters.WithLabelValues(metrics.NodeID, writer.nsStr, writer.logIdStr).Inc()
+	metrics.WpFileWriters.WithLabelValues(metrics.NodeID, writer.logNs, writer.logIdStr).Inc()
 
 	logger.Ctx(ctx).Info("staged file writer created successfully",
 		zap.String("filePath", filePath),
@@ -357,8 +357,8 @@ func (w *StagedFileWriter) sync(ctx context.Context, allowClosed bool) error {
 		w.startFlushTasksQueueProcessing(ctx)
 	}
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "sync", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "sync", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "sync", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "sync", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 
 	return nil
 }
@@ -404,7 +404,7 @@ func (w *StagedFileWriter) rollBufferAndEnqueueFlushTaskUnsafe(ctx context.Conte
 		return false
 	}
 	restDataFirstEntryId := expectedNextEntryId
-	newBuffer := cache.NewSequentialBufferWithData(w.logId, w.segmentId, restDataFirstEntryId, w.maxBufferEntries, restData, w.nsStr)
+	newBuffer := cache.NewSequentialBufferWithData(w.logId, w.segmentId, restDataFirstEntryId, w.maxBufferEntries, restData, w.logNs)
 
 	// Submit flush task
 	logger.Ctx(ctx).Debug("Submitting flush task to channel",
@@ -441,8 +441,8 @@ func (w *StagedFileWriter) rollBufferAndEnqueueFlushTaskUnsafe(ctx context.Conte
 		return false
 	}
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "rollBuffer", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "rollBuffer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "rollBuffer", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "rollBuffer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return true
 }
 
@@ -582,9 +582,9 @@ func (w *StagedFileWriter) processFlushTask(ctx context.Context, task *blockFlus
 	defer func() {
 		op.End(status)
 		if status == "success" {
-			metrics.WpFileFlushBytesWritten.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Add(float64(actualDataSize))
-			metrics.WpFileFlushLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Observe(float64(time.Since(op.StartedAt()).Milliseconds()))
-			metrics.WpFileStoredBytes.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Add(float64(actualDataSize))
+			metrics.WpFileFlushBytesWritten.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Add(float64(actualDataSize))
+			metrics.WpFileFlushLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Observe(float64(time.Since(op.StartedAt()).Milliseconds()))
+			metrics.WpFileStoredBytes.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Add(float64(actualDataSize))
 		}
 	}()
 
@@ -809,7 +809,7 @@ func (w *StagedFileWriter) notifyFlushError(entries []*cache.BufferEntry, err er
 	// Notify all pending entries result channels in sequential order
 	for _, entry := range entries {
 		if entry.NotifyChan != nil {
-			cache.NotifyPendingEntryDirectly(context.TODO(), w.logId, w.segmentId, entry.EntryId, entry.NotifyChan, entry.EntryId, err, w.nsStr, entry.EnqueueTime)
+			cache.NotifyPendingEntryDirectly(context.TODO(), w.logId, w.segmentId, entry.EntryId, entry.NotifyChan, entry.EntryId, err, w.logNs, entry.EnqueueTime)
 		}
 	}
 }
@@ -819,7 +819,7 @@ func (w *StagedFileWriter) notifyFlushSuccess(entries []*cache.BufferEntry) {
 	// Notify all pending entries result channels in sequential order
 	for _, entry := range entries {
 		if entry.NotifyChan != nil {
-			cache.NotifyPendingEntryDirectly(context.TODO(), w.logId, w.segmentId, entry.EntryId, entry.NotifyChan, entry.EntryId, nil, w.nsStr, entry.EnqueueTime)
+			cache.NotifyPendingEntryDirectly(context.TODO(), w.logId, w.segmentId, entry.EntryId, entry.NotifyChan, entry.EntryId, nil, w.logNs, entry.EnqueueTime)
 		}
 	}
 }
@@ -997,8 +997,8 @@ func (w *StagedFileWriter) Finalize(ctx context.Context, lac int64) (_ int64, re
 		if retErr != nil {
 			status = "error"
 		}
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "finalize", status).Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "finalize", status).Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "finalize", status).Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "finalize", status).Observe(float64(time.Since(startTime).Milliseconds()))
 	}()
 
 	w.finalizeMu.Lock()
@@ -1123,7 +1123,7 @@ func (w *StagedFileWriter) Close(ctx context.Context) error {
 			w.file = nil
 		}
 		close(w.flushTaskChan)
-		metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Dec()
+		metrics.WpFileWriters.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Dec()
 	}()
 
 	logger.Ctx(ctx).Info("Close: trigger sync before close", zap.Int64("logId", w.logId), zap.Int64("segmentId", w.segmentId))
@@ -1140,13 +1140,13 @@ func (w *StagedFileWriter) Close(ctx context.Context) error {
 		logger.Ctx(ctx).Warn("wait flush error before close",
 			zap.String("segmentFilePath", w.segmentFilePath),
 			zap.Error(waitErr))
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "close", "error").Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "close", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "close", "error").Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "close", "error").Observe(float64(time.Since(startTime).Milliseconds()))
 		return waitErr
 	}
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "close", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "close", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "close", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "close", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 	return nil
 }
 
@@ -1160,8 +1160,8 @@ func (w *StagedFileWriter) Fence(ctx context.Context) (_ int64, retErr error) {
 		if retErr != nil {
 			status = "error"
 		}
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "fence", status).Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "fence", status).Observe(float64(time.Since(startTime).Milliseconds()))
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "fence", status).Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "fence", status).Observe(float64(time.Since(startTime).Milliseconds()))
 	}()
 
 	// Mark as fenced first to reject new AppendAsync calls (idempotent)
@@ -1205,8 +1205,8 @@ func (w *StagedFileWriter) Compact(ctx context.Context) (_ int64, retErr error) 
 		}
 		op.End(status)
 		elapsed := float64(time.Since(op.StartedAt()).Milliseconds())
-		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "compact", status).Inc()
-		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "compact", status).Observe(elapsed)
+		metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "compact", status).Inc()
+		metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "compact", status).Observe(elapsed)
 	}()
 
 	w.mu.Lock()
@@ -1559,7 +1559,7 @@ func (w *StagedFileWriter) processMergeTask(ctx context.Context, task *mergeBloc
 	blockKey := w.getCompactedBlockKey(mergedBlockID)
 
 	// Upload merged block to minio
-	err := w.storageCli.PutObject(ctx, w.bucket, blockKey, bytes.NewReader(completeBlockData), int64(len(completeBlockData)), w.nsStr, w.logIdStr)
+	err := w.storageCli.PutObject(ctx, w.bucket, blockKey, bytes.NewReader(completeBlockData), int64(len(completeBlockData)), w.logNs, w.logIdStr)
 	if err != nil {
 		return &mergedBlockUploadResult{
 			error: fmt.Errorf("failed to upload merged block: %w", err),
@@ -1578,10 +1578,10 @@ func (w *StagedFileWriter) processMergeTask(ctx context.Context, task *mergeBloc
 	// Update compaction metrics
 	totalTime := time.Since(startTime)
 	blockSize := int64(len(completeBlockData))
-	metrics.WpFileCompactLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Observe(float64(totalTime.Milliseconds()))
-	metrics.WpFileCompactBytesWritten.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Add(float64(blockSize))
-	metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Add(float64(blockSize))
-	metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Inc()
+	metrics.WpFileCompactLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Observe(float64(totalTime.Milliseconds()))
+	metrics.WpFileCompactBytesWritten.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Add(float64(blockSize))
+	metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Add(float64(blockSize))
+	metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Inc()
 
 	logger.Ctx(ctx).Debug("uploaded merged block",
 		zap.String("segmentFilePath", w.segmentFilePath),
@@ -1658,12 +1658,12 @@ func (w *StagedFileWriter) uploadCompactedFooter(ctx context.Context, blockIndex
 
 	// Upload footer
 	footerKey := w.getFooterBlockKey()
-	err := w.storageCli.PutObject(ctx, w.bucket, footerKey, bytes.NewReader(footerData), int64(len(footerData)), w.nsStr, w.logIdStr)
+	err := w.storageCli.PutObject(ctx, w.bucket, footerKey, bytes.NewReader(footerData), int64(len(footerData)), w.logNs, w.logIdStr)
 	if err != nil {
 		return 0, fmt.Errorf("failed to upload footer: %w", err)
 	}
-	metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Add(float64(len(footerData)))
-	metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr).Inc()
+	metrics.WpObjectStorageStoredBytes.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Add(float64(len(footerData)))
+	metrics.WpObjectStorageStoredObjects.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr).Inc()
 
 	logger.Ctx(ctx).Info("uploaded compacted footer",
 		zap.String("segmentFilePath", w.segmentFilePath),
@@ -1699,7 +1699,7 @@ func (w *StagedFileWriter) readRemoteFooter(ctx context.Context) (*codec.FooterR
 	}
 	footerKey := w.getFooterBlockKey()
 
-	objSize, _, err := w.storageCli.StatObject(ctx, w.bucket, footerKey, w.nsStr, w.logIdStr)
+	objSize, _, err := w.storageCli.StatObject(ctx, w.bucket, footerKey, w.logNs, w.logIdStr)
 	if err != nil {
 		if w.storageCli.IsObjectNotExistsError(err) {
 			return nil, 0, nil
@@ -1707,7 +1707,7 @@ func (w *StagedFileWriter) readRemoteFooter(ctx context.Context) (*codec.FooterR
 		return nil, 0, fmt.Errorf("stat footer object: %w", err)
 	}
 
-	reader, err := w.storageCli.GetObject(ctx, w.bucket, footerKey, 0, objSize, w.nsStr, w.logIdStr)
+	reader, err := w.storageCli.GetObject(ctx, w.bucket, footerKey, 0, objSize, w.logNs, w.logIdStr)
 	if err != nil {
 		return nil, 0, fmt.Errorf("get footer object: %w", err)
 	}
@@ -1908,8 +1908,8 @@ func (w *StagedFileWriter) recoverBlocksFromFooterUnsafe(ctx context.Context, fi
 		zap.Int64("firstEntryID", w.firstEntryID.Load()),
 		zap.Int64("lastEntryID", w.lastEntryID.Load()))
 
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "recover_footer", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "recover_footer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_footer", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_footer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 
 	w.recovered.Store(true)
 	return nil
@@ -2051,8 +2051,8 @@ exitLoop:
 	}
 
 	// update metrics
-	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "recover_raw", "success").Inc()
-	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.nsStr, w.logIdStr, "recover_raw", "success").Observe(float64(time.Since(startTime).Milliseconds()))
+	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_raw", "success").Inc()
+	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_raw", "success").Observe(float64(time.Since(startTime).Milliseconds()))
 
 	return nil
 }

--- a/tests/docker/monitor/grafana/templates/dashboard_client.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_client.json
@@ -548,6 +548,117 @@
       ],
       "title": "Segment State Count by Log",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 16,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Log ID",
+            "desc": false
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "woodpecker_client_active_segment_node{log_ns=~\"$log_ns\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Segment → Nodes (by Log)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "Value": true
+            },
+            "renameByName": {
+              "log_id": "Log ID",
+              "segment_id": "Segment ID",
+              "node": "Node"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count by (node) (woodpecker_client_active_segment_node{log_ns=~\"$log_ns\"})",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Segments per Node",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/tests/docker/monitor/grafana/templates/dashboard_client.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_client.json
@@ -659,6 +659,178 @@
       ],
       "title": "Active Segments per Node",
       "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 8,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 42
+          },
+          "id": 9,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(grpc_server_started_total[1m])) by (grpc_method)",
+              "legendFormat": "method={{grpc_method}}",
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Request Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 42
+          },
+          "id": 10,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(grpc_server_handled_total{grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
+              "legendFormat": "method={{grpc_method}} code={{grpc_code}}",
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Error Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 42
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket[1m])) by (grpc_method, le))",
+              "legendFormat": "method={{grpc_method}} P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket[1m])) by (grpc_method, le))",
+              "legendFormat": "method={{grpc_method}} P99",
+              "refId": "B"
+            }
+          ],
+          "title": "gRPC Latency P50/P99",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Transport Layer — gRPC",
+      "type": "row"
     }
   ],
   "refresh": "5s",

--- a/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
@@ -660,6 +660,178 @@
       ],
       "title": "Active Segments per Node",
       "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "id": 8,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 42
+          },
+          "id": 9,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(grpc_server_started_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method)",
+              "legendFormat": "method={{grpc_method}}",
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Request Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 42
+          },
+          "id": 10,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
+              "legendFormat": "method={{grpc_method}} code={{grpc_code}}",
+              "refId": "A"
+            }
+          ],
+          "title": "gRPC Error Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 42
+          },
+          "id": 11,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+              "legendFormat": "method={{grpc_method}} P50",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+              "legendFormat": "method={{grpc_method}} P99",
+              "refId": "B"
+            }
+          ],
+          "title": "gRPC Latency P50/P99",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Transport Layer — gRPC",
+      "type": "row"
     }
   ],
   "refresh": "5s",

--- a/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
@@ -548,6 +548,118 @@
       ],
       "title": "Segment State Count by Log",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 33
+      },
+      "id": 16,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "displayName": "Log ID",
+            "desc": false
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "woodpecker_client_active_segment_node{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Segment → Nodes (by Log)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true,
+              "namespace": true,
+              "cluster": true,
+              "Value": true
+            },
+            "renameByName": {
+              "log_id": "Log ID",
+              "segment_id": "Segment ID",
+              "node": "Node"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count by (node) (woodpecker_client_active_segment_node{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"})",
+          "legendFormat": "{{node}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Segments per Node",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
+++ b/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
@@ -3436,6 +3436,118 @@ data:
           ],
           "title": "Segment State Count by Log",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto"
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 33
+          },
+          "id": 16,
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Log ID",
+                "desc": false
+              }
+            ]
+          },
+          "targets": [
+            {
+              "expr": "woodpecker_client_active_segment_node{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Active Segment → Nodes (by Log)",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true,
+                  "instance": true,
+                  "job": true,
+                  "namespace": true,
+                  "cluster": true,
+                  "Value": true
+                },
+                "renameByName": {
+                  "log_id": "Log ID",
+                  "segment_id": "Segment ID",
+                  "node": "Node"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 33
+          },
+          "id": 17,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "count by (node) (woodpecker_client_active_segment_node{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"})",
+              "legendFormat": "{{node}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Active Segments per Node",
+          "type": "timeseries"
         }
       ],
       "refresh": "5s",

--- a/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
+++ b/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
@@ -3548,6 +3548,178 @@ data:
           ],
           "title": "Active Segments per Node",
           "type": "timeseries"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 41
+          },
+          "id": 8,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 42
+              },
+              "id": 9,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(grpc_server_started_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method)",
+                  "legendFormat": "method={{grpc_method}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "gRPC Request Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 42
+              },
+              "id": 10,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
+                  "legendFormat": "method={{grpc_method}} code={{grpc_code}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "gRPC Error Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 42
+              },
+              "id": 11,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+                  "legendFormat": "method={{grpc_method}} P50",
+                  "refId": "A"
+                },
+                {
+                  "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+                  "legendFormat": "method={{grpc_method}} P99",
+                  "refId": "B"
+                }
+              ],
+              "title": "gRPC Latency P50/P99",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Transport Layer — gRPC",
+          "type": "row"
         }
       ],
       "refresh": "5s",

--- a/woodpecker/log/internal_log_writer.go
+++ b/woodpecker/log/internal_log_writer.go
@@ -49,7 +49,7 @@ type internalLogWriterImpl struct {
 	logHandle          LogHandle
 	auditorMaxInterval int
 	cfg                *config.Configuration
-	metricsNamespace   string
+	logNs              string
 	writerClose        chan struct{}
 	cleanupManager     segment.SegmentCleanupManager
 
@@ -71,7 +71,7 @@ func NewInternalLogWriter(ctx context.Context, logHandle LogHandle, cfg *config.
 		logHandle:          logHandle,
 		auditorMaxInterval: cfg.Woodpecker.Client.Auditor.MaxInterval.Seconds(),
 		cfg:                cfg,
-		metricsNamespace:   metrics.BuildMetricsNamespace(cfg.Minio.BucketName, cfg.Minio.RootPath),
+		logNs:              metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath),
 		writerClose:        make(chan struct{}, 1),
 		cleanupManager:     segment.NewSegmentCleanupManager(cfg.Minio.BucketName, cfg.Minio.RootPath, logHandle.GetMetadataProvider(), logHandle.(*logHandleImpl).ClientPool),
 	}
@@ -100,7 +100,7 @@ func (l *internalLogWriterImpl) Write(ctx context.Context, msg *WriteMessage) *W
 	if !l.isWriterValid.Load() {
 		logger.Ctx(ctx).Warn("Writer lock session has expired",
 			zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()))
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return &WriteResult{
 			LogMessageId: nil,
 			Err:          werr.ErrLogWriterLockLost.WithCauseErrMsg("writer lock session has expired"),
@@ -129,13 +129,13 @@ func (l *internalLogWriterImpl) Write(ctx context.Context, msg *WriteMessage) *W
 	writableSegmentHandle, err := l.logHandle.GetOrCreateWritableSegmentHandle(ctx, l.onWriterInvalidated)
 	if err != nil {
 		callback(-1, -1, err)
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return <-ch
 	}
 	bytes, err := MarshalMessage(msg)
 	if err != nil {
 		logger.Ctx(ctx).Warn("serialize message failed", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Error(err))
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return &WriteResult{
 			LogMessageId: nil,
 			Err:          err,
@@ -147,15 +147,15 @@ func (l *internalLogWriterImpl) Write(ctx context.Context, msg *WriteMessage) *W
 
 	// Update metrics based on result
 	if result.Err != nil {
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
 		if werr.ErrSegmentHandleSegmentRolling.Is(result.Err) {
 			logger.Ctx(ctx).Info("write to rolling segment rejected, retry later", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.String("detail", result.Err.Error()))
 		} else {
 			logger.Ctx(ctx).Warn("write log entry failed", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Error(result.Err))
 		}
 	} else {
-		metrics.WpLogWriterBytesWritten.WithLabelValues(l.metricsNamespace, l.logIdStr).Add(float64(len(bytes)))
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write", "success").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterBytesWritten.WithLabelValues(l.logNs, l.logIdStr).Add(float64(len(bytes)))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "success").Observe(float64(time.Since(start).Milliseconds()))
 	}
 
 	return result
@@ -169,7 +169,7 @@ func (l *internalLogWriterImpl) WriteAsync(ctx context.Context, msg *WriteMessag
 
 	// Check if session is valid
 	if !l.isWriterValid.Load() {
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
 		ch <- &WriteResult{
 			LogMessageId: nil,
 			Err:          werr.ErrLogWriterLockLost.WithCauseErrMsg("writer lock session has expired"),
@@ -182,7 +182,7 @@ func (l *internalLogWriterImpl) WriteAsync(ctx context.Context, msg *WriteMessag
 	bytes, err := MarshalMessage(msg)
 	if err != nil {
 		logger.Ctx(ctx).Warn("serialize message failed", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Error(err))
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
 		ch <- &WriteResult{
 			LogMessageId: nil,
 			Err:          err,
@@ -194,10 +194,10 @@ func (l *internalLogWriterImpl) WriteAsync(ctx context.Context, msg *WriteMessag
 	callback := func(segmentId int64, entryId int64, err error) {
 		logger.Ctx(ctx).Debug("write log entry callback exec", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Int64("segId", segmentId), zap.Int64("entryId", entryId), zap.Error(err))
 		if err == nil {
-			metrics.WpLogWriterBytesWritten.WithLabelValues(l.metricsNamespace, l.logIdStr).Add(float64(len(bytes)))
-			metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write_async", "success").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogWriterBytesWritten.WithLabelValues(l.logNs, l.logIdStr).Add(float64(len(bytes)))
+			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write_async", "success").Observe(float64(time.Since(start).Milliseconds()))
 		} else {
-			metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
 		}
 		// Invalidate the writer BEFORE delivering the result so that subsequent Writes
 		// observe isWriterValid=false and fail fast.
@@ -327,7 +327,7 @@ func (l *internalLogWriterImpl) runAuditor() {
 			sp.End()
 
 			// Track auditor latency
-			metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "auditor_run", "success").Observe(float64(auditDuration.Milliseconds()))
+			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "auditor_run", "success").Observe(float64(auditDuration.Milliseconds()))
 		case <-l.writerClose:
 			logger.Ctx(context.TODO()).Info("Log auditor stopped",
 				zap.String("logName", l.logHandle.GetName()),
@@ -529,14 +529,14 @@ func (l *internalLogWriterImpl) cleanupTruncatedSegmentsIfNecessary(ctx context.
 				zap.Int64("logId", logId),
 				zap.Int64("segmentId", segmentId),
 				zap.Error(err))
-			metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "cleanup_segment", "error").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "cleanup_segment", "error").Observe(float64(time.Since(start).Milliseconds()))
 			failureCount++
 		} else {
 			logger.Ctx(ctx).Info("Finish segment cleanup",
 				zap.String("logName", logName),
 				zap.Int64("logId", logId),
 				zap.Int64("segmentId", segmentId))
-			metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "cleanup_segment", "success").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "cleanup_segment", "success").Observe(float64(time.Since(start).Milliseconds()))
 			successCount++
 		}
 	}
@@ -580,7 +580,7 @@ func (l *internalLogWriterImpl) Close(ctx context.Context) error {
 		}
 
 		logger.Ctx(ctx).Info("log writer closed", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()))
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "close", status).Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "close", status).Observe(float64(time.Since(start).Milliseconds()))
 		result = werr.Combine(closeErr, closeLogHandleErr)
 	})
 	return result

--- a/woodpecker/log/log_handle.go
+++ b/woodpecker/log/log_handle.go
@@ -99,7 +99,7 @@ type logHandleImpl struct {
 	lastRolloverTimeMs int64
 	rollingPolicy      segment.RollingPolicy
 	cfg                *config.Configuration
-	metricsNamespace   string
+	logNs              string
 
 	// Background cleanup goroutine management
 	ctx         context.Context
@@ -139,7 +139,7 @@ func NewLogHandle(name string, logId int64, segments map[int64]*meta.SegmentMeta
 		lastRolloverTimeMs:  -1,
 		rollingPolicy:       defaultRollingPolicy,
 		cfg:                 cfg,
-		metricsNamespace:    metrics.BuildMetricsNamespace(cfg.Minio.BucketName, cfg.Minio.RootPath),
+		logNs:               metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath),
 		ctx:                 ctx,
 		cancel:              cancel,
 		cleanupDone:         make(chan struct{}),
@@ -175,13 +175,13 @@ func (l *logHandleImpl) GetSegments(ctx context.Context) (map[int64]*meta.Segmen
 	logIdStr := strconv.FormatInt(l.Id, 10)
 	result, err := l.Metadata.GetAllSegmentMetadata(ctx, l.Name)
 	if err != nil {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "get_segments", "error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "get_segments", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "get_segments", "error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "get_segments", "error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("failed to get segments", zap.String("logName", l.Name), zap.Int64("logId", l.Id), zap.Error(err))
 		return nil, err
 	}
-	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "get_segments", "success").Inc()
-	metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "get_segments", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "get_segments", "success").Inc()
+	metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "get_segments", "success").Observe(float64(time.Since(start).Milliseconds()))
 	return result, err
 }
 
@@ -219,8 +219,8 @@ func (l *logHandleImpl) openLogWriterWithDistributedLocks(ctx context.Context) (
 
 	sessionLock, acquireLockErr := l.Metadata.AcquireLogWriterLock(ctx, l.Name)
 	if acquireLockErr != nil {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_writer", "lock_error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_writer", "lock_error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "open_log_writer", "lock_error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "open_log_writer", "lock_error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("failed to acquire log writer lock", zap.String("logName", l.Name), zap.Int64("logId", l.Id), zap.Error(acquireLockErr))
 		return nil, acquireLockErr
 	}
@@ -235,15 +235,15 @@ func (l *logHandleImpl) openLogWriterWithDistributedLocks(ctx context.Context) (
 				zap.Int64("logId", l.Id),
 				zap.Error(releaseErr))
 		}
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_writer", "fence_error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_writer", "fence_error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "open_log_writer", "fence_error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "open_log_writer", "fence_error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("failed to fence all active segments", zap.String("logName", l.Name), zap.Int64("logId", l.Id), zap.Error(err))
 		return nil, err
 	}
 
 	// return LogWriter instance if writableSegmentHandle is created
-	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_writer", "success").Inc()
-	metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_writer", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "open_log_writer", "success").Inc()
+	metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "open_log_writer", "success").Observe(float64(time.Since(start).Milliseconds()))
 	logger.Ctx(ctx).Info("open log writer success", zap.String("logName", l.Name), zap.Int64("logId", l.Id))
 	return NewLogWriter(ctx, l, l.cfg, sessionLock), nil
 }
@@ -258,15 +258,15 @@ func (l *logHandleImpl) openInternalLogWriter(ctx context.Context) (LogWriter, e
 	// Fence all active segments to prevent split-brain scenarios
 	err := l.fenceAllActiveSegments(ctx)
 	if err != nil {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_writer", "fence_error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_writer", "fence_error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "open_log_writer", "fence_error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "open_log_writer", "fence_error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("failed to fence all active segments", zap.String("logName", l.Name), zap.Int64("logId", l.Id), zap.Error(err))
 		return nil, err
 	}
 
 	// return LogWriter instance if writableSegmentHandle is created
-	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_writer", "success").Inc()
-	metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_writer", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "open_log_writer", "success").Inc()
+	metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "open_log_writer", "success").Observe(float64(time.Since(start).Milliseconds()))
 	logger.Ctx(ctx).Info("open log writer success", zap.String("logName", l.Name), zap.Int64("logId", l.Id))
 	return NewInternalLogWriter(ctx, l, l.cfg), nil
 }
@@ -510,22 +510,22 @@ func (l *logHandleImpl) GetRecoverableSegmentHandle(ctx context.Context, segment
 
 	s, err := l.GetExistsReadonlySegmentHandle(ctx, segmentId)
 	if err != nil {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "get_recoverable_segment", "error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "get_recoverable_segment", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "get_recoverable_segment", "error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "get_recoverable_segment", "error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("get recoverable segment handle failed", zap.String("logName", l.Name), zap.Int64("logId", l.Id), zap.Int64("segmentId", segmentId), zap.Error(err))
 		return nil, err
 	}
 	if s == nil {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "get_recoverable_segment", "error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "get_recoverable_segment", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "get_recoverable_segment", "error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "get_recoverable_segment", "error").Observe(float64(time.Since(start).Milliseconds()))
 		errMsg := fmt.Sprintf("segment not found for logName:%s segmentId:%d,it may have been deleted", l.Name, segmentId)
 		getSegErr := werr.ErrSegmentNotFound.WithCauseErrMsg(errMsg)
 		logger.Ctx(ctx).Warn("get exists read only segment handle failed", zap.String("logName", l.Name), zap.Int64("logId", l.Id), zap.Int64("segmentId", segmentId), zap.Error(getSegErr))
 		return nil, getSegErr
 	}
 
-	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "get_recoverable_segment", "success").Inc()
-	metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "get_recoverable_segment", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "get_recoverable_segment", "success").Inc()
+	metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "get_recoverable_segment", "success").Observe(float64(time.Since(start).Milliseconds()))
 	return s, nil
 }
 
@@ -703,14 +703,14 @@ func (l *logHandleImpl) OpenLogReader(ctx context.Context, from *LogMessageId, r
 				zap.String("readerName", readerName),
 				zap.Error(closeErr))
 		}
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_reader", "error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_reader", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "open_log_reader", "error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "open_log_reader", "error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("open log reader failed", zap.String("logName", l.Name), zap.Int64("logId", l.Id), zap.Int64("segmentId", startPoint.SegmentId), zap.Int64("entryId", startPoint.EntryId), zap.String("readerName", readerName), zap.Error(err))
 		return nil, werr.ErrLogReaderTempInfoError.WithCauseErr(err)
 	}
 
-	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_reader", "success").Inc()
-	metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "open_log_reader", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "open_log_reader", "success").Inc()
+	metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "open_log_reader", "success").Observe(float64(time.Since(start).Milliseconds()))
 	logger.Ctx(ctx).Info("open log reader success", zap.String("logName", l.Name), zap.Int64("logId", l.Id), zap.Int64("segmentId", startPoint.SegmentId), zap.Int64("entryId", startPoint.EntryId), zap.String("readerName", readerName))
 	return r, nil
 }
@@ -733,8 +733,8 @@ func (l *logHandleImpl) Truncate(ctx context.Context, recordId *LogMessageId) er
 	// 1. Get current LogMeta
 	logMeta, err := l.Metadata.GetLogMeta(ctx, l.Name)
 	if err != nil {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "truncate", "error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "truncate", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return werr.ErrLogHandleTruncateFailed.WithCauseErr(err)
 	}
 
@@ -748,8 +748,8 @@ func (l *logHandleImpl) Truncate(ctx context.Context, recordId *LogMessageId) er
 			zap.Int64("currentTruncEntryId", logMeta.Metadata.TruncatedEntryId),
 			zap.Int64("requestedTruncSegId", recordId.SegmentId),
 			zap.Int64("requestedTruncEntryId", recordId.EntryId))
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "behind_current").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "success").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "truncate", "behind_current").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "truncate", "success").Observe(float64(time.Since(start).Milliseconds()))
 		return nil
 	}
 
@@ -758,12 +758,12 @@ func (l *logHandleImpl) Truncate(ctx context.Context, recordId *LogMessageId) er
 	if err != nil {
 		if werr.ErrSegmentNotFound.Is(err) {
 			logger.Ctx(ctx).Warn("Requested truncation point does not exist, skip", zap.String("logName", l.Name), zap.Int64("logId", l.Id))
-			metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "segment_not_found").Inc()
-			metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "error").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "truncate", "segment_not_found").Inc()
+			metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "truncate", "error").Observe(float64(time.Since(start).Milliseconds()))
 			return nil
 		}
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "segment_error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "truncate", "segment_error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "truncate", "error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("Requested truncation failed", zap.String("logName", l.Name), zap.Int64("logId", l.Id))
 		return werr.ErrLogHandleTruncateFailed.WithCauseErr(err)
 	}
@@ -777,8 +777,8 @@ func (l *logHandleImpl) Truncate(ctx context.Context, recordId *LogMessageId) er
 			zap.Int64("currentTruncEntryId", logMeta.Metadata.TruncatedEntryId),
 			zap.Int64("requestedTruncSegId", recordId.SegmentId),
 			zap.Int64("requestedTruncEntryId", recordId.EntryId))
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "invalid_entry_id").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "truncate", "invalid_entry_id").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "truncate", "error").Observe(float64(time.Since(start).Milliseconds()))
 		invalidErr := werr.ErrLogHandleTruncateFailed.WithCauseErrMsg(
 			fmt.Sprintf("truncation entry ID %d exceeds last entry ID %d for segment %d",
 				recordId.EntryId, segMeta.Metadata.LastEntryId, recordId.SegmentId))
@@ -793,8 +793,8 @@ func (l *logHandleImpl) Truncate(ctx context.Context, recordId *LogMessageId) er
 	// 6. Store the updated metadata
 	err = l.Metadata.UpdateLogMeta(ctx, l.Name, logMeta)
 	if err != nil {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "update_error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "truncate", "update_error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "truncate", "error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("Request truncation failed",
 			zap.String("logName", l.Name),
 			zap.Int64("currentTruncSegId", logMeta.Metadata.TruncatedSegmentId),
@@ -811,8 +811,8 @@ func (l *logHandleImpl) Truncate(ctx context.Context, recordId *LogMessageId) er
 		zap.Int64("truncatedSegmentId", recordId.SegmentId),
 		zap.Int64("truncatedEntryId", recordId.EntryId))
 
-	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "success").Inc()
-	metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "truncate", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "truncate", "success").Inc()
+	metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "truncate", "success").Observe(float64(time.Since(start).Milliseconds()))
 	return nil
 }
 
@@ -825,16 +825,16 @@ func (l *logHandleImpl) CheckAndSetSegmentTruncatedIfNeed(ctx context.Context) e
 	// 1. Get current LogMeta
 	logMeta, err := l.Metadata.GetLogMeta(ctx, l.Name)
 	if err != nil {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "check_segment_truncated", "error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "check_segment_truncated", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "check_segment_truncated", "error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "check_segment_truncated", "error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("check segment truncated state failed", zap.String("logName", l.Name), zap.Int64("logId", l.Id), zap.Error(err))
 		return werr.ErrLogHandleTruncateFailed.WithCauseErr(err)
 	}
 
 	// 2. Check if the requested truncation point is set
 	if logMeta.Metadata.TruncatedSegmentId <= 0 {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "check_segment_truncated", "error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "check_segment_truncated", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "check_segment_truncated", "error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "check_segment_truncated", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return nil
 	}
 
@@ -842,8 +842,8 @@ func (l *logHandleImpl) CheckAndSetSegmentTruncatedIfNeed(ctx context.Context) e
 	// Get all segments that are before the truncation point
 	segments, err := l.GetSegments(ctx)
 	if err != nil {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "check_segment_truncated", "error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "check_segment_truncated", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "check_segment_truncated", "error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "check_segment_truncated", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return werr.ErrLogHandleTruncateFailed.WithCauseErr(err)
 	}
 
@@ -885,8 +885,8 @@ func (l *logHandleImpl) CheckAndSetSegmentTruncatedIfNeed(ctx context.Context) e
 			zap.Int64("segmentId", segId))
 	}
 
-	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "check_segment_truncated", "success").Inc()
-	metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "check_segment_truncated", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "check_segment_truncated", "success").Inc()
+	metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "check_segment_truncated", "success").Observe(float64(time.Since(start).Milliseconds()))
 	return nil
 }
 
@@ -957,14 +957,14 @@ func (l *logHandleImpl) GetTruncatedRecordId(ctx context.Context) (*LogMessageId
 	// fetch the latest metadata
 	logMeta, err := l.Metadata.GetLogMeta(ctx, l.Name)
 	if err != nil {
-		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "get_truncated_record_id", "error").Inc()
-		metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "get_truncated_record_id", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "get_truncated_record_id", "error").Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "get_truncated_record_id", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return nil, werr.ErrLogHandleGetTruncationPointFailed.WithCauseErr(err)
 	}
 
 	// Return the truncation point
-	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.metricsNamespace, logIdStr, "get_truncated_record_id", "success").Inc()
-	metrics.WpLogHandleOperationLatency.WithLabelValues(l.metricsNamespace, logIdStr, "get_truncated_record_id", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "get_truncated_record_id", "success").Inc()
+	metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "get_truncated_record_id", "success").Observe(float64(time.Since(start).Milliseconds()))
 	return &LogMessageId{
 		SegmentId: logMeta.Metadata.TruncatedSegmentId,
 		EntryId:   logMeta.Metadata.TruncatedEntryId,

--- a/woodpecker/log/log_reader.go
+++ b/woodpecker/log/log_reader.go
@@ -54,13 +54,13 @@ var _ LogReader = (*logBatchReaderImpl)(nil)
 
 // An efficient reader that loads fragments and yields elements one by one during traversal.
 type logBatchReaderImpl struct {
-	logName          string
-	logId            int64
-	logIdStr         string // for metrics label only
-	logHandle        LogHandle
-	from             *LogMessageId
-	readerName       string
-	metricsNamespace string
+	logName    string
+	logId      int64
+	logIdStr   string // for metrics label only
+	logHandle  LogHandle
+	from       *LogMessageId
+	readerName string
+	logNs      string
 
 	pendingReadSegmentId int64
 	pendingReadEntryId   int64
@@ -81,7 +81,7 @@ func NewLogBatchReader(ctx context.Context, logHandle LogHandle, segmentHandle s
 		pendingReadSegmentId: from.SegmentId,
 		pendingReadEntryId:   from.EntryId,
 		readerName:           readerName,
-		metricsNamespace:     metrics.BuildMetricsNamespace(cfg.Minio.BucketName, cfg.Minio.RootPath),
+		logNs:                metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath),
 		batch:                nil,
 		next:                 0,
 		lastRead:             time.Now().UnixMilli(),
@@ -99,7 +99,7 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 	start := time.Now()
 
 	if l.logHandle == nil {
-		metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return nil, werr.ErrInternalError.WithCauseErrMsg("log handle is not initialized")
 	}
 
@@ -111,7 +111,7 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 		// Check if context is done
 		select {
 		case <-ctx.Done():
-			metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "cancel").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "cancel").Observe(float64(time.Since(start).Milliseconds()))
 			return nil, ctx.Err()
 		default:
 			// Continue with read operation
@@ -122,7 +122,7 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 			readEntryData := l.batch.Entries[l.next]
 			logMsg, err := l.unmarshalAndCreateLogMessage(ctx, readEntryData.Values, readEntryData.SegId, readEntryData.EntryId)
 			if err != nil {
-				metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
+				metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
 				// clear cache to avoid re-processing corrupted data
 				l.batch = nil
 				l.next = 0
@@ -131,10 +131,10 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 			l.pendingReadEntryId += 1
 			l.next += 1
 			l.lastRead = time.Now().UnixMilli() // Update last read timestamp
-			metrics.WpClientReadEntriesTotal.WithLabelValues(l.metricsNamespace, l.logIdStr).Inc()
-			metrics.WpLogReaderBytesRead.WithLabelValues(l.metricsNamespace, l.logIdStr, l.readerName).Add(float64(len(readEntryData.Values)))
-			metrics.WpClientReadLatency.WithLabelValues(l.metricsNamespace, l.logIdStr).Observe(float64(time.Since(start).Milliseconds()))
-			metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "success").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpClientReadEntriesTotal.WithLabelValues(l.logNs, l.logIdStr).Inc()
+			metrics.WpLogReaderBytesRead.WithLabelValues(l.logNs, l.logIdStr, l.readerName).Add(float64(len(readEntryData.Values)))
+			metrics.WpClientReadLatency.WithLabelValues(l.logNs, l.logIdStr).Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "success").Observe(float64(time.Since(start).Milliseconds()))
 			return logMsg, nil
 		}
 
@@ -143,14 +143,14 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 		if err != nil && werr.ErrSegmentNotFound.Is(err) {
 			// segment not found, wait and try again
 			if waitErr := l.waitWithContext(ctx); waitErr != nil {
-				metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "cancel").Observe(float64(time.Since(start).Milliseconds()))
+				metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "cancel").Observe(float64(time.Since(start).Milliseconds()))
 				return nil, waitErr
 			}
 			continue
 		}
 		if err != nil {
 			// A segment reading error is returned to the application caller, who should decide whether to attempt the call again
-			metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
 			return nil, werr.ErrLogReaderReadFailed.WithCauseErr(err)
 		}
 
@@ -169,7 +169,7 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 			lastReadState = l.batch.LastReadState
 		}
 		batchResult, readBatchErr := segHandle.ReadBatchAdv(ctx, entryId, DefaultBatchEntriesLimit, lastReadState)
-		metrics.WpClientReadRequestsTotal.WithLabelValues(l.metricsNamespace, l.logIdStr).Inc()
+		metrics.WpClientReadRequestsTotal.WithLabelValues(l.logNs, l.logIdStr).Inc()
 		if readBatchErr != nil {
 			// Check if it's end of file error - this is the only reliable way to know segment is finished
 			if werr.ErrFileReaderEndOfFile.Is(readBatchErr) {
@@ -183,14 +183,14 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 			if werr.ErrEntryNotFound.Is(readBatchErr) {
 				// just wait and retry
 				if waitErr := l.waitWithContext(ctx); waitErr != nil {
-					metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "cancel").Observe(float64(time.Since(start).Milliseconds()))
+					metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "cancel").Observe(float64(time.Since(start).Milliseconds()))
 					return nil, waitErr
 				}
 				continue
 			}
 
 			// For other errors, return them directly
-			metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
 			logger.Ctx(ctx).Warn("read entries error", zap.String("logName", l.logName), zap.Int64("logId", l.logId), zap.Int64("segmentId", segId), zap.Int64("entryId", entryId), zap.Error(readBatchErr))
 			return nil, readBatchErr
 		}
@@ -203,7 +203,7 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 		oneEntry := l.batch.Entries[l.next]
 		logMsg, err := l.unmarshalAndCreateLogMessage(ctx, oneEntry.Values, segId, entryId)
 		if err != nil {
-			metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
 			// clear cache to avoid re-processing corrupted data
 			l.batch = nil
 			l.next = 0
@@ -217,10 +217,10 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 		l.lastRead = time.Now().UnixMilli() // Update last read timestamp
 
 		// update metrics
-		metrics.WpClientReadEntriesTotal.WithLabelValues(l.metricsNamespace, l.logIdStr).Inc()
-		metrics.WpLogReaderBytesRead.WithLabelValues(l.metricsNamespace, l.logIdStr, l.readerName).Add(float64(len(oneEntry.Values)))
-		metrics.WpClientReadLatency.WithLabelValues(l.metricsNamespace, l.logIdStr).Observe(float64(time.Since(start).Milliseconds()))
-		metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "read_next", "success").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpClientReadEntriesTotal.WithLabelValues(l.logNs, l.logIdStr).Inc()
+		metrics.WpLogReaderBytesRead.WithLabelValues(l.logNs, l.logIdStr, l.readerName).Add(float64(len(oneEntry.Values)))
+		metrics.WpClientReadLatency.WithLabelValues(l.logNs, l.logIdStr).Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "success").Observe(float64(time.Since(start).Milliseconds()))
 		return logMsg, nil
 	}
 }
@@ -241,7 +241,7 @@ func (l *logBatchReaderImpl) Close(ctx context.Context) error {
 		status = "error"
 	}
 
-	metrics.WpLogReaderOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "close", status).Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "close", status).Observe(float64(time.Since(start).Milliseconds()))
 	return err
 }
 

--- a/woodpecker/log/log_reader_test.go
+++ b/woodpecker/log/log_reader_test.go
@@ -188,9 +188,9 @@ func TestLogReader_GetName(t *testing.T) {
 
 func TestLogReader_ReadNext_NilLogHandle(t *testing.T) {
 	reader := &logBatchReaderImpl{
-		logHandle:        nil,
-		logIdStr:         "1",
-		metricsNamespace: "",
+		logHandle: nil,
+		logIdStr:  "1",
+		logNs:     "",
 	}
 
 	ctx := context.Background()
@@ -212,7 +212,7 @@ func TestLogReader_ReadNext_ContextCancelled(t *testing.T) {
 		pendingReadSegmentId: 0,
 		pendingReadEntryId:   0,
 		readerName:           "test-reader",
-		metricsNamespace:     "",
+		logNs:                "",
 		batch:                nil,
 		next:                 0,
 		lastRead:             time.Now().UnixMilli(),
@@ -247,7 +247,7 @@ func TestLogReader_ReadNext_FromCachedBatch(t *testing.T) {
 		pendingReadSegmentId: 0,
 		pendingReadEntryId:   0,
 		readerName:           "test-reader",
-		metricsNamespace:     "",
+		logNs:                "",
 		batch: &proto.BatchReadResult{
 			Entries: []*proto.LogEntry{
 				{SegId: 0, EntryId: 0, Values: data},
@@ -282,7 +282,7 @@ func TestLogReader_ReadNext_CachedBatchCorruptedData(t *testing.T) {
 		pendingReadSegmentId: 0,
 		pendingReadEntryId:   0,
 		readerName:           "test-reader",
-		metricsNamespace:     "",
+		logNs:                "",
 		batch: &proto.BatchReadResult{
 			Entries: []*proto.LogEntry{
 				{SegId: 0, EntryId: 0, Values: []byte("corrupted data that is not protobuf")},
@@ -325,7 +325,7 @@ func TestLogReader_ReadNext_FreshBatchRead(t *testing.T) {
 		pendingReadEntryId:   0,
 		currentSegmentHandle: mockSegHandle,
 		readerName:           "test-reader",
-		metricsNamespace:     "",
+		logNs:                "",
 		batch:                nil,
 		next:                 0,
 		lastRead:             time.Now().UnixMilli(),
@@ -386,7 +386,7 @@ func TestLogReader_ReadNext_SegmentEOF_MovesToNextSegment(t *testing.T) {
 		pendingReadEntryId:   5,
 		currentSegmentHandle: mockSegHandle0,
 		readerName:           "test-reader",
-		metricsNamespace:     "",
+		logNs:                "",
 		batch:                nil,
 		next:                 0,
 		lastRead:             time.Now().UnixMilli(),
@@ -998,12 +998,12 @@ func TestLogReader_Close(t *testing.T) {
 		mockMetadata := mocks_meta.NewMetadataProvider(t)
 
 		reader := &logBatchReaderImpl{
-			logName:          "test-log",
-			logId:            1,
-			logIdStr:         "1",
-			logHandle:        mockLogHandle,
-			readerName:       "test-reader",
-			metricsNamespace: "",
+			logName:    "test-log",
+			logId:      1,
+			logIdStr:   "1",
+			logHandle:  mockLogHandle,
+			readerName: "test-reader",
+			logNs:      "",
 		}
 
 		mockLogHandle.On("GetMetadataProvider").Return(mockMetadata)
@@ -1020,12 +1020,12 @@ func TestLogReader_Close(t *testing.T) {
 		mockMetadata := mocks_meta.NewMetadataProvider(t)
 
 		reader := &logBatchReaderImpl{
-			logName:          "test-log",
-			logId:            1,
-			logIdStr:         "1",
-			logHandle:        mockLogHandle,
-			readerName:       "test-reader",
-			metricsNamespace: "",
+			logName:    "test-log",
+			logId:      1,
+			logIdStr:   "1",
+			logHandle:  mockLogHandle,
+			readerName: "test-reader",
+			logNs:      "",
 		}
 
 		mockLogHandle.On("GetMetadataProvider").Return(mockMetadata)
@@ -1052,7 +1052,7 @@ func TestLogReader_ReadNext_EntryNotFound_ContextCancelled(t *testing.T) {
 		pendingReadEntryId:   0,
 		currentSegmentHandle: mockSegHandle,
 		readerName:           "test-reader",
-		metricsNamespace:     "",
+		logNs:                "",
 		batch:                nil,
 		next:                 0,
 		lastRead:             time.Now().UnixMilli(),
@@ -1099,7 +1099,7 @@ func TestLogReader_ReadNext_OtherReadError(t *testing.T) {
 		pendingReadEntryId:   0,
 		currentSegmentHandle: mockSegHandle,
 		readerName:           "test-reader",
-		metricsNamespace:     "",
+		logNs:                "",
 		batch:                nil,
 		next:                 0,
 		lastRead:             time.Now().UnixMilli(),
@@ -1146,7 +1146,7 @@ func TestLogReader_ReadNext_MultipleBatchEntries(t *testing.T) {
 		pendingReadSegmentId: 0,
 		pendingReadEntryId:   0,
 		readerName:           "test-reader",
-		metricsNamespace:     "",
+		logNs:                "",
 		batch: &proto.BatchReadResult{
 			Entries: []*proto.LogEntry{
 				{SegId: 0, EntryId: 0, Values: data1},

--- a/woodpecker/log/log_writer.go
+++ b/woodpecker/log/log_writer.go
@@ -63,7 +63,7 @@ func NewLogWriter(ctx context.Context, logHandle LogHandle, cfg *config.Configur
 		logHandle:          logHandle,
 		auditorMaxInterval: cfg.Woodpecker.Client.Auditor.MaxInterval.Seconds(),
 		cfg:                cfg,
-		metricsNamespace:   metrics.BuildMetricsNamespace(cfg.Minio.BucketName, cfg.Minio.RootPath),
+		logNs:              metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath),
 		writerClose:        make(chan struct{}, 1),
 		cleanupManager:     segment.NewSegmentCleanupManager(cfg.Minio.BucketName, cfg.Minio.RootPath, logHandle.GetMetadataProvider(), logHandle.(*logHandleImpl).ClientPool),
 		sessionLock:        sessionLock,
@@ -99,7 +99,7 @@ type logWriterImpl struct {
 	logHandle          LogHandle
 	auditorMaxInterval int
 	cfg                *config.Configuration
-	metricsNamespace   string
+	logNs              string
 	writerClose        chan struct{}
 	cleanupManager     segment.SegmentCleanupManager
 
@@ -175,7 +175,7 @@ func (l *logWriterImpl) Write(ctx context.Context, msg *WriteMessage) *WriteResu
 	if l.sessionLock == nil || !l.sessionLock.IsValid() {
 		logger.Ctx(ctx).Warn("Writer lock session has expired",
 			zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()))
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return &WriteResult{
 			LogMessageId: nil,
 			Err:          werr.ErrLogWriterLockLost.WithCauseErrMsg("writer lock session has expired"),
@@ -203,13 +203,13 @@ func (l *logWriterImpl) Write(ctx context.Context, msg *WriteMessage) *WriteResu
 	writableSegmentHandle, err := l.logHandle.GetOrCreateWritableSegmentHandle(ctx, l.onWriterInvalidated)
 	if err != nil {
 		callback(-1, -1, err)
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return <-ch
 	}
 	bytes, err := MarshalMessage(msg)
 	if err != nil {
 		logger.Ctx(ctx).Warn("serialize message failed", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Error(err))
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return &WriteResult{
 			LogMessageId: nil,
 			Err:          err,
@@ -221,15 +221,15 @@ func (l *logWriterImpl) Write(ctx context.Context, msg *WriteMessage) *WriteResu
 
 	// Update metrics based on result
 	if result.Err != nil {
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
 		if werr.ErrSegmentHandleSegmentRolling.Is(result.Err) {
 			logger.Ctx(ctx).Info("write to rolling segment rejected, retry later", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.String("detail", result.Err.Error()))
 		} else {
 			logger.Ctx(ctx).Warn("write log entry failed", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Error(result.Err))
 		}
 	} else {
-		metrics.WpLogWriterBytesWritten.WithLabelValues(l.metricsNamespace, l.logIdStr).Add(float64(len(bytes)))
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write", "success").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterBytesWritten.WithLabelValues(l.logNs, l.logIdStr).Add(float64(len(bytes)))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "success").Observe(float64(time.Since(start).Milliseconds()))
 	}
 
 	return result
@@ -243,7 +243,7 @@ func (l *logWriterImpl) WriteAsync(ctx context.Context, msg *WriteMessage) <-cha
 
 	// Check if session lock is valid
 	if l.sessionLock == nil || !l.sessionLock.IsValid() {
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
 		ch <- &WriteResult{
 			LogMessageId: nil,
 			Err:          werr.ErrLogWriterLockLost.WithCauseErrMsg("writer lock session has expired"),
@@ -256,7 +256,7 @@ func (l *logWriterImpl) WriteAsync(ctx context.Context, msg *WriteMessage) <-cha
 	bytes, err := MarshalMessage(msg)
 	if err != nil {
 		logger.Ctx(ctx).Warn("serialize message failed", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Error(err))
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
 		ch <- &WriteResult{
 			LogMessageId: nil,
 			Err:          err,
@@ -268,10 +268,10 @@ func (l *logWriterImpl) WriteAsync(ctx context.Context, msg *WriteMessage) <-cha
 	callback := func(segmentId int64, entryId int64, err error) {
 		logger.Ctx(ctx).Debug("write log entry callback exec", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Int64("segId", segmentId), zap.Int64("entryId", entryId), zap.Error(err))
 		if err == nil {
-			metrics.WpLogWriterBytesWritten.WithLabelValues(l.metricsNamespace, l.logIdStr).Add(float64(len(bytes)))
-			metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write_async", "success").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogWriterBytesWritten.WithLabelValues(l.logNs, l.logIdStr).Add(float64(len(bytes)))
+			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write_async", "success").Observe(float64(time.Since(start).Milliseconds()))
 		} else {
-			metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write_async", "error").Observe(float64(time.Since(start).Milliseconds()))
 		}
 		// Invalidate the session lock BEFORE delivering the result so subsequent Writes
 		// observe the invalid state and fail fast.
@@ -401,7 +401,7 @@ func (l *logWriterImpl) runAuditor() {
 			sp.End()
 
 			// Track auditor latency
-			metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "auditor_run", "success").Observe(float64(auditDuration.Milliseconds()))
+			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "auditor_run", "success").Observe(float64(auditDuration.Milliseconds()))
 		case <-l.writerClose:
 			logger.Ctx(context.TODO()).Info("Log auditor stopped",
 				zap.String("logName", l.logHandle.GetName()),
@@ -603,14 +603,14 @@ func (l *logWriterImpl) cleanupTruncatedSegmentsIfNecessary(ctx context.Context)
 				zap.Int64("logId", logId),
 				zap.Int64("segmentId", segmentId),
 				zap.Error(err))
-			metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "cleanup_segment", "error").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "cleanup_segment", "error").Observe(float64(time.Since(start).Milliseconds()))
 			failureCount++
 		} else {
 			logger.Ctx(ctx).Info("Finish segment cleanup",
 				zap.String("logName", logName),
 				zap.Int64("logId", logId),
 				zap.Int64("segmentId", segmentId))
-			metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "cleanup_segment", "success").Observe(float64(time.Since(start).Milliseconds()))
+			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "cleanup_segment", "success").Observe(float64(time.Since(start).Milliseconds()))
 			successCount++
 		}
 	}
@@ -662,7 +662,7 @@ func (l *logWriterImpl) Close(ctx context.Context) error {
 			status = "error"
 		}
 
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.metricsNamespace, l.logIdStr, "close", status).Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "close", status).Observe(float64(time.Since(start).Milliseconds()))
 		result = werr.Combine(closeErr, releaseLockErr, closeLogHandleErr)
 	})
 	return result

--- a/woodpecker/log/log_writer_test.go
+++ b/woodpecker/log/log_writer_test.go
@@ -63,7 +63,7 @@ func createTestInternalWriter(t *testing.T, logHandle LogHandle, cleanupMgr segm
 		logHandle:          logHandle,
 		auditorMaxInterval: cfg.Woodpecker.Client.Auditor.MaxInterval.Seconds(),
 		cfg:                cfg,
-		metricsNamespace:   "",
+		logNs:              "",
 		writerClose:        make(chan struct{}, 1),
 		cleanupManager:     cleanupMgr,
 	}
@@ -620,7 +620,7 @@ func createTestSessionWriter(t *testing.T, logHandle LogHandle, cleanupMgr segme
 		logHandle:          logHandle,
 		auditorMaxInterval: cfg.Woodpecker.Client.Auditor.MaxInterval.Seconds(),
 		cfg:                cfg,
-		metricsNamespace:   "",
+		logNs:              "",
 		writerClose:        make(chan struct{}, 1),
 		cleanupManager:     cleanupMgr,
 		sessionLock:        sessionLock,

--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -53,15 +53,15 @@ var _ Operation = (*AppendOp)(nil)
 // If it is, it sends an acknowledgment back to the application.
 // If a LogStore fails, it retries multiple times.
 type AppendOp struct {
-	mu               sync.Mutex
-	bucketName       string
-	rootPath         string
-	logId            int64
-	segmentId        int64
-	entryId          int64
-	value            []byte
-	callback         func(segmentId int64, entryId int64, err error)
-	metricsNamespace string
+	mu         sync.Mutex
+	bucketName string
+	rootPath   string
+	logId      int64
+	segmentId  int64
+	entryId    int64
+	value      []byte
+	callback   func(segmentId int64, entryId int64, err error)
+	logNs      string
 
 	clientPool      client.LogStoreClientPool
 	handle          SegmentHandle
@@ -80,14 +80,14 @@ func NewAppendOp(bucketName string, rootPath string, logId int64, segmentId int6
 	clientPool client.LogStoreClientPool, handle SegmentHandle, quorumInfo *proto.QuorumInfo,
 ) *AppendOp {
 	op := &AppendOp{
-		bucketName:       bucketName,
-		rootPath:         rootPath,
-		logId:            logId,
-		segmentId:        segmentId,
-		entryId:          entryId,
-		value:            value,
-		callback:         callback,
-		metricsNamespace: metrics.BuildMetricsNamespace(bucketName, rootPath),
+		bucketName: bucketName,
+		rootPath:   rootPath,
+		logId:      logId,
+		segmentId:  segmentId,
+		entryId:    entryId,
+		value:      value,
+		callback:   callback,
+		logNs:      metrics.BuildLogNs(bucketName, rootPath),
 
 		clientPool:      clientPool,
 		handle:          handle,
@@ -222,8 +222,8 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 			if op.completed.CompareAndSwap(false, true) {
 				op.handle.SendAppendSuccessCallbacks(ctx, op.entryId)
 				cost := time.Since(startRequestTime)
-				metrics.WpClientAppendLatency.WithLabelValues(op.metricsNamespace, strconv.FormatInt(op.logId, 10)).Observe(float64(cost.Milliseconds()))
-				metrics.WpClientAppendBytes.WithLabelValues(op.metricsNamespace, strconv.FormatInt(op.logId, 10)).Observe(float64(len(op.value)))
+				metrics.WpClientAppendLatency.WithLabelValues(op.logNs, strconv.FormatInt(op.logId, 10)).Observe(float64(cost.Milliseconds()))
+				metrics.WpClientAppendBytes.WithLabelValues(op.logNs, strconv.FormatInt(op.logId, 10)).Observe(float64(len(op.value)))
 			}
 		}
 		logger.Ctx(ctx).Debug("synced received",

--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -125,6 +125,12 @@ func NewSegmentHandle(ctx context.Context, logId int64, logName string, segmentM
 	segmentHandle.lastAccessTime.Store(time.Now().UnixMilli())
 	if canWrite {
 		segmentHandle.canWriteState.Store(true)
+		metrics.SetActiveSegmentNodes(
+			segmentHandle.metricsNamespace,
+			strconv.FormatInt(segmentHandle.logId, 10),
+			strconv.FormatInt(segmentHandle.segmentId, 10),
+			segmentHandle.quorumInfo.GetNodes(),
+		)
 		segmentHandle.executor.Start(ctx)
 		segmentHandle.completionMgr = newCompletionManager(segmentHandle)
 		segmentHandle.completionMgr.Start(context.Background())
@@ -854,6 +860,14 @@ func (s *segmentHandleImpl) doCloseWritingAndUpdateMetaIfNecessaryUnsafe(ctx con
 	if !s.canWriteState.CompareAndSwap(true, false) {
 		return nil
 	}
+	// Segment is leaving the writable state -- drop its active-segment node series
+	// so the metric only ever reflects the current active segment of each log.
+	metrics.ClearActiveSegmentNodes(
+		s.metricsNamespace,
+		strconv.FormatInt(s.logId, 10),
+		strconv.FormatInt(s.segmentId, 10),
+		s.quorumInfo.GetNodes(),
+	)
 
 	start := time.Now()
 	logIdStr := strconv.FormatInt(s.logId, 10)

--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -112,7 +112,7 @@ func NewSegmentHandle(ctx context.Context, logId int64, logName string, segmentM
 		quorumInfo:          segmentMeta.Metadata.Quorum,
 		executor:            NewSequentialExecutor(executeRequestMaxQueueSize),
 		cfg:                 cfg,
-		metricsNamespace:    metrics.BuildMetricsNamespace(cfg.Minio.BucketName, cfg.Minio.RootPath),
+		logNs:               metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath),
 		objectStorageClient: objectStorageClient,
 	}
 	segmentHandle.lastPushed.Store(segmentMeta.Metadata.LastEntryId)
@@ -126,7 +126,7 @@ func NewSegmentHandle(ctx context.Context, logId int64, logName string, segmentM
 	if canWrite {
 		segmentHandle.canWriteState.Store(true)
 		metrics.SetActiveSegmentNodes(
-			segmentHandle.metricsNamespace,
+			segmentHandle.logNs,
 			strconv.FormatInt(segmentHandle.logId, 10),
 			strconv.FormatInt(segmentHandle.segmentId, 10),
 			segmentHandle.quorumInfo.GetNodes(),
@@ -164,9 +164,9 @@ func NewSegmentHandleWithAppendOpsQueueWithWritable(ctx context.Context, logId i
 				"127.0.0.1",
 			},
 		},
-		executor:         NewSequentialExecutor(executeRequestMaxQueueSize),
-		cfg:              cfg,
-		metricsNamespace: metrics.BuildMetricsNamespace(cfg.Minio.BucketName, cfg.Minio.RootPath),
+		executor: NewSequentialExecutor(executeRequestMaxQueueSize),
+		cfg:      cfg,
+		logNs:    metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath),
 	}
 	segmentHandle.lastPushed.Store(segmentMeta.Metadata.LastEntryId)
 	segmentHandle.lastAddConfirmed.Store(segmentMeta.Metadata.LastEntryId)
@@ -197,7 +197,7 @@ type segmentHandleImpl struct {
 	ClientPool       client.LogStoreClientPool
 	quorumInfo       *proto.QuorumInfo
 	cfg              *config.Configuration
-	metricsNamespace string
+	logNs            string
 
 	sync.RWMutex
 	lastPushed       atomic.Int64
@@ -281,8 +281,8 @@ func (s *segmentHandleImpl) AppendAsync(ctx context.Context, bytes []byte, callb
 	s.appendOpsQueue.PushBack(appendOp)
 	s.submittedSize.Add(int64(len(bytes)))
 	logIdStr := strconv.FormatInt(s.logId, 10)
-	metrics.WpClientAppendRequestsTotal.WithLabelValues(s.metricsNamespace, logIdStr).Inc()
-	metrics.WpSegmentHandlePendingAppendOps.WithLabelValues(s.metricsNamespace, logIdStr).Inc()
+	metrics.WpClientAppendRequestsTotal.WithLabelValues(s.logNs, logIdStr).Inc()
+	metrics.WpSegmentHandlePendingAppendOps.WithLabelValues(s.logNs, logIdStr).Inc()
 }
 
 func (s *segmentHandleImpl) createPendingAppendOp(ctx context.Context, bytes []byte, entryId int64, callback func(segmentId int64, entryId int64, err error)) *AppendOp {
@@ -351,7 +351,7 @@ func (s *segmentHandleImpl) SendAppendSuccessCallbacks(ctx context.Context, trig
 		s.appendOpsQueue.Remove(element)
 		op := element.Value.(*AppendOp)
 		logger.Ctx(ctx).Debug("SendAppendSuccessCallbacks remove", zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.Int64("entryId", op.entryId), zap.Int64("triggerId", triggerEntryId))
-		metrics.WpSegmentHandlePendingAppendOps.WithLabelValues(s.metricsNamespace, strconv.FormatInt(s.logId, 10)).Dec()
+		metrics.WpSegmentHandlePendingAppendOps.WithLabelValues(s.logNs, strconv.FormatInt(s.logId, 10)).Dec()
 	}
 
 	// when seg rolling state mark, if no pending appendOps, trigger completion
@@ -422,7 +422,7 @@ func (s *segmentHandleImpl) HandleAppendRequestFailure(ctx context.Context, trig
 				zap.Int("serverIndex", serverIndex), zap.String("serverAddr", serverAddr))
 			s.appendOpsQueue.Remove(element)
 			op.FastFail(ctx, werr.ErrAppendOpRetrySubmitFailed)
-			metrics.WpSegmentHandlePendingAppendOps.WithLabelValues(s.metricsNamespace, strconv.FormatInt(s.logId, 10)).Dec()
+			metrics.WpSegmentHandlePendingAppendOps.WithLabelValues(s.logNs, strconv.FormatInt(s.logId, 10)).Dec()
 			continue
 		}
 		logger.Ctx(ctx).Debug("append retry", zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.Int64("entryId", op.entryId), zap.Int64("triggerId", triggerEntryId), zap.Int("serverIndex", serverIndex), zap.String("serverAddr", serverAddr))
@@ -445,7 +445,7 @@ func (s *segmentHandleImpl) HandleAppendRequestFailure(ctx context.Context, trig
 		op := element.Value.(*AppendOp)
 		op.FastFail(ctx, err)
 		logger.Ctx(ctx).Debug("append fail after retry", zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.Int64("entryId", op.entryId), zap.Int64("triggerId", triggerEntryId))
-		metrics.WpSegmentHandlePendingAppendOps.WithLabelValues(s.metricsNamespace, strconv.FormatInt(s.logId, 10)).Dec()
+		metrics.WpSegmentHandlePendingAppendOps.WithLabelValues(s.logNs, strconv.FormatInt(s.logId, 10)).Dec()
 	}
 
 	// mark rolling to prevent later append, and trigger rolling segment before all appendOps in queue
@@ -485,11 +485,11 @@ func (s *segmentHandleImpl) ReadBatchAdv(ctx context.Context, from int64, maxEnt
 					zap.Int64("segId", s.segmentId), zap.Int64("from", from),
 					zap.Error(err))
 			}
-			metrics.WpClientDirectReadRequestsTotal.WithLabelValues(s.metricsNamespace, logIdStr, status).Inc()
+			metrics.WpClientDirectReadRequestsTotal.WithLabelValues(s.logNs, logIdStr, status).Inc()
 			return nil, err
 		}
-		metrics.WpClientDirectReadRequestsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "success").Inc()
-		metrics.WpClientDirectReadLatency.WithLabelValues(s.metricsNamespace, logIdStr).Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpClientDirectReadRequestsTotal.WithLabelValues(s.logNs, logIdStr, "success").Inc()
+		metrics.WpClientDirectReadLatency.WithLabelValues(s.logNs, logIdStr).Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Debug("direct read batch success",
 			zap.String("logName", s.logName), zap.Int64("logId", s.logId),
 			zap.Int64("segId", s.segmentId), zap.Int64("from", from),
@@ -745,8 +745,8 @@ func (s *segmentHandleImpl) GetLastAddConfirmed(ctx context.Context) (int64, err
 			continue
 		}
 
-		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "get_lac", "success").Inc()
-		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "get_lac", "success").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "get_lac", "success").Inc()
+		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "get_lac", "success").Observe(float64(time.Since(start).Milliseconds()))
 		return lac, nil
 	}
 
@@ -757,8 +757,8 @@ func (s *segmentHandleImpl) GetLastAddConfirmed(ctx context.Context) (int64, err
 		zap.Int64("segId", s.segmentId),
 		zap.Int("totalNodes", nodeCount),
 		zap.Error(lastError))
-	metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "get_lac", "error").Inc()
-	metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "get_lac", "error").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "get_lac", "error").Inc()
+	metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "get_lac", "error").Observe(float64(time.Since(start).Milliseconds()))
 	return -1, lastError
 }
 
@@ -792,13 +792,13 @@ func (s *segmentHandleImpl) refreshAndGetMetadataUnsafe(ctx context.Context) err
 			zap.Int64("logId", s.logId),
 			zap.Int64("segId", s.segmentId),
 			zap.Error(err))
-		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "refresh_meta", "error").Inc()
-		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "refresh_meta", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "refresh_meta", "error").Inc()
+		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "refresh_meta", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return err
 	}
 	s.segmentMetaCache.Store(newMeta)
-	metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "refresh_meta", "success").Inc()
-	metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "refresh_meta", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "refresh_meta", "success").Inc()
+	metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "refresh_meta", "success").Observe(float64(time.Since(start).Milliseconds()))
 	return nil
 }
 
@@ -863,7 +863,7 @@ func (s *segmentHandleImpl) doCloseWritingAndUpdateMetaIfNecessaryUnsafe(ctx con
 	// Segment is leaving the writable state -- drop its active-segment node series
 	// so the metric only ever reflects the current active segment of each log.
 	metrics.ClearActiveSegmentNodes(
-		s.metricsNamespace,
+		s.logNs,
 		strconv.FormatInt(s.logId, 10),
 		strconv.FormatInt(s.segmentId, 10),
 		s.quorumInfo.GetNodes(),
@@ -904,20 +904,20 @@ func (s *segmentHandleImpl) doCloseWritingAndUpdateMetaIfNecessaryUnsafe(ctx con
 		// new append will fail with ErrSegmentFenced, and application client should reopen new logWriter instead.
 		s.NotifyWriterInvalidation(ctx, fmt.Sprintf("segment:%d meta update revision invalid", s.segmentId))
 		logger.Ctx(ctx).Warn("segment close failed", zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.Int64("lastFlushedEntryId", lastFlushedEntryId), zap.Int64("lastAddConfirmed", s.lastAddConfirmed.Load()), zap.Int64("completionTime", newSegmentMetadata.CompletionTime), zap.Error(err))
-		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "close", "error").Inc()
-		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "close", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "close", "error").Inc()
+		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "close", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return err
 	}
 
 	if err != nil {
 		logger.Ctx(ctx).Warn("segment close failed", zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.Int64("lastFlushedEntryId", lastFlushedEntryId), zap.Int64("lastAddConfirmed", s.lastAddConfirmed.Load()), zap.Int64("completionTime", newSegmentMetadata.CompletionTime), zap.Error(err))
-		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "close", "error").Inc()
-		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "close", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "close", "error").Inc()
+		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "close", "error").Observe(float64(time.Since(start).Milliseconds()))
 	} else {
 		logger.Ctx(ctx).Info("segment closed", zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.Int64("lastFlushedEntryId", lastFlushedEntryId), zap.Int64("lastAddConfirmed", s.lastAddConfirmed.Load()), zap.Int64("completionTime", newSegmentMetadata.CompletionTime))
 		s.segmentMetaCache.Store(newSegMeta)
-		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "close", "success").Inc()
-		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "close", "success").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "close", "success").Inc()
+		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "close", "success").Observe(float64(time.Since(start).Milliseconds()))
 	}
 	return err
 }
@@ -951,7 +951,7 @@ func (s *segmentHandleImpl) fastFailAppendOpsUnsafe(ctx context.Context, lastEnt
 	// Clear the queue
 	for _, element := range elementsToRemove {
 		s.appendOpsQueue.Remove(element)
-		metrics.WpSegmentHandlePendingAppendOps.WithLabelValues(s.metricsNamespace, strconv.FormatInt(s.logId, 10)).Dec()
+		metrics.WpSegmentHandlePendingAppendOps.WithLabelValues(s.logNs, strconv.FormatInt(s.logId, 10)).Dec()
 	}
 	logger.Ctx(ctx).Debug("fastFailAppendOps finish", zap.String("logName", s.logName), zap.Int64("logId", s.logId), zap.Int64("segId", s.segmentId), zap.Int("fastFailOps", len(elementsToRemove)), zap.Int("successCount", successCount), zap.Int("failCount", failCount), zap.Error(err))
 }
@@ -1023,8 +1023,8 @@ func (s *segmentHandleImpl) GetBlocksCount(ctx context.Context) int64 {
 			zap.Error(err))
 		return 0
 	}
-	metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "get_blocks_count", "success").Inc()
-	metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "get_blocks_count", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "get_blocks_count", "success").Inc()
+	metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "get_blocks_count", "success").Observe(float64(time.Since(start).Milliseconds()))
 	return currentBlockCounts
 }
 
@@ -1512,8 +1512,8 @@ func (s *segmentHandleImpl) FenceAndComplete(ctx context.Context) (int64, error)
 	// Send FenceSegment requests to all quorum nodes in parallel
 	lastEntryId, fencedErr := s.fenceSegmentQuorum(ctx, quorumInfo)
 	if fencedErr != nil {
-		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "fence", "error").Inc()
-		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "fence", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "fence", "error").Inc()
+		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "fence", "error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("quorum fence segment failed",
 			zap.String("logName", s.logName),
 			zap.Int64("logId", s.logId),
@@ -1524,8 +1524,8 @@ func (s *segmentHandleImpl) FenceAndComplete(ctx context.Context) (int64, error)
 
 	completeErr := s.completeSegmentQuorum(ctx, quorumInfo, lastEntryId)
 	if completeErr != nil {
-		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "complete", "error").Inc()
-		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "complete", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "complete", "error").Inc()
+		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "complete", "error").Observe(float64(time.Since(start).Milliseconds()))
 		logger.Ctx(ctx).Warn("quorum complete segment failed",
 			zap.String("logName", s.logName),
 			zap.Int64("logId", s.logId),
@@ -1589,8 +1589,8 @@ func (s *segmentHandleImpl) FenceAndComplete(ctx context.Context) (int64, error)
 		zap.Int64("lastEntryId", lastEntryId),
 		zap.Duration("duration", time.Since(start)))
 	s.fencedState.Store(true) // Set fenced state to prevent new append operations
-	metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "fence", "success").Inc()
-	metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "fence", "success").Observe(float64(time.Since(start).Milliseconds()))
+	metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "fence", "success").Inc()
+	metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "fence", "success").Observe(float64(time.Since(start).Milliseconds()))
 	return lastEntryId, nil
 }
 
@@ -1681,8 +1681,8 @@ func (s *segmentHandleImpl) Compact(ctx context.Context) error {
 			zap.Int64("segmentId", s.segmentId),
 			zap.Duration("duration", time.Since(start)),
 			zap.Error(compactErr))
-		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "compact_to_sealed", "error").Inc()
-		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "compact_to_sealed", "error").Observe(float64(time.Since(start).Milliseconds()))
+		metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "compact_to_sealed", "error").Inc()
+		metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "compact_to_sealed", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return compactErr
 	}
 
@@ -1737,8 +1737,8 @@ func (s *segmentHandleImpl) Compact(ctx context.Context) error {
 		zap.Int64("finalSize", compactSegMetaInfo.Size),
 		zap.String("finalState", "Sealed"))
 
-	metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.metricsNamespace, logIdStr, "compact_to_sealed", "success").Inc()
-	metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.metricsNamespace, logIdStr, "compact_to_sealed", "success").Observe(float64(compactionDuration.Milliseconds()))
+	metrics.WpSegmentHandleOperationsTotal.WithLabelValues(s.logNs, logIdStr, "compact_to_sealed", "success").Inc()
+	metrics.WpSegmentHandleOperationLatency.WithLabelValues(s.logNs, logIdStr, "compact_to_sealed", "success").Observe(float64(compactionDuration.Milliseconds()))
 	return updateMetaErr
 }
 

--- a/woodpecker/segment/segment_handle_active_node_test.go
+++ b/woodpecker/segment/segment_handle_active_node_test.go
@@ -1,0 +1,81 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/metrics"
+	"github.com/zilliztech/woodpecker/meta"
+	"github.com/zilliztech/woodpecker/mocks/mocks_meta"
+	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_logstore_client"
+	"github.com/zilliztech/woodpecker/proto"
+)
+
+func TestSegmentHandle_ActiveSegmentNodeMetric_SetAndClear(t *testing.T) {
+	metrics.WpActiveSegmentNode.Reset()
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(metrics.WpActiveSegmentNode)
+
+	mockMetadata := mocks_meta.NewMetadataProvider(t)
+	mockMetadata.EXPECT().UpdateSegmentMetadata(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil).Maybe()
+
+	cfg := &config.Configuration{
+		Woodpecker: config.WoodpeckerConfig{
+			Client: config.ClientConfig{
+				SegmentAppend: config.SegmentAppendConfig{QueueSize: 10, MaxRetries: 2},
+			},
+		},
+	}
+
+	segmentMeta := &meta.SegmentMeta{
+		Metadata: &proto.SegmentMetadata{
+			SegNo:       7,
+			State:       proto.SegmentState_Active,
+			LastEntryId: -1,
+			Quorum: &proto.QuorumInfo{
+				Id: 1, Aq: 1, Es: 3, Wq: 3,
+				Nodes: []string{"10.0.0.1:8000", "10.0.0.2:8000", "10.0.0.3:8000"},
+			},
+		},
+		Revision: 1,
+	}
+
+	sh := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, true, nil).(*segmentHandleImpl)
+
+	count, err := testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, count, "writable segment should publish one series per quorum node")
+
+	// Transition out of writable; clear must fire exactly once (CAS true->false).
+	err = sh.doCloseWritingAndUpdateMetaIfNecessaryUnsafe(context.Background(), -1)
+	assert.NoError(t, err)
+
+	count, err = testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "series removed after segment leaves writable state")
+}

--- a/woodpecker/woodpecker_client.go
+++ b/woodpecker/woodpecker_client.go
@@ -223,7 +223,7 @@ func openLogUnsafe(ctx context.Context, metadata meta.MetadataProvider, logName 
 		return nil, err
 	}
 	newLogHandle := log.NewLogHandle(logName, logMeta.Metadata.GetLogId(), segmentsMeta, metadata, clientPool, cfg, selectQuorumFunc, objectStorageClient)
-	metrics.WpLogNameIdMapping.WithLabelValues(metrics.BuildMetricsNamespace(cfg.Minio.BucketName, cfg.Minio.RootPath), logName).Set(float64(logMeta.Metadata.GetLogId()))
+	metrics.WpLogNameIdMapping.WithLabelValues(metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath), logName).Set(float64(logMeta.Metadata.GetLogId()))
 	return newLogHandle, nil
 }
 


### PR DESCRIPTION
## What & why

Closes #197.

Adds client-side observability to verify, per `log_ns` / `log_id`, **which nodes a log's current active (writable) segment is using** — so when a node switch / failover happens you can confirm all active segments have actually moved onto the newly switched-to nodes.

A log has at most one active segment at a time, and that segment's quorum node set is immutable for its lifetime — a "switch" is the active segment rolling to `Completed` and the log selecting a fresh node set for a new active segment. Until now there was no metric showing which nodes the current active segment sits on.

## Changes

**Metric** (`common/metrics/client_metrics.go`)
- New gauge `woodpecker_client_active_segment_node{log_ns, log_id, segment_id, node} = 1` — one series per quorum node of the current active segment.
- Package-level helpers `SetActiveSegmentNodes` / `ClearActiveSegmentNodes` (mirroring the existing `UpdateSegmentState`), registered in `RegisterClientMetricsWithRegisterer`.

**Lifecycle wiring** (`woodpecker/segment/segment_handle.go`)
- SET when a segment becomes writable (`NewSegmentHandle`, `canWrite` branch — quorum known).
- CLEAR immediately after the lone `canWriteState.CompareAndSwap(true,false)` in `doCloseWritingAndUpdateMetaIfNecessaryUnsafe`, before any early return.
- That CAS is the **only** `true→false` transition in the file, and all completion / rolling / fence / force-close / log-close paths funnel through it — so set-on-construct + clear-after-CAS fire exactly once each per segment. No series leak, delete-on-switch keeps cardinality bounded (≈ open logs × Wq).

**Dashboards** (docker + k8s client templates)
- "Active Segment → Nodes (by Log)" table — which nodes each log's active segment writes to.
- "Active Segments per Node" timeseries (`count by (node)`) — watch old nodes drop to 0 and new nodes rise during a switch.
- docker uses `__DATASOURCE_UID__` + `log_ns`; k8s uses `${prometheus}` + `cluster/namespace/log_ns`. No new template variables.

## Out of scope (intentional)

No proto/etcd/server/quorum-selection changes; no append hot-path instrumentation; no seed-pool/pool-dimension metric (a node's pool is inferable from its name + static config — not worth changing the `SelectQuorum` signature). See the design doc for the rationale.

## Verifying a switch

```promql
# old node should be empty after the switch
count(woodpecker_client_active_segment_node{node="<old-node>"})
# logs still on old nodes
woodpecker_client_active_segment_node{node=~"<old-nodes>"}
```

## Testing

- `go build ./...` clean.
- Unit: `TestActiveSegmentNodes_SetAndClear` (metrics) — set publishes one series per node, clear deletes them (verified via `testutil.GatherAndCount`).
- Unit: `TestSegmentHandle_ActiveSegmentNodeMetric_SetAndClear` — a real writable `NewSegmentHandle` publishes 3 series, and the real `doClose...` path removes them.
- `TestK8sDashboards_Valid` passes (valid JSON, no `__DATASOURCE_UID__`, `${prometheus}` + required template vars intact).

Design & plan: `docs/superpowers/specs/2026-06-24-active-segment-node-metric-design.md`, `docs/superpowers/plans/2026-06-24-active-segment-node-metric.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
