### PR TITLE
fix(ci): cap nightly Chaos Mesh minikube to 4 CPUs to match ubuntu-latest

### DIFF
--- a/.github/workflows/nightly-chaos-mesh.yaml
+++ b/.github/workflows/nightly-chaos-mesh.yaml
@@ -21,6 +21,11 @@ jobs:
           curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
           kubectl version --client
       - name: Run network-chaos suite
+        env:
+          # ubuntu-latest hosted runners have 4 vCPU; the script defaults minikube to 6,
+          # which fails instantly with RSRC_INSUFFICIENT_CORES (exit 29). Pin to the
+          # runner's capacity. See #199.
+          MK_CPUS: "4"
         run: ./tests/chaos_mesh/run_network_chaos.sh
       - name: Upload chaos artifacts on failure
         if: failure()


### PR DESCRIPTION
## What

Pin `MK_CPUS=4` on the `Run network-chaos suite` step of the nightly Chaos Mesh workflow.

## Why

The `Chaos Mesh Test` job has been failing **every** nightly run since the suite landed (#181) — it has never passed once (30/30 failures across recent runs). It dies ~1s into the step:

```
X Exiting due to RSRC_INSUFFICIENT_CORES: Requested cpu count 6 is greater than the available cpus of 4
##[error]Process completed with exit code 29.
```

`run_network_chaos.sh` defaults minikube to **6 CPUs** (`MK_CPUS:-6`), but the `ubuntu-latest` hosted runner is fixed at **4 vCPU / 16 GB**. This is a deterministic config mismatch, not transient runner capacity — so it fails 100% of the time.

This single job accounts for essentially all recent nightly failures (11 of the last 12 failed runs had it as the *only* failing job, identical signature). Full analysis in #199.

## Fix

The script already honors a `MK_CPUS` override, so this pins the request to the runner's capacity without touching the script:

```yaml
      - name: Run network-chaos suite
        env:
          MK_CPUS: "4"
        run: ./tests/chaos_mesh/run_network_chaos.sh
```

`MK_MEMORY=8192` is unchanged and fits the 16 GB runner.

## Follow-up

Watch the next couple of nightly runs to confirm the chaos suite is stable at 4 cores. If it proves too tight, the fallback is moving the job to a larger (8-core hosted / self-hosted) runner to keep the original 6-core design.

Fixes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)
