### PR TITLE
perf(segment): parallelize per-replica fan-out in AppendOp.Execute

### DIFF
--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -117,10 +117,37 @@ func (op *AppendOp) Execute() {
 		op.resultChannels = make([]channel.ResultChannel, len(op.quorumInfo.Nodes))
 	}
 
-	for i := 0; i < len(op.quorumInfo.Nodes); i++ {
-		// send request to the node
-		op.sendWriteRequestRetry(ctx, i)
+	// Fan out the per-replica sends concurrently.
+	//
+	// Each sendWriteRequestRetry blocks inside cli.AppendEntry until that
+	// replica returns its first (Buffered) response. Issuing them sequentially
+	// made an op's critical path the SUM of the per-replica round-trips, which
+	// caps single-log append throughput at roughly 1/(ensembleSize * RTT). The
+	// durable acks are already handled asynchronously (see receivedAckCallback),
+	// so only these initial sends were serialized.
+	//
+	// Sending to all replicas in parallel makes the critical path the MAX
+	// round-trip instead of the sum, lifting single-log throughput by up to the
+	// ensemble size. Each goroutine only touches its own serverIndex slot
+	// (resultChannels[i], channelErrors[i], channelAttempts[i]), so there is no
+	// shared-state race. Ordering is unaffected: entry IDs are pre-assigned in
+	// AppendAsync and acknowledged in order by SendAppendSuccessCallbacks.
+	nodeCount := len(op.quorumInfo.Nodes)
+	if nodeCount == 1 {
+		// Fast path: avoid goroutine/WaitGroup overhead for a single replica.
+		op.sendWriteRequestRetry(ctx, 0)
+		return
 	}
+	var wg sync.WaitGroup
+	wg.Add(nodeCount)
+	for i := 0; i < nodeCount; i++ {
+		go func(serverIndex int) {
+			defer wg.Done()
+			// send request to the node
+			op.sendWriteRequestRetry(ctx, serverIndex)
+		}(i)
+	}
+	wg.Wait()
 }
 
 // sendWriteRequestRetry used for retry single request

--- a/woodpecker/segment/append_op_test.go
+++ b/woodpecker/segment/append_op_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1155,4 +1156,47 @@ func testSimpleQuorum(t *testing.T, nodeCount, ackQuorum, successCount int, expe
 		assert.False(t, op.completed.Load(), "Operation should not be completed")
 		assert.Less(t, op.ackSet.Count(), ackQuorum, fmt.Sprintf("Less than %d nodes should have acked (insufficient for quorum)", ackQuorum))
 	}
+}
+
+// TestAppendOp_Execute_ParallelFanout verifies that Execute() issues the
+// per-replica sends concurrently rather than sequentially. Each AppendEntry
+// blocks for sendDelay; if the sends were serialized the call would take
+// ~ensembleSize*sendDelay, whereas a parallel fan-out takes ~sendDelay.
+func TestAppendOp_Execute_ParallelFanout(t *testing.T) {
+	const sendDelay = 80 * time.Millisecond
+
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+
+	quorumInfo := &proto.QuorumInfo{
+		Id:    1,
+		Wq:    3,
+		Aq:    2,
+		Es:    3,
+		Nodes: []string{"node1", "node2", "node3"},
+	}
+
+	var sends atomic.Int32
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil)
+	mockClient.EXPECT().IsRemoteClient().Return(true)
+	mockClient.EXPECT().
+		AppendEntry(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, _ string, _ string, _ int64, _ *proto.LogEntry, _ channel.ResultChannel) {
+			sends.Add(1)
+			time.Sleep(sendDelay)
+		}).
+		Return(int64(3), nil)
+
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo)
+
+	start := time.Now()
+	op.Execute()
+	elapsed := time.Since(start)
+
+	assert.Equal(t, int32(3), sends.Load(), "all replicas should be contacted")
+	assert.Equal(t, 3, len(op.resultChannels))
+	assert.Less(t, elapsed, 2*sendDelay, "per-replica sends should run concurrently (sequential would be ~ensembleSize*sendDelay)")
+
+	cleanupAppendOp(t, op)
 }


### PR DESCRIPTION
## What

`AppendOp.Execute()` issued the per-replica writes **sequentially** — each `sendWriteRequestRetry` blocks inside `cli.AppendEntry` until that replica returns its first `Buffered` response before the next replica is contacted. An op's critical path was therefore the **sum** of the per-replica round-trips, capping single-log append throughput at roughly `1/(ensembleSize × RTT)`. The durable acks are already asynchronous (`receivedAckCallback`), so only these initial sends were serialized.

This PR fans the per-replica sends out **concurrently**, so the op's critical path becomes the **max** round-trip instead of the sum.

## Why

Profiling a single-shard (single log), `batch=1` write workload, single-log append throughput plateaus at ~810 appends/s while CPU (~13–16%) and server-side flush (~19% busy, 32 flush threads) both have large headroom — i.e. the limiter is the per-op serial fan-out, not compute or flush. Parallelizing is expected to raise single-log throughput by up to the ensemble size.

See #201 for the full analysis.

## Change

```go
// before: sequential — critical path = Σ per-replica RTT
for i := 0; i < len(op.quorumInfo.Nodes); i++ {
    op.sendWriteRequestRetry(ctx, i)
}

// after: concurrent fan-out — critical path = max per-replica RTT
//        (single-replica fast path avoids goroutine overhead)
var wg sync.WaitGroup
wg.Add(nodeCount)
for i := 0; i < nodeCount; i++ {
    go func(serverIndex int) { defer wg.Done(); op.sendWriteRequestRetry(ctx, serverIndex) }(i)
}
wg.Wait()
```

## Safety / correctness

- **No new races:** each goroutine touches only its own `serverIndex` slot (`resultChannels[i]`, `channelErrors[i]`, `channelAttempts[i]`); the per-replica durable-ack goroutines (`receivedAckCallback`) already ran concurrently before this change.
- **Ordering unaffected:** entry IDs are pre-assigned in `AppendAsync` and acknowledged in order by `SendAppendSuccessCallbacks`.
- **Client-only:** no proto or server changes.

## Tests

- New `TestAppendOp_Execute_ParallelFanout`: a 3-replica ensemble with a per-send delay must complete in ~1× the delay (parallel), not ~3× (sequential).
- `go build ./...`, `go vet`, `gofmt` clean.
- Full `./woodpecker/segment/` suite passes, and the `AppendOp` + quorum-write tests pass under `-race`.

## Follow-up

Companion (larger) optimization tracked in #202 — client-side group commit / batched `AddEntries` — composes on top of this fan-out change.

Issue: #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)
