### PR TITLE
enhance(config): make delete-marker local reclaim near-real-time by default (#223)

### DIFF
--- a/common/config/configuration.go
+++ b/common/config/configuration.go
@@ -363,9 +363,13 @@ type ProcessorCleanupPolicyConfig struct {
 // (delete-marker reclaim, and future cleaner/gc tasks).
 type MaintenanceStrategyConfig struct {
 	// DeleteGracePeriod is how long after a log/instance is marked deleted before its
-	// LOCAL data is reclaimed (object storage is never auto-reclaimed). Default 72h.
+	// LOCAL data is reclaimed (object storage is never auto-reclaimed). Default 5s:
+	// reclaim is near-real-time — calling the delete API means the caller has already
+	// confirmed the data is no longer needed. The short non-zero grace only preserves
+	// the marker's crash-safety (marker durably on disk before any data is removed).
 	DeleteGracePeriod DurationSeconds `yaml:"deleteGracePeriod"`
 	// DeleteReclaimInterval is how often the reclaim task scans delete markers.
+	// Default 2s, so deleted data disappears within ~grace+interval of the request.
 	DeleteReclaimInterval DurationSeconds `yaml:"deleteReclaimInterval"`
 }
 
@@ -858,8 +862,8 @@ func getDefaultWoodpeckerConfig() WoodpeckerConfig {
 				ShutdownTimeout: DurationSeconds{Duration: Duration{duration: 15 * time.Second}},  // 15s
 			},
 			MaintenanceStrategy: MaintenanceStrategyConfig{
-				DeleteGracePeriod:     DurationSeconds{Duration: Duration{duration: 72 * time.Hour}},
-				DeleteReclaimInterval: DurationSeconds{Duration: Duration{duration: 10 * time.Minute}},
+				DeleteGracePeriod:     DurationSeconds{Duration: Duration{duration: 5 * time.Second}},
+				DeleteReclaimInterval: DurationSeconds{Duration: Duration{duration: 2 * time.Second}},
 			},
 			NodeSelectionPolicy: NodeSelectionPolicyConfig{
 				LoadAwareEnabled:   true,

--- a/common/config/configuration_test.go
+++ b/common/config/configuration_test.go
@@ -85,8 +85,8 @@ func TestNewConfiguration(t *testing.T) {
 	assert.Equal(t, 60, config.Woodpecker.Logstore.ProcessorCleanupPolicy.CleanupInterval.Seconds())
 	assert.Equal(t, 300, config.Woodpecker.Logstore.ProcessorCleanupPolicy.MaxIdleTime.Seconds())
 	assert.Equal(t, 15, config.Woodpecker.Logstore.ProcessorCleanupPolicy.ShutdownTimeout.Seconds())
-	assert.Equal(t, 259200, config.Woodpecker.Logstore.MaintenanceStrategy.DeleteGracePeriod.Seconds())  // 72h = 259200s
-	assert.Equal(t, 600, config.Woodpecker.Logstore.MaintenanceStrategy.DeleteReclaimInterval.Seconds()) // 10m = 600s
+	assert.Equal(t, 5, config.Woodpecker.Logstore.MaintenanceStrategy.DeleteGracePeriod.Seconds())     // near-real-time reclaim
+	assert.Equal(t, 2, config.Woodpecker.Logstore.MaintenanceStrategy.DeleteReclaimInterval.Seconds()) // near-real-time reclaim
 	assert.Equal(t, "minio", config.Woodpecker.Storage.Type)
 	assert.Equal(t, "/var/lib/woodpecker", config.Woodpecker.Storage.RootPath)
 	assert.Equal(t, "info", config.Log.Level)
@@ -186,8 +186,8 @@ func TestNewConfiguration(t *testing.T) {
 	assert.Equal(t, 60, defaultConfig.Woodpecker.Logstore.ProcessorCleanupPolicy.CleanupInterval.Seconds())
 	assert.Equal(t, 300, defaultConfig.Woodpecker.Logstore.ProcessorCleanupPolicy.MaxIdleTime.Seconds())
 	assert.Equal(t, 15, defaultConfig.Woodpecker.Logstore.ProcessorCleanupPolicy.ShutdownTimeout.Seconds())
-	assert.Equal(t, 259200, defaultConfig.Woodpecker.Logstore.MaintenanceStrategy.DeleteGracePeriod.Seconds())  // 72h = 259200s
-	assert.Equal(t, 600, defaultConfig.Woodpecker.Logstore.MaintenanceStrategy.DeleteReclaimInterval.Seconds()) // 10m = 600s
+	assert.Equal(t, 5, defaultConfig.Woodpecker.Logstore.MaintenanceStrategy.DeleteGracePeriod.Seconds())     // near-real-time reclaim
+	assert.Equal(t, 2, defaultConfig.Woodpecker.Logstore.MaintenanceStrategy.DeleteReclaimInterval.Seconds()) // near-real-time reclaim
 	assert.Equal(t, "default", defaultConfig.Woodpecker.Storage.Type)
 	assert.Equal(t, "/tmp/woodpecker", defaultConfig.Woodpecker.Storage.RootPath)
 	assert.Equal(t, "info", defaultConfig.Log.Level)

--- a/config/woodpecker.yaml
+++ b/config/woodpecker.yaml
@@ -122,8 +122,8 @@ woodpecker:
       maxIdleTime: 300 # How long a processor can be idle before cleanup in seconds, default is 300 seconds
       shutdownTimeout: 15 # Timeout for closing all processors during LogStore shutdown in seconds, default is 15 seconds
     maintenanceStrategy:
-      deleteGracePeriod: 259200 # How long after a log is marked deleted before local data is reclaimed, in seconds (default 72h = 259200s)
-      deleteReclaimInterval: 600 # How often the reclaim task scans delete markers, in seconds (default 10m = 600s)
+      deleteGracePeriod: 5 # Seconds after a log is marked deleted before local data is reclaimed. Near-real-time by default: calling the delete API means the caller has confirmed the data is no longer needed.
+      deleteReclaimInterval: 2 # How often the reclaim task scans delete markers, in seconds. Deleted data disappears within ~gracePeriod+interval of the request.
     nodeSelectionPolicy:
       loadAwareEnabled: true    # Prefer lower-load nodes among eligible candidates (issue #114)
       loadReportInterval: 10    # Seconds between a node publishing its own load factor


### PR DESCRIPTION
Closes #223.

Changes the delete-marker local reclaim defaults from conservative to **near-real-time**:

| Config (`woodpecker.logstore.maintenanceStrategy`) | Before | After |
| --- | --- | --- |
| `deleteGracePeriod` | 259200s (72h) | **5s** |
| `deleteReclaimInterval` | 600s (10m) | **2s** |

With the new defaults, the local data of a deleted log/instance is reclaimed within **~7s** of the delete request (grace + one scan interval). Comments in both `config/woodpecker.yaml` and `configuration.go` now state the contract explicitly: calling the delete API (`POST /admin/log/delete`, `POST /admin/instance/delete`, or the client-side delete-log composition) means the caller has already confirmed the data is no longer needed.

## Why

- **The 72h grace bought no real recovery path.** The client-side deletion deletes the etcd log metadata immediately after marking all quorum nodes, so the surviving local files had nothing to re-attach to.
- **Disk space stayed occupied for 3 days** after a successful delete — surprising to operators and harmful under disk pressure (#215).
- **It blocked decommission**: `safe_to_terminate` counts deleted-but-in-grace `data.log` files, so deleting logs then decommissioning a node forced a 72h wait.

The grace stays **non-zero (5s)** to preserve the marker mechanism's crash-safety: the marker is durably on disk before any data is removed, and reclaim remains idempotent/retry-safe across restarts. Operators who want the old window can still set `deleteGracePeriod: 259200`.

## Changes

- `common/config/configuration.go`: new defaults + contract documented on the struct fields.
- `config/woodpecker.yaml`: values + comments updated.
- `common/config/configuration_test.go`: default-value assertions updated (both the shipped-yaml load test and the `NewConfiguration()` defaults test).

No behavior change to the reclaim mechanism itself — tests constructing the reclaim task pass explicit grace values and are unaffected.

## Testing

- `go test ./common/config/` and `go test ./server/` pass.
- `TestDeleteLog_EndToEnd_EmbedLocal` passes with the new defaults (marker asserted milliseconds after delete, re-create uses a new logId so the old dir's reclaim doesn't interfere).
- With the reclaim steps now logging at INFO (#219), the near-real-time behavior is directly observable: `delete marker created` → `reclaim: removed local data directory` → `delete marker removed` → `reclaimed deleted log/instance local data` within ~7s.

## Out of scope

Object-storage data of deleted logs is still **never** auto-reclaimed (the `CleanData` operation referenced in `server/maintenance.go` remains unimplemented) — tracked separately from this defaults change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)