### PR TITLE
test(monitor): adapt Grafana dashboards to a plain PodMonitor scrape strategy

### DIFF
--- a/tests/docker/monitor/grafana/templates/dashboard_server.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_server.json
@@ -2771,7 +2771,7 @@
         "includeAll": true,
         "multi": true,
         "name": "log_ns",
-        "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\".+\"}))",
+        "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{log_ns=~\".+\"}))",
         "refresh": 2,
         "regex": "/log_ns=\"([^\"]+)\"/",
         "type": "query"
@@ -2789,13 +2789,13 @@
         "includeAll": true,
         "multi": true,
         "name": "log_id",
-        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
+        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{log_ns=~\"$log_ns\", log_id=~\".+\"}))",
         "refresh": 2,
         "regex": "/log_id=\"([^\"]+)\"/",
         "type": "query"
       },
       {
-        "allValue": "woodpecker-node[0-9]+|woodpecker/woodpecker-server",
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": "$__all"
@@ -2808,7 +2808,7 @@
         "includeAll": true,
         "multi": true,
         "name": "server_job",
-        "query": "label_values(go_goroutines{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\"}, job)",
+        "query": "label_values(woodpecker_server_logstore_instances_total, job)",
         "refresh": 2,
         "type": "query"
       }

--- a/tests/k8s/monitor/README.md
+++ b/tests/k8s/monitor/README.md
@@ -36,15 +36,19 @@ resources before running:
 MK_CPUS=6 MK_MEMORY=8192 ./run_monitor_tests.sh
 ```
 
-## Label Scheme: `cluster` / `namespace` / `log_ns`
+## Label Scheme: `namespace` / `log_ns`
 
-Woodpecker metrics carry three key labels:
+Woodpecker metrics carry two key labels:
 
 | Label | Value | Source |
 |-------|-------|--------|
-| `cluster` | `woodpecker-minikube` | set in `kube-prometheus-values.yaml` via `externalLabels` |
 | `namespace` | Kubernetes namespace (e.g. `woodpecker`) | injected by kube-prometheus-stack from the PodMonitor namespace |
 | `log_ns` | Woodpecker logical log namespace (e.g. `my-log`) | emitted by the server/client as a metric label |
+
+Dashboards derive everything else from these: the `namespace` dropdown is
+discovered via `go_info`, and the hidden `server_job` variable resolves the
+PodMonitor-assigned `job` label within the selected namespace (also via
+`go_info`), so no job name or cluster name is hardcoded.
 
 ### Breaking-change note for production dashboards
 
@@ -74,6 +78,5 @@ The test checks:
 3. **ServerMetrics** — core server metrics are present and non-zero.
 4. **ClientMetrics** — core client metrics are present and non-zero.
 5. **LabelScheme** — every `woodpecker_server_logstore_active_logs` series
-   carries `cluster=woodpecker-minikube`, `namespace=woodpecker`, a non-empty
-   `log_ns`, and no `exported_namespace` (which would indicate a relabeling
-   conflict).
+   carries `namespace=woodpecker`, a non-empty `log_ns`, and no
+   `exported_namespace` (which would indicate a relabeling conflict).

--- a/tests/k8s/monitor/dashboards_test.go
+++ b/tests/k8s/monitor/dashboards_test.go
@@ -43,11 +43,14 @@ func TestK8sDashboards_Valid(t *testing.T) {
 		if !strings.Contains(s, "${prometheus}") {
 			t.Errorf("%s: missing ${prometheus} datasource var", f)
 		}
+		if strings.Contains(s, "$cluster") {
+			t.Errorf("%s: stray $cluster reference", f)
+		}
 		names := map[string]bool{}
 		for _, v := range obj["templating"].(map[string]any)["list"].([]any) {
 			names[v.(map[string]any)["name"].(string)] = true
 		}
-		for _, want := range []string{"prometheus", "cluster", "namespace", "log_ns"} {
+		for _, want := range []string{"prometheus", "namespace", "log_ns"} {
 			if !names[want] {
 				t.Errorf("%s: missing template var %q", f, want)
 			}

--- a/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
@@ -55,7 +55,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_append_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_append_requests_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -106,12 +106,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append latency P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append latency P99",
           "refId": "B"
         }
@@ -162,12 +162,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append bytes P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append bytes P99",
           "refId": "B"
         }
@@ -218,7 +218,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_read_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_read_requests_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -269,12 +269,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Read latency P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Read latency P99",
           "refId": "B"
         }
@@ -325,12 +325,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_reader_bytes_read{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_reader_bytes_read{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}} read bytes",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(woodpecker_client_writer_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_writer_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}} write bytes",
           "refId": "B"
         }
@@ -381,7 +381,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
+          "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
           "legendFormat": "op={{operation}} status={{status}}",
           "refId": "A"
         }
@@ -432,7 +432,7 @@
       },
       "targets": [
         {
-          "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (log_id)",
+          "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_log_name_id_mapping{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_log_name_id_mapping{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -541,7 +541,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_segment_state{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_segment_state{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} {{state}}",
           "refId": "A"
         }
@@ -581,7 +581,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_active_segment_node{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_active_segment_node{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -599,7 +599,6 @@
               "instance": true,
               "job": true,
               "namespace": true,
-              "cluster": true,
               "Value": true
             },
             "renameByName": {
@@ -653,7 +652,7 @@
       },
       "targets": [
         {
-          "expr": "count by (node) (woodpecker_client_active_segment_node{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"})",
+          "expr": "count by (node) (woodpecker_client_active_segment_node{namespace=~\"$namespace\", log_ns=~\"$log_ns\"})",
           "legendFormat": "{{node}}",
           "refId": "A"
         }
@@ -714,7 +713,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(grpc_server_started_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method)",
+              "expr": "sum(rate(grpc_server_started_total{namespace=~\"$namespace\"}[1m])) by (grpc_method)",
               "legendFormat": "method={{grpc_method}}",
               "refId": "A"
             }
@@ -765,7 +764,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
+              "expr": "sum(rate(grpc_server_handled_total{namespace=~\"$namespace\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
               "legendFormat": "method={{grpc_method}} code={{grpc_code}}",
               "refId": "A"
             }
@@ -816,12 +815,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
               "legendFormat": "method={{grpc_method}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
               "legendFormat": "method={{grpc_method}} P99",
               "refId": "B"
             }
@@ -856,29 +855,13 @@
         "multi": false
       },
       {
-        "name": "cluster",
-        "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${prometheus}"
-        },
-        "query": "label_values(go_info, cluster)",
-        "refresh": 2,
-        "includeAll": true,
-        "multi": true,
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        }
-      },
-      {
         "name": "namespace",
         "type": "query",
         "datasource": {
           "type": "prometheus",
           "uid": "${prometheus}"
         },
-        "query": "label_values(woodpecker_client_append_requests_total{cluster=~\"$cluster\"}, namespace)",
+        "query": "label_values(go_info, namespace)",
         "refresh": 2,
         "includeAll": true,
         "multi": true,
@@ -900,7 +883,7 @@
         "includeAll": true,
         "multi": true,
         "name": "log_ns",
-        "query": "label_values(woodpecker_client_append_requests_total, log_ns)",
+        "query": "label_values(woodpecker_client_append_requests_total{namespace=~\"$namespace\"}, log_ns)",
         "refresh": 2,
         "type": "query"
       }

--- a/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
@@ -54,12 +54,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_active_logs{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} logs",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_logstore_active_segments{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} segments",
               "refId": "B"
             }
@@ -110,7 +110,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_instances_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_instances_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -161,7 +161,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_logstore_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
+              "expr": "sum(rate(woodpecker_server_logstore_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
               "legendFormat": "op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -212,12 +212,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
               "legendFormat": "op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
               "legendFormat": "op={{operation}} P99",
               "refId": "B"
             }
@@ -268,7 +268,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_active_segment_processors{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_logstore_active_segment_processors{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -333,12 +333,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Buffer P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Buffer P99",
               "refId": "B"
             }
@@ -389,7 +389,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_file_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+              "expr": "sum(rate(woodpecker_server_file_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
               "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -440,12 +440,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -496,12 +496,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_writer{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+              "expr": "sum(woodpecker_server_file_writer{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
               "legendFormat": "{{node_id}} logID={{log_id}} writer",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_file_reader{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+              "expr": "sum(woodpecker_server_file_reader{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
               "legendFormat": "{{node_id}} logID={{log_id}} reader",
               "refId": "B"
             }
@@ -552,12 +552,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Flush P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Flush P99",
               "refId": "B"
             }
@@ -608,12 +608,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} ReadBatch P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} ReadBatch P99",
               "refId": "B"
             }
@@ -664,12 +664,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Compact P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Compact P99",
               "refId": "B"
             }
@@ -720,12 +720,12 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_flush_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+              "expr": "sum(rate(woodpecker_server_flush_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
               "legendFormat": "{{node_id}} flush",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(woodpecker_server_compact_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+              "expr": "sum(rate(woodpecker_server_compact_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
               "legendFormat": "{{node_id}} compact",
               "refId": "B"
             }
@@ -790,7 +790,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_object_storage_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+              "expr": "sum(rate(woodpecker_server_object_storage_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
               "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -841,12 +841,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -897,12 +897,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -953,7 +953,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
+              "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
               "legendFormat": "{{node_id}} op={{operation}}",
               "refId": "A"
             }
@@ -1018,7 +1018,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_cpu_usage{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_cpu_usage{namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -1069,12 +1069,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_memory_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_memory_used_bytes{namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} used",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_system_memory_usage_ratio{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_memory_usage_ratio{namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} ratio",
               "refId": "B"
             }
@@ -1125,12 +1125,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_disk_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_disk_used_bytes{namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} used",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_system_disk_total_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_disk_total_bytes{namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} total",
               "refId": "B"
             }
@@ -1181,7 +1181,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_io_wait{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_io_wait{namespace=~\"$namespace\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -1232,7 +1232,7 @@
           },
           "targets": [
             {
-              "expr": "process_open_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "process_open_fds{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} open",
               "refId": "A"
             }
@@ -1283,12 +1283,12 @@
           },
           "targets": [
             {
-              "expr": "rate(process_network_receive_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+              "expr": "rate(process_network_receive_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
               "legendFormat": "{{pod}} {{instance}} rx",
               "refId": "A"
             },
             {
-              "expr": "rate(process_network_transmit_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+              "expr": "rate(process_network_transmit_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
               "legendFormat": "{{pod}} {{instance}} tx",
               "refId": "B"
             }
@@ -1339,7 +1339,7 @@
           },
           "targets": [
             {
-              "expr": "process_open_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"} / process_max_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "process_open_fds{namespace=~\"$namespace\", job=~\"$server_job\"} / process_max_fds{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1390,7 +1390,7 @@
           },
           "targets": [
             {
-              "expr": "time() - process_start_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "time() - process_start_time_seconds{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1441,7 +1441,7 @@
           },
           "targets": [
             {
-              "expr": "process_virtual_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "process_virtual_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1506,7 +1506,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (pod, instance)",
+              "expr": "sum(rate(process_cpu_seconds_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (pod, instance)",
               "legendFormat": "{{pod}} {{instance}} cpu",
               "refId": "A"
             }
@@ -1557,7 +1557,7 @@
           },
           "targets": [
             {
-              "expr": "sum(process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+              "expr": "sum(process_resident_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
               "legendFormat": "{{pod}} {{instance}} memory",
               "refId": "A"
             }
@@ -1608,7 +1608,7 @@
           },
           "targets": [
             {
-              "expr": "sum(go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+              "expr": "sum(go_goroutines{namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
               "legendFormat": "{{pod}} {{instance}} goroutines",
               "refId": "A"
             }
@@ -1659,7 +1659,7 @@
           },
           "targets": [
             {
-              "expr": "rate(process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+              "expr": "rate(process_cpu_seconds_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1710,7 +1710,7 @@
           },
           "targets": [
             {
-              "expr": "process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "process_resident_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1761,7 +1761,7 @@
           },
           "targets": [
             {
-              "expr": "go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_goroutines{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1812,7 +1812,7 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_alloc_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_alloc_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1863,17 +1863,17 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} in-use",
               "refId": "A"
             },
             {
-              "expr": "go_memstats_heap_idle_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_idle_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} idle",
               "refId": "B"
             },
             {
-              "expr": "go_memstats_heap_released_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_released_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} released",
               "refId": "C"
             }
@@ -1924,7 +1924,7 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_heap_objects{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_objects{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1975,7 +1975,7 @@
           },
           "targets": [
             {
-              "expr": "go_gc_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\", quantile=\"1\"}",
+              "expr": "go_gc_duration_seconds{namespace=~\"$namespace\", job=~\"$server_job\", quantile=\"1\"}",
               "legendFormat": "{{pod}} {{instance}} max",
               "refId": "A"
             }
@@ -2026,7 +2026,7 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_gc_cpu_fraction{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_gc_cpu_fraction{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2077,12 +2077,12 @@
           },
           "targets": [
             {
-              "expr": "rate(go_memstats_mallocs_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+              "expr": "rate(go_memstats_mallocs_total{namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
               "legendFormat": "{{pod}} {{instance}} mallocs",
               "refId": "A"
             },
             {
-              "expr": "rate(go_memstats_frees_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+              "expr": "rate(go_memstats_frees_total{namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
               "legendFormat": "{{pod}} {{instance}} frees",
               "refId": "B"
             }
@@ -2133,7 +2133,7 @@
           },
           "targets": [
             {
-              "expr": "rate(go_memstats_alloc_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+              "expr": "rate(go_memstats_alloc_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2184,12 +2184,12 @@
           },
           "targets": [
             {
-              "expr": "go_sched_gomaxprocs_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_sched_gomaxprocs_threads{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} GOMAXPROCS",
               "refId": "A"
             },
             {
-              "expr": "go_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_threads{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} threads",
               "refId": "B"
             }
@@ -2240,7 +2240,7 @@
           },
           "targets": [
             {
-              "expr": "rate(go_gc_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+              "expr": "rate(go_gc_duration_seconds_count{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
               "legendFormat": "{{pod}} {{instance}} GC/s",
               "refId": "A"
             }
@@ -2291,12 +2291,12 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_sys_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_sys_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} sys",
               "refId": "A"
             },
             {
-              "expr": "go_memstats_stack_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_stack_inuse_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} stack",
               "refId": "B"
             }
@@ -2347,12 +2347,12 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_next_gc_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_next_gc_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} next GC",
               "refId": "A"
             },
             {
-              "expr": "go_gc_gomemlimit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_gc_gomemlimit_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} memory limit",
               "refId": "B"
             }
@@ -2417,7 +2417,7 @@
           },
           "targets": [
             {
-              "expr": "woodpecker_server_op_registry_pool_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "woodpecker_server_op_registry_pool_usage{namespace=~\"$namespace\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2468,7 +2468,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (signal)",
+              "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (signal)",
               "legendFormat": "{{signal}}",
               "refId": "A"
             }
@@ -2519,7 +2519,7 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])) by (le))",
               "legendFormat": "P99",
               "refId": "A"
             }
@@ -2584,7 +2584,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_stored_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_file_stored_bytes{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2635,7 +2635,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_object_storage_stored_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_object_storage_stored_bytes{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2686,7 +2686,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_stored_count{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_file_stored_count{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2737,7 +2737,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_object_storage_stored_objects{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_object_storage_stored_objects{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2772,29 +2772,13 @@
         "multi": false
       },
       {
-        "name": "cluster",
-        "type": "query",
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${prometheus}"
-        },
-        "query": "label_values(go_info, cluster)",
-        "refresh": 2,
-        "includeAll": true,
-        "multi": true,
-        "current": {
-          "text": "All",
-          "value": "$__all"
-        }
-      },
-      {
         "name": "namespace",
         "type": "query",
         "datasource": {
           "type": "prometheus",
           "uid": "${prometheus}"
         },
-        "query": "label_values(go_info{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", cluster=~\"$cluster\"}, namespace)",
+        "query": "label_values(go_info, namespace)",
         "refresh": 2,
         "includeAll": true,
         "multi": true,
@@ -2816,7 +2800,7 @@
         "includeAll": true,
         "multi": true,
         "name": "log_ns",
-        "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\".+\"}))",
+        "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", log_ns=~\".+\"}))",
         "refresh": 2,
         "regex": "/log_ns=\"([^\"]+)\"/",
         "type": "query"
@@ -2834,13 +2818,13 @@
         "includeAll": true,
         "multi": true,
         "name": "log_id",
-        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
+        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
         "refresh": 2,
         "regex": "/log_id=\"([^\"]+)\"/",
         "type": "query"
       },
       {
-        "allValue": "woodpecker-node[0-9]+|woodpecker/woodpecker-server",
+        "allValue": ".*",
         "current": {
           "text": "All",
           "value": "$__all"
@@ -2853,7 +2837,7 @@
         "includeAll": true,
         "multi": true,
         "name": "server_job",
-        "query": "label_values(go_goroutines{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\"}, job)",
+        "query": "label_values(go_info{namespace=~\"$namespace\"}, job)",
         "refresh": 2,
         "type": "query"
       }

--- a/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
+++ b/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
@@ -64,12 +64,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_logstore_active_logs{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} logs",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(woodpecker_server_logstore_active_segments{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} segments",
                   "refId": "B"
                 }
@@ -120,7 +120,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_logstore_instances_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_logstore_instances_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}}",
                   "refId": "A"
                 }
@@ -171,7 +171,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_logstore_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
+                  "expr": "sum(rate(woodpecker_server_logstore_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
                   "legendFormat": "op={{operation}} status={{status}}",
                   "refId": "A"
                 }
@@ -222,12 +222,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
                   "legendFormat": "op={{operation}} P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
                   "legendFormat": "op={{operation}} P99",
                   "refId": "B"
                 }
@@ -278,7 +278,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_logstore_active_segment_processors{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "expr": "sum(woodpecker_server_logstore_active_segment_processors{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
                   "legendFormat": "logID={{log_id}}",
                   "refId": "A"
                 }
@@ -343,12 +343,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Buffer P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Buffer P99",
                   "refId": "B"
                 }
@@ -399,7 +399,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_file_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+                  "expr": "sum(rate(woodpecker_server_file_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
                   "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
                   "refId": "A"
                 }
@@ -450,12 +450,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P99",
                   "refId": "B"
                 }
@@ -506,12 +506,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_file_writer{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+                  "expr": "sum(woodpecker_server_file_writer{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
                   "legendFormat": "{{node_id}} logID={{log_id}} writer",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(woodpecker_server_file_reader{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+                  "expr": "sum(woodpecker_server_file_reader{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
                   "legendFormat": "{{node_id}} logID={{log_id}} reader",
                   "refId": "B"
                 }
@@ -562,12 +562,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Flush P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Flush P99",
                   "refId": "B"
                 }
@@ -618,12 +618,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} ReadBatch P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} ReadBatch P99",
                   "refId": "B"
                 }
@@ -674,12 +674,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Compact P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Compact P99",
                   "refId": "B"
                 }
@@ -730,12 +730,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_flush_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+                  "expr": "sum(rate(woodpecker_server_flush_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
                   "legendFormat": "{{node_id}} flush",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(rate(woodpecker_server_compact_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+                  "expr": "sum(rate(woodpecker_server_compact_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
                   "legendFormat": "{{node_id}} compact",
                   "refId": "B"
                 }
@@ -800,7 +800,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_object_storage_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+                  "expr": "sum(rate(woodpecker_server_object_storage_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
                   "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
                   "refId": "A"
                 }
@@ -851,12 +851,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P99",
                   "refId": "B"
                 }
@@ -907,12 +907,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P99",
                   "refId": "B"
                 }
@@ -963,7 +963,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
+                  "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
                   "legendFormat": "{{node_id}} op={{operation}}",
                   "refId": "A"
                 }
@@ -1028,7 +1028,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_cpu_usage{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_cpu_usage{namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}}",
                   "refId": "A"
                 }
@@ -1079,12 +1079,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_memory_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_memory_used_bytes{namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} used",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(woodpecker_server_system_memory_usage_ratio{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_memory_usage_ratio{namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} ratio",
                   "refId": "B"
                 }
@@ -1135,12 +1135,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_disk_used_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_disk_used_bytes{namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} used",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(woodpecker_server_system_disk_total_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_disk_total_bytes{namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} total",
                   "refId": "B"
                 }
@@ -1191,7 +1191,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_io_wait{cluster=~\"$cluster\", namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_io_wait{namespace=~\"$namespace\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}}",
                   "refId": "A"
                 }
@@ -1242,7 +1242,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "process_open_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "process_open_fds{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} open",
                   "refId": "A"
                 }
@@ -1293,12 +1293,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "rate(process_network_receive_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+                  "expr": "rate(process_network_receive_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
                   "legendFormat": "{{pod}} {{instance}} rx",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(process_network_transmit_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+                  "expr": "rate(process_network_transmit_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
                   "legendFormat": "{{pod}} {{instance}} tx",
                   "refId": "B"
                 }
@@ -1349,7 +1349,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "process_open_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"} / process_max_fds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "process_open_fds{namespace=~\"$namespace\", job=~\"$server_job\"} / process_max_fds{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1400,7 +1400,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "time() - process_start_time_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "time() - process_start_time_seconds{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1451,7 +1451,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "process_virtual_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "process_virtual_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1516,7 +1516,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (pod, instance)",
+                  "expr": "sum(rate(process_cpu_seconds_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (pod, instance)",
                   "legendFormat": "{{pod}} {{instance}} cpu",
                   "refId": "A"
                 }
@@ -1567,7 +1567,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+                  "expr": "sum(process_resident_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
                   "legendFormat": "{{pod}} {{instance}} memory",
                   "refId": "A"
                 }
@@ -1618,7 +1618,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+                  "expr": "sum(go_goroutines{namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
                   "legendFormat": "{{pod}} {{instance}} goroutines",
                   "refId": "A"
                 }
@@ -1669,7 +1669,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "rate(process_cpu_seconds_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+                  "expr": "rate(process_cpu_seconds_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1720,7 +1720,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "process_resident_memory_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "process_resident_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1771,7 +1771,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_goroutines{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_goroutines{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1822,7 +1822,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_alloc_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_alloc_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1873,17 +1873,17 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_heap_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} in-use",
                   "refId": "A"
                 },
                 {
-                  "expr": "go_memstats_heap_idle_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_heap_idle_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} idle",
                   "refId": "B"
                 },
                 {
-                  "expr": "go_memstats_heap_released_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_heap_released_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} released",
                   "refId": "C"
                 }
@@ -1934,7 +1934,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_heap_objects{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_heap_objects{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1985,7 +1985,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_gc_duration_seconds{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\", quantile=\"1\"}",
+                  "expr": "go_gc_duration_seconds{namespace=~\"$namespace\", job=~\"$server_job\", quantile=\"1\"}",
                   "legendFormat": "{{pod}} {{instance}} max",
                   "refId": "A"
                 }
@@ -2036,7 +2036,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_gc_cpu_fraction{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_gc_cpu_fraction{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -2087,12 +2087,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "rate(go_memstats_mallocs_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+                  "expr": "rate(go_memstats_mallocs_total{namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
                   "legendFormat": "{{pod}} {{instance}} mallocs",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(go_memstats_frees_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+                  "expr": "rate(go_memstats_frees_total{namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
                   "legendFormat": "{{pod}} {{instance}} frees",
                   "refId": "B"
                 }
@@ -2143,7 +2143,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "rate(go_memstats_alloc_bytes_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -2194,12 +2194,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_sched_gomaxprocs_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_sched_gomaxprocs_threads{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} GOMAXPROCS",
                   "refId": "A"
                 },
                 {
-                  "expr": "go_threads{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_threads{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} threads",
                   "refId": "B"
                 }
@@ -2250,7 +2250,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "rate(go_gc_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+                  "expr": "rate(go_gc_duration_seconds_count{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
                   "legendFormat": "{{pod}} {{instance}} GC/s",
                   "refId": "A"
                 }
@@ -2301,12 +2301,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_sys_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_sys_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} sys",
                   "refId": "A"
                 },
                 {
-                  "expr": "go_memstats_stack_inuse_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_stack_inuse_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} stack",
                   "refId": "B"
                 }
@@ -2357,12 +2357,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_next_gc_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_next_gc_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} next GC",
                   "refId": "A"
                 },
                 {
-                  "expr": "go_gc_gomemlimit_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_gc_gomemlimit_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} memory limit",
                   "refId": "B"
                 }
@@ -2427,7 +2427,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "woodpecker_server_op_registry_pool_usage{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "woodpecker_server_op_registry_pool_usage{namespace=~\"$namespace\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -2478,7 +2478,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (signal)",
+                  "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (signal)",
                   "legendFormat": "{{signal}}",
                   "refId": "A"
                 }
@@ -2529,7 +2529,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", job=~\"$server_job\"}[5m])) by (le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])) by (le))",
                   "legendFormat": "P99",
                   "refId": "A"
                 }
@@ -2594,7 +2594,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_file_stored_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "expr": "sum(woodpecker_server_file_stored_bytes{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
                   "legendFormat": "logID={{log_id}}",
                   "refId": "A"
                 }
@@ -2645,7 +2645,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_object_storage_stored_bytes{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "expr": "sum(woodpecker_server_object_storage_stored_bytes{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
                   "legendFormat": "logID={{log_id}}",
                   "refId": "A"
                 }
@@ -2696,7 +2696,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_file_stored_count{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "expr": "sum(woodpecker_server_file_stored_count{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
                   "legendFormat": "logID={{log_id}}",
                   "refId": "A"
                 }
@@ -2747,7 +2747,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_object_storage_stored_objects{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "expr": "sum(woodpecker_server_object_storage_stored_objects{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
                   "legendFormat": "logID={{log_id}}",
                   "refId": "A"
                 }
@@ -2782,29 +2782,13 @@ data:
             "multi": false
           },
           {
-            "name": "cluster",
-            "type": "query",
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${prometheus}"
-            },
-            "query": "label_values(go_info, cluster)",
-            "refresh": 2,
-            "includeAll": true,
-            "multi": true,
-            "current": {
-              "text": "All",
-              "value": "$__all"
-            }
-          },
-          {
             "name": "namespace",
             "type": "query",
             "datasource": {
               "type": "prometheus",
               "uid": "${prometheus}"
             },
-            "query": "label_values(go_info{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", cluster=~\"$cluster\"}, namespace)",
+            "query": "label_values(go_info, namespace)",
             "refresh": 2,
             "includeAll": true,
             "multi": true,
@@ -2826,7 +2810,7 @@ data:
             "includeAll": true,
             "multi": true,
             "name": "log_ns",
-            "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\".+\"}))",
+            "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", log_ns=~\".+\"}))",
             "refresh": 2,
             "regex": "/log_ns=\"([^\"]+)\"/",
             "type": "query"
@@ -2844,13 +2828,13 @@ data:
             "includeAll": true,
             "multi": true,
             "name": "log_id",
-            "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
+            "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
             "refresh": 2,
             "regex": "/log_id=\"([^\"]+)\"/",
             "type": "query"
           },
           {
-            "allValue": "woodpecker-node[0-9]+|woodpecker/woodpecker-server",
+            "allValue": ".*",
             "current": {
               "text": "All",
               "value": "$__all"
@@ -2863,7 +2847,7 @@ data:
             "includeAll": true,
             "multi": true,
             "name": "server_job",
-            "query": "label_values(go_goroutines{job=~\"woodpecker-node[0-9]+|woodpecker/woodpecker-server\"}, job)",
+            "query": "label_values(go_info{namespace=~\"$namespace\"}, job)",
             "refresh": 2,
             "type": "query"
           }
@@ -2943,7 +2927,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_client_append_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "expr": "sum(rate(woodpecker_client_append_requests_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2994,12 +2978,12 @@ data:
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Append latency P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Append latency P99",
               "refId": "B"
             }
@@ -3050,12 +3034,12 @@ data:
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Append bytes P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Append bytes P99",
               "refId": "B"
             }
@@ -3106,7 +3090,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_client_read_requests_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "expr": "sum(rate(woodpecker_client_read_requests_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -3157,12 +3141,12 @@ data:
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Read latency P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Read latency P99",
               "refId": "B"
             }
@@ -3213,12 +3197,12 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_client_reader_bytes_read{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "expr": "sum(rate(woodpecker_client_reader_bytes_read{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
               "legendFormat": "logID={{log_id}} read bytes",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(woodpecker_client_writer_bytes_written{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "expr": "sum(rate(woodpecker_client_writer_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
               "legendFormat": "logID={{log_id}} write bytes",
               "refId": "B"
             }
@@ -3269,7 +3253,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
+              "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
               "legendFormat": "op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -3320,7 +3304,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (log_id)",
+              "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -3360,7 +3344,7 @@ data:
           },
           "targets": [
             {
-              "expr": "woodpecker_client_log_name_id_mapping{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+              "expr": "woodpecker_client_log_name_id_mapping{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
               "format": "table",
               "instant": true,
               "legendFormat": "",
@@ -3429,7 +3413,7 @@ data:
           },
           "targets": [
             {
-              "expr": "woodpecker_client_segment_state{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+              "expr": "woodpecker_client_segment_state{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
               "legendFormat": "logID={{log_id}} {{state}}",
               "refId": "A"
             }
@@ -3469,7 +3453,7 @@ data:
           },
           "targets": [
             {
-              "expr": "woodpecker_client_active_segment_node{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+              "expr": "woodpecker_client_active_segment_node{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
               "format": "table",
               "instant": true,
               "legendFormat": "",
@@ -3487,7 +3471,6 @@ data:
                   "instance": true,
                   "job": true,
                   "namespace": true,
-                  "cluster": true,
                   "Value": true
                 },
                 "renameByName": {
@@ -3541,7 +3524,7 @@ data:
           },
           "targets": [
             {
-              "expr": "count by (node) (woodpecker_client_active_segment_node{cluster=~\"$cluster\", namespace=~\"$namespace\", log_ns=~\"$log_ns\"})",
+              "expr": "count by (node) (woodpecker_client_active_segment_node{namespace=~\"$namespace\", log_ns=~\"$log_ns\"})",
               "legendFormat": "{{node}}",
               "refId": "A"
             }
@@ -3602,7 +3585,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(grpc_server_started_total{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method)",
+                  "expr": "sum(rate(grpc_server_started_total{namespace=~\"$namespace\"}[1m])) by (grpc_method)",
                   "legendFormat": "method={{grpc_method}}",
                   "refId": "A"
                 }
@@ -3653,7 +3636,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(grpc_server_handled_total{cluster=~\"$cluster\", namespace=~\"$namespace\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
+                  "expr": "sum(rate(grpc_server_handled_total{namespace=~\"$namespace\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
                   "legendFormat": "method={{grpc_method}} code={{grpc_code}}",
                   "refId": "A"
                 }
@@ -3704,12 +3687,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
                   "legendFormat": "method={{grpc_method}} P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
                   "legendFormat": "method={{grpc_method}} P99",
                   "refId": "B"
                 }
@@ -3744,29 +3727,13 @@ data:
             "multi": false
           },
           {
-            "name": "cluster",
-            "type": "query",
-            "datasource": {
-              "type": "prometheus",
-              "uid": "${prometheus}"
-            },
-            "query": "label_values(go_info, cluster)",
-            "refresh": 2,
-            "includeAll": true,
-            "multi": true,
-            "current": {
-              "text": "All",
-              "value": "$__all"
-            }
-          },
-          {
             "name": "namespace",
             "type": "query",
             "datasource": {
               "type": "prometheus",
               "uid": "${prometheus}"
             },
-            "query": "label_values(woodpecker_client_append_requests_total{cluster=~\"$cluster\"}, namespace)",
+            "query": "label_values(go_info, namespace)",
             "refresh": 2,
             "includeAll": true,
             "multi": true,
@@ -3788,7 +3755,7 @@ data:
             "includeAll": true,
             "multi": true,
             "name": "log_ns",
-            "query": "label_values(woodpecker_client_append_requests_total, log_ns)",
+            "query": "label_values(woodpecker_client_append_requests_total{namespace=~\"$namespace\"}, log_ns)",
             "refresh": 2,
             "type": "query"
           }

--- a/tests/k8s/monitor/manifests/kube-prometheus-values.yaml
+++ b/tests/k8s/monitor/manifests/kube-prometheus-values.yaml
@@ -11,8 +11,6 @@ kubeEtcd: { enabled: false }
 coreDns: { enabled: false }
 prometheus:
   prometheusSpec:
-    externalLabels:
-      cluster: woodpecker-minikube
     podMonitorSelectorNilUsesHelmValues: false
     serviceMonitorSelectorNilUsesHelmValues: false
     ruleSelectorNilUsesHelmValues: false

--- a/tests/k8s/monitor/manifests/podmonitor-client.yaml
+++ b/tests/k8s/monitor/manifests/podmonitor-client.yaml
@@ -19,6 +19,3 @@ spec:
       path: /metrics
       interval: 15s
       honorLabels: true
-      relabelings:
-        - targetLabel: cluster
-          replacement: woodpecker-minikube

--- a/tests/k8s/monitor/manifests/podmonitor-server.yaml
+++ b/tests/k8s/monitor/manifests/podmonitor-server.yaml
@@ -19,6 +19,3 @@ spec:
       path: /metrics
       interval: 15s
       honorLabels: true
-      relabelings:
-        - targetLabel: cluster
-          replacement: woodpecker-minikube

--- a/tests/k8s/monitor/monitor_test.go
+++ b/tests/k8s/monitor/monitor_test.go
@@ -22,7 +22,7 @@ import (
 	"time"
 )
 
-// TestK8sMonitor_Metrics verifies scrape targets and the cluster/namespace/log_ns
+// TestK8sMonitor_Metrics verifies scrape targets and the namespace/log_ns
 // label scheme against a Prometheus reachable at $WP_K8S_PROM_URL (a kubectl
 // port-forward set up by run_monitor_tests.sh). Skipped when unset so the package
 // stays `go test ./...`-safe without a live cluster.
@@ -71,9 +71,6 @@ func TestK8sMonitor_Metrics(t *testing.T) {
 			t.Fatal("no logstore_active_logs series")
 		}
 		for _, m := range series {
-			if m["cluster"] != "woodpecker-minikube" {
-				t.Errorf("cluster=%q, want woodpecker-minikube", m["cluster"])
-			}
 			if m["namespace"] != "woodpecker" {
 				t.Errorf("namespace=%q, want k8s namespace woodpecker", m["namespace"])
 			}


### PR DESCRIPTION
Fixes #217

## What

Adjusts the monitor Grafana dashboard templates to fit a plain PodMonitor collection strategy: no synthetic `cluster` label, no hardcoded scrape job names.

### k8s dashboards (`tests/k8s/monitor/grafana/templates/`)

- Removed the `cluster` template variable and every `cluster=~"$cluster"` matcher (70 exprs in the server dashboard, 15 in the client one).
- `namespace` is now discovered uniformly via `label_values(go_info, namespace)` in both dashboards.
- The hidden `server_job` variable resolves the PodMonitor-assigned `job` label via `label_values(go_info{namespace=~"$namespace"}, job)` instead of the hardcoded `woodpecker-node[0-9]+|woodpecker/woodpecker-server` regex.
- `log_ns` / `log_id` variable discovery is scoped by `$namespace` via woodpecker's own metrics.

### docker dashboard (`tests/docker/monitor/grafana/templates/dashboard_server.json`)

- Same de-hardcoding; `server_job` is discovered from `woodpecker_server_logstore_instances_total` because the docker setup has no `namespace` label to scope `go_info` (which would otherwise pull the test-client process into server panels).

### Manifests, tests, docs

- Dropped the `cluster` relabelings from both PodMonitors and `externalLabels` from `kube-prometheus-values.yaml`.
- `dashboards_test.go`: `cluster` removed from the required-variable list; any stray `$cluster` reference now fails the test.
- `monitor_test.go`: LabelScheme no longer asserts `cluster=woodpecker-minikube`.
- Regenerated `manifests/dashboard-configmaps.yaml` from the updated templates.
- README label-scheme section updated to `namespace` / `log_ns`.

## Verification

- `go vet ./tests/k8s/monitor/` clean; `TestK8sDashboards_Valid` passes.
- All dashboard JSONs and the regenerated configmap validated (YAML + embedded JSON parse, zero `$cluster` / `woodpecker-minikube` remnants across `tests/k8s` and `tests/docker`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)