### PR TITLE
fix(reader): read from a truncated-but-not-yet-GC'd position on reopen (#209)

### DIFF
--- a/tests/integration/e2e_truncate_test.go
+++ b/tests/integration/e2e_truncate_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/zilliztech/woodpecker/common/config"
 	"github.com/zilliztech/woodpecker/proto"
@@ -660,6 +661,144 @@ func TestReadBeforeTruncationPoint(t *testing.T) {
 			assert.NoError(t, err)
 
 			// stop embed LogStore singleton
+			stopEmbedLogStoreErr := woodpecker.StopEmbedLogStore()
+			assert.NoError(t, stopEmbedLogStoreErr, "close embed LogStore instance error")
+		})
+	}
+}
+
+// TestReopenAtTruncatedButNotGCedPosition verifies that a reader explicitly reopened at
+// a specific position inside a segment that is logically Truncated but not yet physically
+// GC'd reads from exactly that position, instead of being force-advanced to the truncation
+// point. Regression test for issue #209.
+func TestReopenAtTruncatedButNotGCedPosition(t *testing.T) {
+	tmpDir := t.TempDir()
+	rootPath := filepath.Join(tmpDir, "TestReopenAtTruncatedButNotGCedPosition")
+	testCases := []struct {
+		name        string
+		storageType string
+		rootPath    string
+	}{
+		{name: "LocalFsStorage", storageType: "local", rootPath: rootPath},
+		{name: "ObjectStorage", storageType: "", rootPath: ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := config.NewConfiguration("../../config/woodpecker.yaml")
+			assert.NoError(t, err)
+			if tc.storageType != "" {
+				cfg.Woodpecker.Storage.Type = tc.storageType
+			}
+			if tc.rootPath != "" {
+				cfg.Woodpecker.Storage.RootPath = tc.rootPath
+			}
+			// Small segment size to force multiple segments.
+			cfg.Woodpecker.Client.SegmentRollingPolicy.MaxSize = 1024 * 2 // 2KB
+
+			client, err := woodpecker.NewEmbedClientFromConfig(context.Background(), cfg)
+			assert.NoError(t, err)
+
+			logName := "truncate_reopen_truncated_pos_" + t.Name() + "_" + time.Now().Format("20060102150405")
+			err = client.CreateLog(context.Background(), logName)
+			assert.NoError(t, err)
+			logHandle, err := client.OpenLog(context.Background(), logName)
+			assert.NoError(t, err)
+
+			logWriter, err := logHandle.OpenLogWriter(context.Background())
+			assert.NoError(t, err)
+
+			const totalMsgs = 10
+			const msgSize = 1024 // 1KB per message -> ~2 messages per 2KB segment
+			writtenIds := make([]*log.LogMessageId, totalMsgs)
+			for i := 0; i < totalMsgs; i++ {
+				payload := make([]byte, msgSize)
+				for j := 0; j < msgSize; j++ {
+					payload[j] = byte(i % 256)
+				}
+				result := logWriter.Write(context.Background(), &log.WriteMessage{
+					Payload:    payload,
+					Properties: map[string]string{"index": fmt.Sprintf("%d", i)},
+				})
+				assert.NoError(t, result.Err)
+				writtenIds[i] = result.LogMessageId
+			}
+
+			// Specific read position: the first message of segment 1. We deliberately avoid
+			// segment 0 / entry 0 because (0,0) collides with the "earliest" sentinel and
+			// would legitimately be force-adjusted to the truncation point on open.
+			var specificPos *log.LogMessageId
+			specificIdx := -1
+			for i := 0; i < totalMsgs; i++ {
+				if writtenIds[i].SegmentId == 1 {
+					specificPos = writtenIds[i]
+					specificIdx = i
+					break
+				}
+			}
+			require.NotNil(t, specificPos, "expected at least one message in segment 1")
+			require.False(t, specificPos.SegmentId == 0 && specificPos.EntryId == 0)
+
+			// Truncation point: a message in a segment strictly after specificPos's segment,
+			// so specificPos's whole segment is below the truncation point and gets marked
+			// Truncated (yet kept; it is not the truncation segment itself).
+			var truncatePoint *log.LogMessageId
+			for i := 0; i < totalMsgs; i++ {
+				if writtenIds[i].SegmentId > specificPos.SegmentId {
+					truncatePoint = writtenIds[i]
+					break
+				}
+			}
+			require.NotNil(t, truncatePoint, "expected a message in a later segment")
+			require.Greater(t, truncatePoint.SegmentId, specificPos.SegmentId)
+
+			// Truncate, then deterministically persist the pre-truncation segments' Truncated
+			// state to the metadata store.
+			err = logHandle.Truncate(context.Background(), truncatePoint)
+			assert.NoError(t, err)
+			err = logHandle.CheckAndSetSegmentTruncatedIfNeed(context.Background())
+			assert.NoError(t, err)
+
+			// Restart the client so the reader gets FRESH segment handles that reflect the
+			// persisted Truncated state. (Without a restart, the in-process segment handle's
+			// cached metadata still reads as non-truncated and would mask the bug; the real
+			// "reopen" scenario uses fresh handles.) Default TTL is 72h, so nothing is GC'd.
+			err = logWriter.Close(context.Background())
+			assert.NoError(t, err)
+			stopErr := woodpecker.StopEmbedLogStore()
+			assert.NoError(t, stopErr, "close embed LogStore instance error")
+
+			newClient, err := woodpecker.NewEmbedClientFromConfig(context.Background(), cfg)
+			assert.NoError(t, err)
+			newLogHandle, err := newClient.OpenLog(context.Background(), logName)
+			assert.NoError(t, err)
+
+			// Confirm specificPos's segment is Truncated but still physically present.
+			segments, err := newLogHandle.GetSegments(context.Background())
+			assert.NoError(t, err)
+			seg, ok := segments[specificPos.SegmentId]
+			require.True(t, ok, "truncated segment %d must still exist (not yet GC'd)", specificPos.SegmentId)
+			assert.Equal(t, proto.SegmentState_Truncated, seg.Metadata.State,
+				"segment %d should be marked Truncated", specificPos.SegmentId)
+
+			// Reopen a NEW reader at the explicit truncated-but-not-GC'd position.
+			reader, err := newLogHandle.OpenLogReader(context.Background(), specificPos, "reopen-at-truncated-pos-reader")
+			assert.NoError(t, err)
+
+			msg, err := reader.ReadNext(context.Background())
+			assert.NoError(t, err)
+			require.NotNil(t, msg)
+
+			// Must read from exactly the requested position, NOT the truncation point.
+			assert.Equal(t, specificPos.SegmentId, msg.Id.SegmentId,
+				"reader must start at the requested (truncated-but-present) segment, not be advanced")
+			assert.Equal(t, specificPos.EntryId, msg.Id.EntryId,
+				"reader must start at the requested entry, not the truncation point")
+			assert.Equal(t, fmt.Sprintf("%d", specificIdx), msg.Properties["index"])
+
+			err = reader.Close(context.Background())
+			assert.NoError(t, err)
+
 			stopEmbedLogStoreErr := woodpecker.StopEmbedLogStore()
 			assert.NoError(t, stopEmbedLogStoreErr, "close embed LogStore instance error")
 		})

--- a/woodpecker/log/log_reader.go
+++ b/woodpecker/log/log_reader.go
@@ -18,6 +18,7 @@ package log
 
 import (
 	"context"
+	"math"
 	"strconv"
 	"time"
 
@@ -369,11 +370,31 @@ func (l *logBatchReaderImpl) isEntryInCurrentSegment(ctx context.Context) bool {
 	return true
 }
 
-// findNextReadableSegment finds the next segment that can be read from
+// findNextReadableSegment finds the next segment that can be read from.
+//
+// A segment that is logically Truncated but still physically present is readable:
+// truncation only adjusts the start position at open time (see
+// logHandleImpl.adjustPendingReadPointIfTruncated). The only thing that forces a
+// runtime position move is physical GC, detected via ErrSegmentNotFound. (issue #209)
+//
+// When a segment is missing we distinguish "GC'd" from "not written yet" using the
+// truncation point: a missing segment whose id <= truncatedSegmentId has been GC'd
+// (cleanup only deletes segments up to the truncation point, and the truncation
+// segment itself can be GC'd once the point advances), so we skip forward to the
+// oldest segment that still exists; a missing segment beyond the truncation point is
+// not written yet, so we stop and let the caller wait. When the log was never
+// truncated (truncatedSegmentId < 0) there is no GC region, so a missing segment is
+// always treated as not-yet-written.
 func (l *logBatchReaderImpl) findNextReadableSegment(ctx context.Context, latestSegmentId int64) (segment.SegmentHandle, int64, int64, error) {
 	// Start searching from the next segment (entry ID will be 0)
 	nextSegmentId := l.pendingReadSegmentId
 	nextEntryId := l.pendingReadEntryId
+
+	// truncatedSegmentId is fetched lazily, only on the first ErrSegmentNotFound, so
+	// that idle tail readers (pending > latest, loop body never runs) do not read meta
+	// on every poll (cf. #189/#190).
+	var truncatedSegmentId int64 = -1
+	truncatedFetched := false
 
 	for nextSegmentId <= latestSegmentId {
 		segHandle, err := l.logHandle.GetExistsReadonlySegmentHandle(context.Background(), nextSegmentId)
@@ -388,27 +409,29 @@ func (l *logBatchReaderImpl) findNextReadableSegment(ctx context.Context, latest
 		}
 
 		if err != nil && werr.ErrSegmentNotFound.Is(err) {
-			// Segment doesn't exist, try next one
-			nextSegmentId++
-			continue
+			// Segment metadata is gone. Decide whether it was physically GC'd (skip
+			// forward) or simply not written yet (stop and let the caller wait).
+			if !truncatedFetched {
+				truncatedSegmentId = l.fetchTruncatedSegmentIdForSkip(ctx)
+				truncatedFetched = true
+			}
+			if truncatedSegmentId >= 0 && nextSegmentId <= truncatedSegmentId {
+				// Within the GC-able range and missing -> it has been cleaned. Probe
+				// forward to the next segment.
+				nextSegmentId++
+				continue
+			}
+			// Beyond the truncation point (or never truncated): treat as not-yet-written
+			// and let the caller wait for it without moving the read position.
+			break
 		}
 
 		// assert segHandle != nil
 		if segHandle != nil {
 			m := segHandle.GetMetadata(context.Background())
 
-			// Skip truncated segments
-			if m.Metadata.State == proto.SegmentState_Truncated {
-				logger.Ctx(ctx).Debug("skip truncated segment",
-					zap.String("logName", l.logName),
-					zap.Int64("logId", l.logId),
-					zap.Int64("segmentId", segHandle.GetId(ctx)),
-					zap.String("readerName", l.readerName))
-				nextSegmentId++
-				continue
-			}
-
-			// Found a readable segment (completed or active)
+			// NOTE: a Truncated-but-still-present segment is readable and must NOT be
+			// skipped here; logical truncation is enforced only at open time. (#209)
 			logger.Ctx(ctx).Debug("found readable segment",
 				zap.String("logName", l.logName),
 				zap.Int64("logId", l.logId),
@@ -416,6 +439,16 @@ func (l *logBatchReaderImpl) findNextReadableSegment(ctx context.Context, latest
 				zap.String("state", m.Metadata.State.String()),
 				zap.String("readerName", l.readerName))
 			if nextSegmentId > l.pendingReadSegmentId {
+				// We advanced past one or more physically cleaned (GC'd) segments to
+				// satisfy this read. Surface the forced position move for audit. (#209)
+				logger.Ctx(ctx).Warn("requested read position is in a cleaned(GC'd) range, skipping forward to the oldest available segment",
+					zap.String("logName", l.logName),
+					zap.Int64("logId", l.logId),
+					zap.String("readerName", l.readerName),
+					zap.Int64("requestedSegmentId", l.pendingReadSegmentId),
+					zap.Int64("requestedEntryId", l.pendingReadEntryId),
+					zap.Int64("resumeSegmentId", nextSegmentId),
+					zap.String("resumeSegmentState", m.Metadata.State.String()))
 				// move to nextSegment's first entryId
 				nextEntryId = 0
 			}
@@ -429,6 +462,23 @@ func (l *logBatchReaderImpl) findNextReadableSegment(ctx context.Context, latest
 	// No existing segment found, wait for future segment (silent: this is the
 	// steady-state of an idle tail reader and must not log on every poll, issue #190).
 	return nil, -1, -1, werr.ErrSegmentNotFound.WithCauseErrMsg("no existing readable segment found")
+}
+
+// fetchTruncatedSegmentIdForSkip returns the current truncation point's segment id,
+// used to decide whether a missing segment was physically GC'd. If the truncation
+// point cannot be read, it degrades to the legacy bounded scan (skip the missing
+// segment within [pending, latest]) instead of blocking, by returning math.MaxInt64.
+func (l *logBatchReaderImpl) fetchTruncatedSegmentIdForSkip(ctx context.Context) int64 {
+	truncatedId, err := l.logHandle.GetTruncatedRecordId(ctx)
+	if err != nil {
+		logger.Ctx(ctx).Warn("failed to get truncation point while resolving a missing segment, falling back to skip",
+			zap.String("logName", l.logName),
+			zap.Int64("logId", l.logId),
+			zap.String("readerName", l.readerName),
+			zap.Error(err))
+		return math.MaxInt64
+	}
+	return truncatedId.SegmentId
 }
 
 func (l *logBatchReaderImpl) GetName() string {

--- a/woodpecker/log/log_reader_test.go
+++ b/woodpecker/log/log_reader_test.go
@@ -657,11 +657,13 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("SkipTruncatedSegment", func(t *testing.T) {
+	t.Run("ReadTruncatedSegmentNotGCed", func(t *testing.T) {
+		// A segment that is logically Truncated but still physically present must be
+		// read directly from the requested position. It is only skipped once it has
+		// been physically GC'd (ErrSegmentNotFound). See issue #209.
 		mockLogHandle := &testLogHandleMock{}
 		mockLogHandle.Test(t)
 		mockTruncatedSegHandle := mocks_segment_handle.NewSegmentHandle(t)
-		mockActiveSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
 			logName:              "test-log",
@@ -670,39 +672,110 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 			logHandle:            mockLogHandle,
 			readerName:           "test-reader",
 			pendingReadSegmentId: 0,
-			pendingReadEntryId:   0,
+			pendingReadEntryId:   3,
 		}
 
-		// Segment 0 is truncated
+		// Segment 0 is marked Truncated but still exists -> must be returned as-is
 		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(0)).Return(mockTruncatedSegHandle, nil)
 		mockTruncatedSegHandle.EXPECT().GetMetadata(mock.Anything).Return(&meta.SegmentMeta{
 			Metadata: &proto.SegmentMetadata{
-				State: proto.SegmentState_Truncated,
+				State:       proto.SegmentState_Truncated,
+				LastEntryId: 10,
 			},
 		})
 		mockTruncatedSegHandle.EXPECT().GetId(mock.Anything).Return(int64(0)).Maybe()
 
-		// Segment 1 is active
-		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(1)).Return(mockActiveSegHandle, nil)
-		mockActiveSegHandle.EXPECT().GetMetadata(mock.Anything).Return(&meta.SegmentMeta{
+		ctx := context.Background()
+		segHandle, segId, entryId, err := reader.findNextReadableSegment(ctx, 0)
+		assert.NotNil(t, segHandle)
+		assert.Equal(t, int64(0), segId)
+		assert.Equal(t, int64(3), entryId) // unchanged: read directly from the requested position
+		assert.NoError(t, err)
+		// The segment is still present, so no truncation-point lookup is needed.
+		mockLogHandle.AssertNotCalled(t, "GetTruncatedRecordId", mock.Anything)
+	})
+
+	t.Run("SkipGCedSegmentToOldestLiveSegment", func(t *testing.T) {
+		// Requested position falls on physically GC'd segments (ErrSegmentNotFound)
+		// below the truncation point -> skip forward to the oldest segment that still
+		// exists and continue from its first entry. See issue #209.
+		mockLogHandle := &testLogHandleMock{}
+		mockLogHandle.Test(t)
+		mockLiveSegHandle := mocks_segment_handle.NewSegmentHandle(t)
+
+		reader := &logBatchReaderImpl{
+			logName:              "test-log",
+			logId:                1,
+			logIdStr:             "1",
+			logHandle:            mockLogHandle,
+			readerName:           "test-reader",
+			pendingReadSegmentId: 0,
+			pendingReadEntryId:   7,
+		}
+
+		// Truncation point at segment 5; segments 0 and 1 are GC'd, segment 2 is live.
+		mockLogHandle.On("GetTruncatedRecordId", mock.Anything).Return(&LogMessageId{SegmentId: 5, EntryId: 100}, nil)
+		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(0)).Return(nil, werr.ErrSegmentNotFound)
+		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(1)).Return(nil, werr.ErrSegmentNotFound)
+		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(2)).Return(mockLiveSegHandle, nil)
+		mockLiveSegHandle.EXPECT().GetMetadata(mock.Anything).Return(&meta.SegmentMeta{
 			Metadata: &proto.SegmentMetadata{
 				State:       proto.SegmentState_Active,
-				LastEntryId: 5,
+				LastEntryId: 20,
 			},
 		})
-		mockActiveSegHandle.EXPECT().GetId(mock.Anything).Return(int64(1)).Maybe()
+		mockLiveSegHandle.EXPECT().GetId(mock.Anything).Return(int64(2)).Maybe()
 
 		ctx := context.Background()
-		segHandle, segId, entryId, err := reader.findNextReadableSegment(ctx, 1)
+		segHandle, segId, entryId, err := reader.findNextReadableSegment(ctx, 5)
 		assert.NotNil(t, segHandle)
-		assert.Equal(t, int64(1), segId)
-		assert.Equal(t, int64(0), entryId) // reset to 0 because we moved to next segment
+		assert.Equal(t, int64(2), segId)
+		assert.Equal(t, int64(0), entryId) // reset to 0 because we advanced past GC'd segments
 		assert.NoError(t, err)
 	})
 
-	t.Run("SegmentNotFoundError", func(t *testing.T) {
+	t.Run("WaitWhenMissingSegmentBeyondTruncationPoint", func(t *testing.T) {
+		// A missing segment that is *beyond* the truncation point is "not written yet"
+		// (future) -> wait, do NOT skip forward even if a later segment already exists.
+		// This preserves normal tail-read behavior. See issue #209.
 		mockLogHandle := &testLogHandleMock{}
 		mockLogHandle.Test(t)
+		mockSeg7 := mocks_segment_handle.NewSegmentHandle(t)
+
+		reader := &logBatchReaderImpl{
+			logName:              "test-log",
+			logId:                1,
+			logIdStr:             "1",
+			logHandle:            mockLogHandle,
+			readerName:           "test-reader",
+			pendingReadSegmentId: 6,
+			pendingReadEntryId:   0,
+		}
+
+		mockLogHandle.On("GetTruncatedRecordId", mock.Anything).Return(&LogMessageId{SegmentId: 3, EntryId: 50}, nil)
+		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(6)).Return(nil, werr.ErrSegmentNotFound)
+		// Segment 7 exists but must NOT be reached, because 6 > truncatedPoint(3).
+		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(7)).Return(mockSeg7, nil).Maybe()
+		mockSeg7.EXPECT().GetMetadata(mock.Anything).Return(&meta.SegmentMeta{
+			Metadata: &proto.SegmentMetadata{State: proto.SegmentState_Active, LastEntryId: 5},
+		}).Maybe()
+		mockSeg7.EXPECT().GetId(mock.Anything).Return(int64(7)).Maybe()
+
+		ctx := context.Background()
+		segHandle, segId, entryId, err := reader.findNextReadableSegment(ctx, 7)
+		assert.Nil(t, segHandle)
+		assert.Equal(t, int64(-1), segId)
+		assert.Equal(t, int64(-1), entryId)
+		assert.True(t, werr.ErrSegmentNotFound.Is(err))
+	})
+
+	t.Run("NoTruncationPointMissingSegmentWaits", func(t *testing.T) {
+		// When the log was never truncated (truncated point == -1) there is no GC
+		// region; a missing segment is "not written yet" -> wait, do not move the read
+		// position (unchanged legacy behavior). See issue #209.
+		mockLogHandle := &testLogHandleMock{}
+		mockLogHandle.Test(t)
+		mockSeg1 := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
 			logName:              "test-log",
@@ -714,17 +787,116 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 			pendingReadEntryId:   0,
 		}
 
-		// Segment 0 not found (skip), segment 1 also not found
+		mockLogHandle.On("GetTruncatedRecordId", mock.Anything).Return(&LogMessageId{SegmentId: -1, EntryId: -1}, nil)
 		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(0)).Return(nil, werr.ErrSegmentNotFound)
-		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(1)).Return(nil, werr.ErrSegmentNotFound)
+		// Segment 1 exists but must NOT be reached because there is no GC region.
+		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(1)).Return(mockSeg1, nil).Maybe()
+		mockSeg1.EXPECT().GetMetadata(mock.Anything).Return(&meta.SegmentMeta{
+			Metadata: &proto.SegmentMetadata{State: proto.SegmentState_Active, LastEntryId: 5},
+		}).Maybe()
+		mockSeg1.EXPECT().GetId(mock.Anything).Return(int64(1)).Maybe()
 
 		ctx := context.Background()
 		segHandle, segId, entryId, err := reader.findNextReadableSegment(ctx, 1)
 		assert.Nil(t, segHandle)
 		assert.Equal(t, int64(-1), segId)
 		assert.Equal(t, int64(-1), entryId)
-		assert.Error(t, err)
 		assert.True(t, werr.ErrSegmentNotFound.Is(err))
+	})
+
+	t.Run("TruncationSegmentItselfGCedSkipsForward", func(t *testing.T) {
+		// Boundary: the missing segment id == truncated point's segment id. After the
+		// truncation point advances, the old truncation segment can itself be GC'd, so
+		// a missing segment AT the truncation point must skip forward (<=, not <).
+		// See issue #209.
+		mockLogHandle := &testLogHandleMock{}
+		mockLogHandle.Test(t)
+		mockSeg6 := mocks_segment_handle.NewSegmentHandle(t)
+
+		reader := &logBatchReaderImpl{
+			logName:              "test-log",
+			logId:                1,
+			logIdStr:             "1",
+			logHandle:            mockLogHandle,
+			readerName:           "test-reader",
+			pendingReadSegmentId: 5,
+			pendingReadEntryId:   2,
+		}
+
+		mockLogHandle.On("GetTruncatedRecordId", mock.Anything).Return(&LogMessageId{SegmentId: 5, EntryId: 0}, nil)
+		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(5)).Return(nil, werr.ErrSegmentNotFound)
+		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(6)).Return(mockSeg6, nil)
+		mockSeg6.EXPECT().GetMetadata(mock.Anything).Return(&meta.SegmentMeta{
+			Metadata: &proto.SegmentMetadata{State: proto.SegmentState_Active, LastEntryId: 5},
+		})
+		mockSeg6.EXPECT().GetId(mock.Anything).Return(int64(6)).Maybe()
+
+		ctx := context.Background()
+		segHandle, segId, entryId, err := reader.findNextReadableSegment(ctx, 6)
+		assert.NotNil(t, segHandle)
+		assert.Equal(t, int64(6), segId)
+		assert.Equal(t, int64(0), entryId)
+		assert.NoError(t, err)
+	})
+
+	t.Run("GetTruncatedRecordIdErrorFallsBackToSkip", func(t *testing.T) {
+		// If the truncation point cannot be read, degrade to skipping the missing
+		// segment (legacy bounded-scan behavior) rather than blocking forever.
+		mockLogHandle := &testLogHandleMock{}
+		mockLogHandle.Test(t)
+		mockSeg1 := mocks_segment_handle.NewSegmentHandle(t)
+
+		reader := &logBatchReaderImpl{
+			logName:              "test-log",
+			logId:                1,
+			logIdStr:             "1",
+			logHandle:            mockLogHandle,
+			readerName:           "test-reader",
+			pendingReadSegmentId: 0,
+			pendingReadEntryId:   0,
+		}
+
+		mockLogHandle.On("GetTruncatedRecordId", mock.Anything).Return(nil, werr.ErrInternalError)
+		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(0)).Return(nil, werr.ErrSegmentNotFound)
+		mockLogHandle.On("GetExistsReadonlySegmentHandle", mock.Anything, int64(1)).Return(mockSeg1, nil)
+		mockSeg1.EXPECT().GetMetadata(mock.Anything).Return(&meta.SegmentMeta{
+			Metadata: &proto.SegmentMetadata{State: proto.SegmentState_Active, LastEntryId: 5},
+		})
+		mockSeg1.EXPECT().GetId(mock.Anything).Return(int64(1)).Maybe()
+
+		ctx := context.Background()
+		segHandle, segId, entryId, err := reader.findNextReadableSegment(ctx, 1)
+		assert.NotNil(t, segHandle)
+		assert.Equal(t, int64(1), segId)
+		assert.Equal(t, int64(0), entryId)
+		assert.NoError(t, err)
+	})
+
+	t.Run("IdleReaderBeyondLatestDoesNotFetchTruncationPoint", func(t *testing.T) {
+		// pending(5) > latest(4): the scan loop never runs, so an idle tail reader must
+		// return ErrSegmentNotFound WITHOUT reading the truncation point (no per-poll
+		// etcd read, cf. #189/#190).
+		mockLogHandle := &testLogHandleMock{}
+		mockLogHandle.Test(t)
+
+		reader := &logBatchReaderImpl{
+			logName:              "test-log",
+			logId:                1,
+			logIdStr:             "1",
+			logHandle:            mockLogHandle,
+			readerName:           "test-reader",
+			pendingReadSegmentId: 5,
+			pendingReadEntryId:   0,
+		}
+
+		ctx := context.Background()
+		segHandle, segId, entryId, err := reader.findNextReadableSegment(ctx, 4)
+		assert.Nil(t, segHandle)
+		assert.Equal(t, int64(-1), segId)
+		assert.Equal(t, int64(-1), entryId)
+		assert.True(t, werr.ErrSegmentNotFound.Is(err))
+		mockLogHandle.AssertNotCalled(t, "GetTruncatedRecordId", mock.Anything)
+		mockLogHandle.AssertNotCalled(t, "GetExistsReadonlySegmentHandle", mock.Anything, mock.Anything)
 	})
 
 	t.Run("GetSegmentHandleReturnsOtherError", func(t *testing.T) {


### PR DESCRIPTION
## What

Fixes #209.

A reader **reopened at an explicit (non-earliest) position** should read from that position as long as the data is still physically present — logically *truncated* but not yet garbage-collected (GC'd). Previously such a reader was force-advanced to the truncation point, silently dropping the requested position.

## Why it happened

Two layers disagreed:

- **Open time** — `adjustPendingReadPointIfTruncated` / `shouldMoveToTruncationPoint` already only force the start to the truncation point for `earliest` reads, and keep an explicit position as-is.
- **Read time** — `findNextReadableSegment` then **unconditionally skipped `SegmentState_Truncated` segments**, advancing to the truncation point and undoing the open-time decision.

Truncation is a *logical* marker (data still present); only physical GC (`ErrSegmentNotFound`, after `DeleteSegmentMetadata`) should force a runtime position move. There is no recorded GC watermark — `ErrSegmentNotFound` is the only signal, which is robust to partial-cleanup holes.

## Change (`woodpecker/log/log_reader.go`, `findNextReadableSegment`)

1. **Don't skip `Truncated`-but-present segments** — they are readable like any completed/active segment.
2. **On `ErrSegmentNotFound`, distinguish GC'd vs not-yet-written via the truncation point:**
   - `truncatedSegmentId < 0` (never truncated, sentinel `-1`) → wait, don't move.
   - `nextSegmentId <= truncatedSegmentId` → physically GC'd → skip forward to the oldest still-present segment. `<=` (not `<`) so the truncation segment itself is skippable once the point advances and it gets GC'd.
   - otherwise (beyond the truncation point) → not written yet → wait without moving.
   - The truncation point is fetched **lazily**, only on the `ErrSegmentNotFound` branch, so idle tail readers (`pending > latest`, loop body never runs) never read metadata per poll (cf. #189/#190). On fetch error it degrades to skip (legacy bounded scan) rather than blocking.
3. **Logging for forced position moves:** keep **INFO** for the open-time `earliest → truncated+1` adjustment; add **WARN** when a read skips forward across a cleaned (GC'd) range (requested → resume position), for auditability.

## Behavior matrix

| Open mode | Data state | Behavior |
|---|---|---|
| `earliest (0,0)` | truncation point exists | move start to `truncated+1` at open (INFO) |
| explicit position | normal / truncated-but-not-GC'd | read directly from that position, no adjustment |
| explicit position | falls in a GC'd range | skip forward to the oldest available segment (WARN) |

## Tests

- **Unit** — `TestLogReader_FindNextReadableSegment` rewritten to cover: reading a truncated-but-present segment; skipping a GC'd prefix to the oldest live segment; waiting when a missing segment is beyond the truncation point; waiting (unchanged) when the log was never truncated; the `<=` boundary (truncation segment itself GC'd); the fetch-error fallback; and that idle readers do **not** fetch the truncation point.
- **e2e** — `TestReopenAtTruncatedButNotGCedPosition` restarts the client so the reader gets fresh segment handles reflecting the persisted `Truncated` state (the in-process handle cache otherwise masks the bug). It fails without the fix and passes with it, on both LocalFs and ObjectStorage backends.

Full `woodpecker/log` suite + `golangci-lint` clean; whole-repo build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
