### PR TITLE
perf(client): drain batch acks with one goroutine per node

### DIFF
--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -262,6 +262,37 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 		zap.Int64("syncedId", syncedResult.SyncedId), zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId), zap.Int64("entryId", op.entryId), zap.String("serverAddr", serverAddr))
 }
 
+// applyNodeAck processes a single node's durability result for this op: quorum
+// counting and, on reaching Aq, the in-order SendAppendSuccessCallbacks. It is
+// the post-read half of receivedAckCallback, factored out so the batch path can
+// drive many ops' acks from ONE per-node goroutine (reading the results in
+// entry-id order) instead of spawning a goroutine per op.
+func (op *AppendOp) applyNodeAck(ctx context.Context, startRequestTime time.Time, result *channel.AppendResult, readErr error, serverIndex int, serverAddr string) {
+	if op.fastCalled.Load() {
+		return
+	}
+	if readErr != nil {
+		op.channelErrors[serverIndex] = readErr
+		op.handle.HandleAppendRequestFailure(ctx, op.entryId, readErr, serverIndex, serverAddr)
+		return
+	}
+	if result.SyncedId == -1 || result.Err != nil {
+		op.channelErrors[serverIndex] = result.Err
+		op.handle.HandleAppendRequestFailure(ctx, op.entryId, result.Err, serverIndex, serverAddr)
+		return
+	}
+	if result.SyncedId >= op.entryId {
+		if op.ackSet.SetAndCount(serverIndex) >= int(op.quorumInfo.Aq) {
+			if op.completed.CompareAndSwap(false, true) {
+				op.handle.SendAppendSuccessCallbacks(ctx, op.entryId)
+				cost := time.Since(startRequestTime)
+				metrics.WpClientAppendLatency.WithLabelValues(op.logNs, strconv.FormatInt(op.logId, 10)).Observe(float64(cost.Milliseconds()))
+				metrics.WpClientAppendBytes.WithLabelValues(op.logNs, strconv.FormatInt(op.logId, 10)).Observe(float64(len(op.value)))
+			}
+		}
+	}
+}
+
 func (op *AppendOp) FastFail(ctx context.Context, err error) {
 	logger.Ctx(ctx).Debug("FastFail start calling",
 		zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId), zap.Int64("entryId", op.entryId), zap.Error(err))

--- a/woodpecker/segment/batch_append_op.go
+++ b/woodpecker/segment/batch_append_op.go
@@ -128,11 +128,18 @@ func (b *BatchAppendOp) sendBatchToNode(ctx context.Context, entries []*proto.Lo
 		return
 	}
 
-	// Send succeeded: hand each op its per-replica result sink so its own
-	// callback waits for and processes the durability ack.
-	for i, op := range b.ops {
-		go op.receivedAckCallback(ctx, startRequestTime, op.entryId, resultChs[i], nil, nodeIdx, serverAddr)
-	}
+	// Send succeeded: ONE goroutine per node drains the per-entry durability
+	// acks IN ORDER (the server streams them in entry-id / flush order) and
+	// applies quorum inline, instead of spawning a receivedAckCallback goroutine
+	// per op. For a batch of N entries this is 1 goroutine per node instead of N.
+	go func() {
+		readCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TODO configurable
+		defer cancel()
+		for i, op := range b.ops {
+			result, readErr := resultChs[i].ReadResult(readCtx)
+			op.applyNodeAck(ctx, startRequestTime, result, readErr, nodeIdx, serverAddr)
+		}
+	}()
 }
 
 // failNode marks every op in the batch as failed on the given replica, routing


### PR DESCRIPTION
## What

`BatchAppendOp` spawned a `receivedAckCallback` **goroutine per op per replica** — for a batch of N entries that is `N x Wq` goroutines plus N result channels. Under high concurrency the goroutine storm dominates the Go scheduler and inflates the whole write path.

The server streams the per-entry durability acks in **entry-id / flush order**, so one goroutine per node can read the results **sequentially** and apply quorum **inline**. This factors the post-read quorum logic out of `receivedAckCallback` into `AppendOp.applyNodeAck` and calls it from a single per-node drain goroutine.

- single-entry `AppendOp` path is unchanged (still uses `receivedAckCallback`);
- failure cascades are still handled by the client `AppendEntries` stream-error path (fails all remaining sinks on `Recv` error);
- for a batch of N entries this is **1 goroutine per node instead of N**.

## Results

Same setup as the batch buffer-append PR, stacked on top of it:

| metric | before (batch append) | after |
|---|---:|---:|
| throughput | 26,805 appends/s | **28,992 appends/s (+8.2%)** |
| client ack processing (total work) | baseline | **~42x less** |

Cumulative with the batch-append PR: **23,165 -> 28,992 appends/s (+25.2%)** vs the pre-optimization baseline.

## Testing

- `./woodpecker/segment/...` and `./woodpecker/client/...` suites pass.
- The service write path runs with **0 failures**.

## Notes

- This is a **client-side-only** change, **no wire-protocol change**. A fuller version would have the server emit one *watermark* `Synced` per flush instead of one per entry; the gain looks modest here and it changes wire semantics, so it's left as an optional follow-up.
- The +8.2% throughput understates the change: the benchmark **co-locates** client and server in one process, so ~8000 write goroutines still dominate the scheduler regardless. In a real deployment (separate client/server), removing the client's own N x Wq goroutine storm should give a larger throughput gain — the total ack-work reduction (~42x) reflects that better than wall throughput.

## Depends on

The batch buffer-append PR (`perf/server-batch-append`) and group commit (#208); this PR targets that branch.

issue: #202
