### PR TITLE
fix(docs): exclude superpowers/ from Jekyll build to fix Pages build (#204)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,3 +10,8 @@ exclude:
   - vendor/gems/
   - vendor/ruby/
   - wip
+  # Internal AI-agent planning/spec artifacts (writing-plans skill output).
+  # Not user-facing docs, and they contain double-curly-brace sequences (PromQL/
+  # Grafana templating, Python f-string brace-escaping) that Jekyll's Liquid
+  # engine fails to parse, which breaks the Pages build. See issue #204.
+  - superpowers


### PR DESCRIPTION
## Problem

The `pages-build-deployment` workflow fails at the **Build with Jekyll** step ([example run](https://github.com/zilliztech/woodpecker/actions/runs/28154603390)):

```
Liquid syntax error (line 755): Variable '{{job=~"{JOB}' was not properly
terminated with regexp: /}}/ in superpowers/plans/2026-06-22-k8s-monitor-log-ns.md
```

## Root cause

Jekyll runs the Liquid template engine over raw markdown **before** rendering — and it does so even for content inside fenced code blocks. `docs/superpowers/plans/2026-06-22-k8s-monitor-log-ns.md:755` contains a Python snippet:

```python
q_var("namespace", f'label_values(go_info{{job=~"{JOB}", cluster=~"$cluster"}}, namespace)'),
```

The `{{...}}` is Python f-string brace-escaping producing literal PromQL `{job=~...}`, but Liquid reads `{{job=~"{JOB}` as an unterminated template variable and aborts the build.

This is not a one-off — the same pattern appears in several other internal planning/spec docs under `docs/superpowers/` (`2026-06-23-quorum-dynamic-config.md`, `2026-06-04-chaos-mesh-network-jitter.md`, `2026-06-24-active-segment-node-metric.md`, `superpowers/specs/2026-06-24-active-segment-node-metric-design.md`). They would keep breaking the build as new plans land.

## Fix

`docs/superpowers/` holds internal AI-agent planning/spec artifacts (`writing-plans` skill output), not user-facing documentation. The repo already excludes the `wip/` directory from the published site for the same reason. This PR adds `superpowers` to the `exclude:` list in `docs/_config.yml`, mirroring the existing `wip` exclusion.

This fixes the build immediately and prevents the whole class of failure from recurring.

## Verification

A full local github-pages Jekyll build wasn't available in this environment, so the fix was verified statically:

- The failing build log itself prints `EntryFilter: excluded /wip`, confirming the `exclude:` mechanism removes a top-level docs directory from the build entirely (it's never Liquid-rendered).
- All files under `docs/` containing `{{...}}` are confirmed to live under `wip/` (already excluded) or `superpowers/` (excluded by this PR) — no other page can trigger this error.

Fixes #204
