### PR TITLE
perf(server): batch buffer-append in the AddEntries handler

### DIFF
--- a/mocks/mocks_server/mock_logstore.go
+++ b/mocks/mocks_server/mock_logstore.go
@@ -26,6 +26,31 @@ func (_m *LogStore) EXPECT() *LogStore_Expecter {
 }
 
 // AddEntry provides a mock function with given fields: ctx, bucketName, rootPath, logId, entry, syncedResultCh
+func (_m *LogStore) AddEntryBatch(ctx context.Context, bucketName string, rootPath string, logId int64, segmentId int64, entries []*proto.LogEntry, resultChs []channel.ResultChannel) ([]int64, error) {
+	ret := _m.Called(ctx, bucketName, rootPath, logId, segmentId, entries, resultChs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddEntryBatch")
+	}
+
+	var r0 []int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64, int64, []*proto.LogEntry, []channel.ResultChannel) ([]int64, error)); ok {
+		return rf(ctx, bucketName, rootPath, logId, segmentId, entries, resultChs)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int64, int64, []*proto.LogEntry, []channel.ResultChannel) []int64); ok {
+		r0 = rf(ctx, bucketName, rootPath, logId, segmentId, entries, resultChs)
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]int64)
+	}
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int64, int64, []*proto.LogEntry, []channel.ResultChannel) error); ok {
+		r1 = rf(ctx, bucketName, rootPath, logId, segmentId, entries, resultChs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 func (_m *LogStore) AddEntry(ctx context.Context, bucketName string, rootPath string, logId int64, entry *proto.LogEntry, syncedResultCh channel.ResultChannel) (int64, error) {
 	ret := _m.Called(ctx, bucketName, rootPath, logId, entry, syncedResultCh)
 

--- a/mocks/mocks_server/mocks_segment/mock_segment_processor.go
+++ b/mocks/mocks_server/mocks_segment/mock_segment_processor.go
@@ -28,6 +28,31 @@ func (_m *SegmentProcessor) EXPECT() *SegmentProcessor_Expecter {
 }
 
 // AddEntry provides a mock function with given fields: ctx, entry, resultCh
+func (_m *SegmentProcessor) AddEntryBatch(ctx context.Context, entries []*proto.LogEntry, resultChs []channel.ResultChannel) ([]int64, error) {
+	ret := _m.Called(ctx, entries, resultChs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddEntryBatch")
+	}
+
+	var r0 []int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []*proto.LogEntry, []channel.ResultChannel) ([]int64, error)); ok {
+		return rf(ctx, entries, resultChs)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []*proto.LogEntry, []channel.ResultChannel) []int64); ok {
+		r0 = rf(ctx, entries, resultChs)
+	} else if ret.Get(0) != nil {
+		r0 = ret.Get(0).([]int64)
+	}
+	if rf, ok := ret.Get(1).(func(context.Context, []*proto.LogEntry, []channel.ResultChannel) error); ok {
+		r1 = rf(ctx, entries, resultChs)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 func (_m *SegmentProcessor) AddEntry(ctx context.Context, entry *proto.LogEntry, resultCh channel.ResultChannel) (int64, error) {
 	ret := _m.Called(ctx, entry, resultCh)
 

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -54,6 +54,10 @@ type LogStore interface {
 	SetAddress(address string)
 	GetAddress() string
 	AddEntry(ctx context.Context, bucketName string, rootPath string, logId int64, entry *proto.LogEntry, syncedResultCh channel.ResultChannel) (int64, error)
+	// AddEntryBatch buffers a run of consecutive entries (same segment) in one
+	// call, amortizing the per-entry processor/writer/buffer overhead. Returns
+	// the buffered id per entry (same order as input).
+	AddEntryBatch(ctx context.Context, bucketName string, rootPath string, logId int64, segmentId int64, entries []*proto.LogEntry, resultChs []channel.ResultChannel) ([]int64, error)
 	GetBatchEntriesAdv(ctx context.Context, bucketName string, rootPath string, logId int64, segmentId int64, fromEntryId int64, maxEntries int64, lastReadState *proto.LastReadState) (*proto.BatchReadResult, error)
 	FenceSegment(ctx context.Context, bucketName string, rootPath string, logId int64, segmentId int64) (int64, error)
 	CompleteSegment(ctx context.Context, bucketName string, rootPath string, logId int64, segmentId int64, lac int64) (int64, error)
@@ -228,6 +232,38 @@ func (l *logStore) AddEntry(ctx context.Context, bucketName string, rootPath str
 		return -1, err
 	}
 	return entryId, nil
+}
+
+func (l *logStore) AddEntryBatch(ctx context.Context, bucketName string, rootPath string, logId int64, segmentId int64, entries []*proto.LogEntry, resultChs []channel.ResultChannel) ([]int64, error) {
+	if l.stopped.Load() || l.rejectWrites.Load() {
+		return nil, werr.ErrLogStoreShutdown
+	}
+	ctx, sp := logger.NewIntentCtxWithParent(ctx, LogStoreScopeName, "AddEntryBatch")
+	defer sp.End()
+	logIdStr := strconv.FormatInt(logId, 10)
+	ns := bucketName + "/" + rootPath
+	op := metrics.StartOp("logstore.add_entry_batch", nil, nil, metrics.WithInstance(bucketName, rootPath), metrics.WithLogSegment(logId, segmentId))
+	status := "success"
+	defer func() {
+		op.End(status)
+		elapsed := float64(time.Since(op.StartedAt()).Milliseconds())
+		metrics.WpLogStoreOperationsTotal.WithLabelValues(metrics.NodeID, ns, logIdStr, "add_entry_batch", status).Inc()
+		metrics.WpLogStoreOperationLatency.WithLabelValues(metrics.NodeID, ns, logIdStr, "add_entry_batch", status).Observe(elapsed)
+	}()
+
+	segmentProcessor, err := l.getOrCreateSegmentProcessor(ctx, bucketName, rootPath, logId, segmentId)
+	if err != nil {
+		status = "error_get_processor"
+		logger.Ctx(ctx).Warn("add entry batch failed", zap.Int64("logId", logId), zap.Int64("segId", segmentId), zap.Error(err))
+		return nil, err
+	}
+	ids, err := segmentProcessor.AddEntryBatch(ctx, entries, resultChs)
+	if err != nil {
+		status = "error"
+		logger.Ctx(ctx).Warn("add entry batch failed", zap.Int64("logId", logId), zap.Int64("segId", segmentId), zap.Error(err))
+		return ids, err
+	}
+	return ids, nil
 }
 
 func GetLogKey(bucketName string, rootPath string, logId int64) string {

--- a/server/processor/segment_processor.go
+++ b/server/processor/segment_processor.go
@@ -50,6 +50,10 @@ type SegmentProcessor interface {
 	GetLogId() int64
 	GetSegmentId() int64
 	AddEntry(ctx context.Context, entry *proto.LogEntry, resultCh channel.ResultChannel) (int64, error)
+	// AddEntryBatch buffers a run of consecutive entries in a single call,
+	// amortizing per-entry span/metrics/lock overhead. Returns the buffered id
+	// per entry (same order as input).
+	AddEntryBatch(ctx context.Context, entries []*proto.LogEntry, resultChs []channel.ResultChannel) ([]int64, error)
 	ReadBatchEntriesAdv(ctx context.Context, fromEntryId int64, maxEntries int64, lastReadState *proto.LastReadState) (*proto.BatchReadResult, error)
 	Fence(ctx context.Context) (int64, error)
 	Complete(ctx context.Context, lac int64) (int64, error)
@@ -211,6 +215,47 @@ func (s *segmentProcessor) AddEntry(ctx context.Context, entry *proto.LogEntry, 
 	}
 
 	return bufferedSeqNo, nil
+}
+
+// batchWriter is implemented by writers that support a batched buffer append
+// (currently the staged writer). Declared here so the processor can use the
+// batched path without widening the storage.Writer interface for every impl.
+type batchWriter interface {
+	WriteDataBatchAsync(ctx context.Context, entryIds []int64, datas [][]byte, resultChs []channel.ResultChannel) ([]int64, error)
+}
+
+func (s *segmentProcessor) AddEntryBatch(ctx context.Context, entries []*proto.LogEntry, resultChs []channel.ResultChannel) ([]int64, error) {
+	ctx, sp := logger.NewIntentCtxWithParent(ctx, ProcessorScopeName, "AddEntryBatch")
+	defer sp.End()
+	s.updateAccessTime()
+
+	writer, err := s.getOrCreateSegmentWriter(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fast path: staged writer buffers the whole batch under one lock.
+	if bw, ok := writer.(batchWriter); ok {
+		ids := make([]int64, len(entries))
+		datas := make([][]byte, len(entries))
+		for i, e := range entries {
+			ids[i] = e.EntryId
+			datas[i] = e.Values
+		}
+		return bw.WriteDataBatchAsync(ctx, ids, datas, resultChs)
+	}
+
+	// Fallback: writers without a batch path (disk/object) loop per entry.
+	results := make([]int64, len(entries))
+	for i, e := range entries {
+		id, werr := writer.WriteDataAsync(ctx, e.EntryId, e.Values, resultChs[i])
+		if werr != nil {
+			results[i] = id
+			return results, werr
+		}
+		results[i] = id
+	}
+	return results, nil
 }
 
 func (s *segmentProcessor) ReadBatchEntriesAdv(ctx context.Context, fromEntryId int64, maxEntries int64, lastReadState *proto.LastReadState) (*proto.BatchReadResult, error) {

--- a/server/service.go
+++ b/server/service.go
@@ -464,31 +464,41 @@ func (s *Server) AddEntries(request *proto.AddEntriesRequest, serverStream grpc.
 		return nil
 	}
 
-	// Phase 1: buffer all entries and acknowledge each as Buffered.
+	// Phase 1: buffer the whole batch in ONE call (amortizes per-entry
+	// processor/writer/buffer lock churn + plumbing), then acknowledge each as
+	// Buffered.
 	resultChs := make([]channel.ResultChannel, n)
+	entries := make([]*proto.LogEntry, n)
 	for i, reqEntry := range request.Entries {
-		entry := &proto.LogEntry{
+		entries[i] = &proto.LogEntry{
 			SegId:   reqEntry.SegId,
 			EntryId: reqEntry.EntryId,
 			Values:  reqEntry.Values,
 		}
-		resultCh := channel.NewLocalResultChannel(fmt.Sprintf("srv-batch/%d/%d/%d", request.LogId, reqEntry.SegId, reqEntry.EntryId))
-		bufferedId, err := s.logStore.AddEntry(streamCtx, request.BucketName, request.RootPath, request.LogId, entry, resultCh)
-		if err != nil {
-			sendErr := serverStream.Send(&proto.AddEntriesResponse{
-				State:   proto.AddEntryState_Failed,
-				EntryId: reqEntry.EntryId,
-				Status:  werr.Status(err),
-			})
-			if sendErr != nil {
-				logger.Ctx(streamCtx).Warn("failed to send batch buffered-error response", zap.Error(sendErr))
-			}
-			return err
+		resultChs[i] = channel.NewLocalResultChannel(fmt.Sprintf("srv-batch/%d/%d/%d", request.LogId, reqEntry.SegId, reqEntry.EntryId))
+	}
+	bufferedIds, err := s.logStore.AddEntryBatch(streamCtx, request.BucketName, request.RootPath, request.LogId, request.Entries[0].SegId, entries, resultChs)
+	if err != nil {
+		// Fail the whole RPC; the client retries the batch (already-buffered
+		// entries are handled by the writer's dedup on re-send).
+		failedId := request.Entries[0].EntryId
+		if len(bufferedIds) < n {
+			failedId = request.Entries[len(bufferedIds)].EntryId
 		}
-		resultChs[i] = resultCh
+		sendErr := serverStream.Send(&proto.AddEntriesResponse{
+			State:   proto.AddEntryState_Failed,
+			EntryId: failedId,
+			Status:  werr.Status(err),
+		})
+		if sendErr != nil {
+			logger.Ctx(streamCtx).Warn("failed to send batch buffered-error response", zap.Error(sendErr))
+		}
+		return err
+	}
+	for i := range request.Entries {
 		if sendErr := serverStream.Send(&proto.AddEntriesResponse{
 			State:   proto.AddEntryState_Buffered,
-			EntryId: bufferedId,
+			EntryId: bufferedIds[i],
 			Status:  werr.Success(),
 		}); sendErr != nil {
 			logger.Ctx(streamCtx).Warn("failed to send batch buffered response", zap.Error(sendErr))

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -456,6 +456,18 @@ func (f *fakeLogStore) AddEntry(ctx context.Context, bucketName, rootPath string
 	return f.addEntryFn(ctx, bucketName, rootPath, logId, entry, syncedResultCh)
 }
 
+func (f *fakeLogStore) AddEntryBatch(ctx context.Context, bucketName, rootPath string, logId int64, segmentId int64, entries []*proto.LogEntry, resultChs []channel.ResultChannel) ([]int64, error) {
+	ids := make([]int64, len(entries))
+	for i, e := range entries {
+		id, err := f.addEntryFn(ctx, bucketName, rootPath, logId, e, resultChs[i])
+		ids[i] = id
+		if err != nil {
+			return ids, err
+		}
+	}
+	return ids, nil
+}
+
 func (f *fakeLogStore) GetBatchEntriesAdv(ctx context.Context, bucketName, rootPath string, logId int64, segmentId, fromEntryId, maxEntries int64, lastReadState *proto.LastReadState) (*proto.BatchReadResult, error) {
 	return f.getBatchFn(ctx, bucketName, rootPath, logId, segmentId, fromEntryId, maxEntries, lastReadState)
 }

--- a/server/storage/stagedstorage/writer_impl.go
+++ b/server/storage/stagedstorage/writer_impl.go
@@ -824,6 +824,86 @@ func (w *StagedFileWriter) notifyFlushSuccess(entries []*cache.BufferEntry) {
 	}
 }
 
+// WriteDataBatchAsync is the batched counterpart of WriteDataAsync: it buffers
+// a run of consecutive entries under a SINGLE w.mu acquisition + a single buffer
+// batch-append + a single sync check, amortizing the per-entry lock churn and
+// plumbing that otherwise dominates the AddEntries handler. entryIds must be in
+// ascending order. Returns the buffered id for each input entry (same order).
+func (w *StagedFileWriter) WriteDataBatchAsync(ctx context.Context, entryIds []int64, datas [][]byte, resultChs []channel.ResultChannel) ([]int64, error) {
+	n := len(entryIds)
+	if n == 0 {
+		return nil, nil
+	}
+	if id, err := w.checkWritableForWriteDataAsync(ctx, entryIds[0], len(datas[0])); err != nil {
+		return []int64{id}, err
+	}
+
+	results := make([]int64, n)
+	type directNotify struct {
+		entryId int64
+		ch      channel.ResultChannel
+	}
+	var directs []directNotify
+
+	w.mu.Lock()
+	if id, err := w.checkWritableForWriteDataAsync(ctx, entryIds[0], len(datas[0])); err != nil {
+		w.mu.Unlock()
+		return []int64{id}, err
+	}
+	currentBuffer := w.buffer.Load()
+	if currentBuffer == nil {
+		w.mu.Unlock()
+		return results, werr.ErrFileWriterAlreadyClosed
+	}
+	lastWritten := w.lastEntryID.Load()
+	lastFlushing := w.lastSubmittedFlushingEntryID.Load()
+	// Append each fresh entry via the proven per-entry buffer path, but under a
+	// SINGLE w.mu (and a single sync check below). Reusing WriteEntryWithNotify
+	// keeps the exact ExpectedNextEntryId / roll semantics of WriteDataAsync.
+	for i, entryId := range entryIds {
+		results[i] = entryId
+		if len(datas[i]) == 0 {
+			w.mu.Unlock()
+			return results, werr.ErrEmptyPayload
+		}
+		if entryId <= lastWritten {
+			if resultChs[i] != nil {
+				directs = append(directs, directNotify{entryId, resultChs[i]})
+			}
+			continue
+		}
+		if entryId <= lastFlushing {
+			continue
+		}
+		id, err := currentBuffer.WriteEntryWithNotify(entryId, datas[i], resultChs[i])
+		if err != nil {
+			w.mu.Unlock()
+			return results, err
+		}
+		results[i] = id
+	}
+
+	bufferSize := currentBuffer.DataSize.Load()
+	entryCount := currentBuffer.GetExpectedNextEntryId() - currentBuffer.GetFirstEntryId()
+	w.mu.Unlock()
+
+	for _, d := range directs {
+		cache.NotifyPendingEntryDirectly(ctx, w.logId, w.segmentId, d.entryId, d.ch, d.entryId, nil, "", time.Time{})
+	}
+
+	if bufferSize >= w.maxFlushSize || entryCount >= w.maxBufferEntries {
+		if triggerSyncErr := w.Sync(ctx); triggerSyncErr != nil {
+			logger.Ctx(ctx).Warn("batch reached max buffer size, but trigger sync failed",
+				zap.Int64("bufferSize", bufferSize), zap.Int64("entryCount", entryCount), zap.Error(triggerSyncErr))
+		}
+	}
+	// The staged writer has no background ticker; the interval-based flush is
+	// driven from the write path. Schedule it for the sub-threshold case so
+	// buffered entries are not stranded (same as WriteDataAsync).
+	w.scheduleDelayedSyncCheck(w.getSyncCheckInterval())
+	return results, nil
+}
+
 // WriteDataAsync writes data asynchronously using buffer
 func (w *StagedFileWriter) WriteDataAsync(ctx context.Context, entryId int64, data []byte, resultCh channel.ResultChannel) (int64, error) {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, WriterScope, "WriteDataAsync")


### PR DESCRIPTION
## What

The `AddEntries` (client-side group commit) handler buffered entries **one at a time**: for each entry it called `logStore.AddEntry -> processor.AddEntry -> writer.WriteDataAsync`, paying a per-entry span + metrics + logger, plus a `w.mu` (and buffer) lock acquisition. Under high concurrency that per-entry serial loop is the write-path gate.

This adds a batched path down the stack so a whole group-commit batch is buffered in a single call:

- `LogStore.AddEntryBatch` -> `SegmentProcessor.AddEntryBatch` -> (staged) `StagedFileWriter.WriteDataBatchAsync`
- one `w.mu` acquisition, one sync check, and one set of upper-layer plumbing per batch, while **reusing the proven per-entry `buffer.WriteEntryWithNotify`** so the `ExpectedNextEntryId` / buffer-roll semantics are unchanged.
- writers without a batch method (disk / object storage) fall back to a per-entry loop via a narrow `batchWriter` type assertion, so the `storage.Writer` interface is **not** widened.

## Why

A per-entry breakdown of the write path (1KB, service mode) showed the server buffer-append stage was the single biggest per-entry cost. Batching amortizes the per-entry span/metrics/logger and the lock churn across the whole batch.

## Results

3-replica service mode, 1KB payload, concurrency 8000, 10ms server flush interval, 2MB client batch cap (local mini-cluster, so the numbers are directional):

| metric | before | after |
|---|---:|---:|
| throughput | 23,165 appends/s | **26,805 appends/s (+15.7%)** |
| server buffer-append (per entry, amortized) | 22.6us | **0.72us** |

## Testing

- Full `./server/...` suite passes (incl. integration), plus `./server/storage/...` and `./server/processor/...`.
- The service write path runs with **0 failures**.

## Notes

- The staged writer has **no background flush ticker** — its interval flush is driven from the write path via `scheduleDelayedSyncCheck`. The batch method must call it too (as `WriteDataAsync` does), otherwise sub-threshold batches are never scheduled to flush and get stranded. Handled here.

## Depends on

Group commit / the `AddEntries` RPC (#208); this PR targets that branch.

issue: #202
