### PR TITLE
fix(segment): rebuild per-replica result channel on retry when its type mismatches the client

### DIFF
--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -172,14 +172,19 @@ func (op *AppendOp) sendWriteRequest(ctx context.Context, cli client.LogStoreCli
 	defer sp.End()
 	startRequestTime := time.Now()
 
-	if len(op.resultChannels) > serverIndex && op.resultChannels[serverIndex] == nil {
-		// create new result channel for this server if not exists
-		if cli.IsRemoteClient() {
-			resultChannel := channel.NewRemoteResultChannel(op.Identifier())
-			op.resultChannels[serverIndex] = resultChannel
-		} else {
-			resultChannel := channel.NewLocalResultChannel(op.Identifier())
-			op.resultChannels[serverIndex] = resultChannel
+	if len(op.resultChannels) > serverIndex {
+		// (Re)create the result channel when the slot is empty or holds a channel
+		// whose type doesn't match the client. The batch path installs a
+		// LocalResultChannel here; a remote client's single-entry AppendEntry
+		// requires a RemoteResultChannel and rejects a LocalResultChannel with
+		// ErrInternalError. A matching channel is reused (retry idempotency).
+		_, isRemoteChannel := op.resultChannels[serverIndex].(*channel.RemoteResultChannel)
+		if op.resultChannels[serverIndex] == nil || isRemoteChannel != cli.IsRemoteClient() {
+			if cli.IsRemoteClient() {
+				op.resultChannels[serverIndex] = channel.NewRemoteResultChannel(op.Identifier())
+			} else {
+				op.resultChannels[serverIndex] = channel.NewLocalResultChannel(op.Identifier())
+			}
 		}
 	}
 

--- a/woodpecker/segment/append_op_test.go
+++ b/woodpecker/segment/append_op_test.go
@@ -105,6 +105,82 @@ func TestAppendOp_Retry_RebuildsResultChannelForRemoteClient(t *testing.T) {
 		"retry must rebuild a RemoteResultChannel for a remote client, not reuse the batch's LocalResultChannel")
 }
 
+// newApplyNodeAckOp builds an AppendOp wired only for applyNodeAck unit tests
+// (no client pool needed; applyNodeAck only touches the handle and op state).
+func newApplyNodeAckOp(t *testing.T, quorumInfo *proto.QuorumInfo) (*AppendOp, *mocks_segment_handle.SegmentHandle) {
+	t.Helper()
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("v"),
+		func(int64, int64, error) {}, nil, mockHandle, quorumInfo)
+	return op, mockHandle
+}
+
+// TestAppendOp_applyNodeAck_ReadError_RoutesToFailure covers the batch drain
+// handing applyNodeAck a read error (e.g. the shared-timeout DeadlineExceeded):
+// the op must route it through HandleAppendRequestFailure and record the error.
+func TestAppendOp_applyNodeAck_ReadError_RoutesToFailure(t *testing.T) {
+	op, mockHandle := newApplyNodeAckOp(t, &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}})
+	readErr := werr.ErrSegmentHandleWriteFailed
+	mockHandle.EXPECT().HandleAppendRequestFailure(mock.Anything, int64(3), readErr, 0, "node1").Return().Once()
+
+	op.applyNodeAck(context.Background(), time.Now(), nil, readErr, 0, "node1")
+
+	assert.Equal(t, readErr, op.channelErrors[0])
+	assert.False(t, op.completed.Load())
+}
+
+// TestAppendOp_applyNodeAck_FailedResult_RoutesToFailure covers a per-entry
+// Failed durability result (SyncedId == -1 / Err set) being routed to failure.
+func TestAppendOp_applyNodeAck_FailedResult_RoutesToFailure(t *testing.T) {
+	op, mockHandle := newApplyNodeAckOp(t, &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}})
+	failErr := werr.ErrSegmentFenced
+	mockHandle.EXPECT().HandleAppendRequestFailure(mock.Anything, int64(3), failErr, 0, "node1").Return().Once()
+
+	op.applyNodeAck(context.Background(), time.Now(), &channel.AppendResult{SyncedId: -1, Err: failErr}, nil, 0, "node1")
+
+	assert.Equal(t, failErr, op.channelErrors[0])
+	assert.False(t, op.completed.Load())
+}
+
+// TestAppendOp_applyNodeAck_FastCalled_NoOp verifies that once the op has been
+// fast-completed (FastFail/FastSuccess), a late node ack is dropped: neither a
+// failure nor a success callback fires. The strict mock (no expectations) fails
+// the test if any handle method is called.
+func TestAppendOp_applyNodeAck_FastCalled_NoOp(t *testing.T) {
+	op, _ := newApplyNodeAckOp(t, &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}})
+	op.fastCalled.Store(true)
+
+	op.applyNodeAck(context.Background(), time.Now(), &channel.AppendResult{SyncedId: 3}, nil, 0, "node1")
+	op.applyNodeAck(context.Background(), time.Now(), nil, werr.ErrSegmentFenced, 0, "node1")
+
+	assert.False(t, op.completed.Load())
+}
+
+// TestAppendOp_applyNodeAck_QuorumReached_Success covers a single-replica quorum:
+// one synced ack reaches Aq and acknowledges the entry exactly once.
+func TestAppendOp_applyNodeAck_QuorumReached_Success(t *testing.T) {
+	op, mockHandle := newApplyNodeAckOp(t, &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}})
+	mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(3)).Return().Once()
+
+	op.applyNodeAck(context.Background(), time.Now(), &channel.AppendResult{SyncedId: 3}, nil, 0, "node1")
+
+	assert.True(t, op.completed.Load())
+}
+
+// TestAppendOp_applyNodeAck_BelowQuorumThenReached covers Aq=2: the first node's
+// ack does not acknowledge (below quorum), the second reaches quorum and fires
+// SendAppendSuccessCallbacks exactly once.
+func TestAppendOp_applyNodeAck_BelowQuorumThenReached(t *testing.T) {
+	op, mockHandle := newApplyNodeAckOp(t, &proto.QuorumInfo{Id: 1, Wq: 2, Aq: 2, Es: 2, Nodes: []string{"node1", "node2"}})
+	mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(3)).Return().Once()
+
+	op.applyNodeAck(context.Background(), time.Now(), &channel.AppendResult{SyncedId: 3}, nil, 0, "node1")
+	assert.False(t, op.completed.Load(), "single ack must not reach Aq=2")
+
+	op.applyNodeAck(context.Background(), time.Now(), &channel.AppendResult{SyncedId: 3}, nil, 1, "node2")
+	assert.True(t, op.completed.Load(), "second ack reaches Aq=2")
+}
+
 func TestNewAppendOp(t *testing.T) {
 	logId := int64(1)
 	segmentId := int64(2)

--- a/woodpecker/segment/append_op_test.go
+++ b/woodpecker/segment/append_op_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/zilliztech/woodpecker/common/channel"
+	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_logstore_client"
 	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_segment_handle"
 	"github.com/zilliztech/woodpecker/proto"
@@ -47,6 +48,61 @@ func cleanupAppendOp(t *testing.T, op *AppendOp) {
 	}
 	// Give goroutines time to see fastCalled and exit
 	time.Sleep(100 * time.Millisecond)
+}
+
+// TestAppendOp_Retry_RebuildsResultChannelForRemoteClient is a regression test for
+// issue #225 (#1): the group-commit batch path installs a LocalResultChannel in
+// op.resultChannels[serverIndex]. A subsequent single-entry retry must NOT reuse
+// that Local channel against a remote client — the remote AppendEntry requires a
+// RemoteResultChannel and rejects a Local one with ErrInternalError, which would
+// make every retry deterministically fail and force a segment roll. The retry must
+// instead rebuild a fresh channel whose type matches the client.
+func TestAppendOp_Retry_RebuildsResultChannelForRemoteClient(t *testing.T) {
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+
+	quorumInfo := &proto.QuorumInfo{
+		Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"},
+	}
+	op := NewAppendOp("bucket", "root", 1, 2, 10, []byte("v"),
+		func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo)
+
+	// Simulate the batch path having installed a LocalResultChannel in the slot.
+	op.resultChannels = make([]channel.ResultChannel, 1)
+	op.resultChannels[0] = channel.NewLocalResultChannel(op.Identifier())
+
+	mockClient.EXPECT().IsRemoteClient().Return(true).Maybe()
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node1").Return(mockClient, nil)
+
+	var captured channel.ResultChannel
+	mockClient.EXPECT().
+		AppendEntry(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ string, _ int64, _ *proto.LogEntry, ch channel.ResultChannel) (int64, error) {
+			captured = ch
+			// Return a retryable error so the background receivedAckCallback takes the
+			// synchronous-error path and returns immediately (no ReadResult wait).
+			return -1, werr.ErrInternalError
+		})
+
+	// receivedAckCallback runs in a background goroutine; signal when it finishes so
+	// the mock is not exercised after the test returns.
+	done := make(chan struct{})
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(context.Context, int64, error, int, string) { close(done) }).Return().Once()
+
+	op.sendWriteRequestRetry(context.Background(), 0)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("receivedAckCallback did not complete")
+	}
+
+	_, isRemote := captured.(*channel.RemoteResultChannel)
+	assert.True(t, isRemote,
+		"retry must rebuild a RemoteResultChannel for a remote client, not reuse the batch's LocalResultChannel")
 }
 
 func TestNewAppendOp(t *testing.T) {
@@ -630,9 +686,12 @@ func TestAppendOp_Execute_RetryIdempotency_WithNilChannels(t *testing.T) {
 	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo)
 	t.Cleanup(func() { cleanupAppendOp(t, op) })
 
-	// Manually set up result channels with one nil channel (simulating partial failure)
+	// Manually set up result channels with one nil channel (simulating partial failure).
+	// The existing channel must match the client type (remote here) — a matching
+	// channel is reused, whereas a mismatched one is rebuilt (see the retry
+	// channel-type regression test).
 	op.resultChannels = make([]channel.ResultChannel, 2)
-	op.resultChannels[0] = channel.NewLocalResultChannel("test-channel-0")
+	op.resultChannels[0] = channel.NewRemoteResultChannel("test-channel-0")
 	op.resultChannels[1] = nil // This should be recreated
 
 	originalChannel0 := op.resultChannels[0]
@@ -642,7 +701,7 @@ func TestAppendOp_Execute_RetryIdempotency_WithNilChannels(t *testing.T) {
 
 	// Verify that existing non-nil channel is preserved and nil channel is created
 	assert.Equal(t, 2, len(op.resultChannels))
-	assert.Same(t, originalChannel0, op.resultChannels[0], "Existing non-nil channel should be preserved")
+	assert.Same(t, originalChannel0, op.resultChannels[0], "Existing matching channel should be preserved")
 	assert.NotNil(t, op.resultChannels[1], "Nil channel should be created")
 }
 

--- a/woodpecker/segment/batch_append_op_test.go
+++ b/woodpecker/segment/batch_append_op_test.go
@@ -18,6 +18,7 @@ package segment
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -176,4 +177,131 @@ func TestSequentialExecutor_CoalescesAppendOps(t *testing.T) {
 
 	assert.Equal(t, int32(len(quorumInfo.Nodes)), appendEntriesCalls.Load(),
 		"the whole batch should send one AppendEntries per replica")
+}
+
+// waitWG waits for wg with a timeout, failing the test rather than hanging.
+func waitWG(t *testing.T, wg *sync.WaitGroup, d time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatal("timed out waiting for async callbacks")
+	}
+}
+
+func newBatchOps(t *testing.T, n int, pool *mocks_logstore_client.LogStoreClientPool, handle *mocks_segment_handle.SegmentHandle, quorumInfo *proto.QuorumInfo) []*AppendOp {
+	t.Helper()
+	ops := make([]*AppendOp, n)
+	for i := 0; i < n; i++ {
+		ops[i] = NewAppendOp("a-bucket", "files", 1, 2, int64(10+i), []byte("v"),
+			func(int64, int64, error) {}, pool, handle, quorumInfo)
+	}
+	return ops
+}
+
+// TestBatchAppendOp_InstallsLocalResultChannelInOpSlot pins the precondition that
+// the retry channel-type fix relies on: a successful batch leaves a
+// LocalResultChannel in each op's per-replica slot. If this ever changes, the
+// retry rebuild (TestAppendOp_Retry_RebuildsResultChannelForRemoteClient) is
+// testing a scenario that can no longer occur.
+func TestBatchAppendOp_InstallsLocalResultChannelInOpSlot(t *testing.T) {
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}}
+
+	const batchN = 2
+	ops := newBatchOps(t, batchN, mockPool, mockHandle, quorumInfo)
+
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil)
+	mockClient.EXPECT().
+		AppendEntries(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ string, _ int64, entries []*proto.LogEntry, chs []channel.ResultChannel) ([]int64, error) {
+			ids := make([]int64, len(entries))
+			for i, e := range entries {
+				ids[i] = e.EntryId
+				ch := chs[i]
+				eid := e.EntryId
+				go func() { _ = ch.SendResult(context.Background(), &channel.AppendResult{SyncedId: eid}) }()
+			}
+			return ids, nil
+		})
+
+	var wg sync.WaitGroup
+	wg.Add(batchN)
+	for i := 0; i < batchN; i++ {
+		mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(10+i)).
+			Run(func(context.Context, int64) { wg.Done() }).Return().Once()
+	}
+
+	NewBatchAppendOp(ops).Execute()
+	waitWG(t, &wg, 5*time.Second)
+
+	for i, op := range ops {
+		assert.NotNil(t, op.resultChannels[0], "op %d should have a channel in slot 0", i)
+		_, isLocal := op.resultChannels[0].(*channel.LocalResultChannel)
+		assert.True(t, isLocal, "op %d slot should hold a LocalResultChannel after batch send", i)
+	}
+}
+
+// TestBatchAppendOp_GetClientFails_AllOpsRoutedToFailure covers the send-side
+// failure where the client pool can't produce a client: every op in the batch
+// must be routed through HandleAppendRequestFailure for that node, with the
+// error recorded per op.
+func TestBatchAppendOp_GetClientFails_AllOpsRoutedToFailure(t *testing.T) {
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}}
+
+	const batchN = 3
+	ops := newBatchOps(t, batchN, mockPool, mockHandle, quorumInfo)
+
+	clientErr := errors.New("no client available")
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node1").Return(nil, clientErr)
+
+	var wg sync.WaitGroup
+	wg.Add(batchN)
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, mock.Anything, clientErr, 0, "node1").
+		Run(func(context.Context, int64, error, int, string) { wg.Done() }).Return().Times(batchN)
+
+	NewBatchAppendOp(ops).Execute()
+	waitWG(t, &wg, 5*time.Second)
+
+	for i, op := range ops {
+		assert.Equal(t, clientErr, op.channelErrors[0], "op %d should record the client error", i)
+	}
+}
+
+// TestBatchAppendOp_AppendEntriesError_AllOpsRoutedToFailure covers the batch RPC
+// itself failing: every op must be routed through HandleAppendRequestFailure.
+func TestBatchAppendOp_AppendEntriesError_AllOpsRoutedToFailure(t *testing.T) {
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}}
+
+	const batchN = 3
+	ops := newBatchOps(t, batchN, mockPool, mockHandle, quorumInfo)
+
+	sendErr := errors.New("append entries failed")
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node1").Return(mockClient, nil)
+	mockClient.EXPECT().
+		AppendEntries(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, sendErr)
+
+	var wg sync.WaitGroup
+	wg.Add(batchN)
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, mock.Anything, sendErr, 0, "node1").
+		Run(func(context.Context, int64, error, int, string) { wg.Done() }).Return().Times(batchN)
+
+	NewBatchAppendOp(ops).Execute()
+	waitWG(t, &wg, 5*time.Second)
+
+	for i, op := range ops {
+		assert.Equal(t, sendErr, op.channelErrors[0], "op %d should record the send error", i)
+	}
 }


### PR DESCRIPTION
## What

Fixes finding #1 of #225: a batched `AppendOp` that later needs a retry deterministically fails with `ErrInternalError` against a remote client.

`BatchAppendOp.sendBatchToNode` installs a `LocalResultChannel` in `op.resultChannels[nodeIdx]` for every op (`batch_append_op.go:117-119`). That slot is also the single-entry retry path's channel slot. On retry, `sendWriteRequest` only built a fresh channel when the slot was `nil` (`append_op.go:175`), so it **reused the batch's `LocalResultChannel`** and handed it to the remote client's `AppendEntry`. For a `Buffered` response the remote client type-asserts `syncedResultCh.(*channel.RemoteResultChannel)` and returns `ErrInternalError` on mismatch (`logstore_client_remote.go:112-116`). Since `ErrInternalError` is retryable, every retry re-hit the same poisoned channel, burned all `MaxRetries`, and forced a segment roll.

Batching is on by default (`segmentAppend.maxBatchEntries: 1000`), so this triggers whenever a real remote client forms a batch of ≥2 and any op in it hits a transient per-replica failure (network blip, node restart, one RPC timeout) — i.e. under load, where group commit is active.

## Fix

`sendWriteRequest` now (re)creates the result channel when the slot is empty **or** holds a channel whose type doesn't match the client; a matching channel is still reused (retry idempotency preserved):

```go
if len(op.resultChannels) > serverIndex {
	_, isRemoteChannel := op.resultChannels[serverIndex].(*channel.RemoteResultChannel)
	if op.resultChannels[serverIndex] == nil || isRemoteChannel != cli.IsRemoteClient() {
		if cli.IsRemoteClient() {
			op.resultChannels[serverIndex] = channel.NewRemoteResultChannel(op.Identifier())
		} else {
			op.resultChannels[serverIndex] = channel.NewLocalResultChannel(op.Identifier())
		}
	}
}
```

Only the mismatched batch-`Local`-vs-remote case changes behavior; every other path (initial send, same-type retry) is unchanged, so the existing per-server channel-reuse idempotency is preserved.

## Why not fix it in the batch path / channel type

- The batch legitimately wants a `LocalResultChannel`: `AppendEntries` routes acks via `SendResult` directly (no stream to attach), and Local is a blocking mailbox vs. Remote's 10ms-poll fallback. It also must register the channel in `op.resultChannels` so `FastFail`/`FastSuccess` can promptly unblock the batch drain.
- Making the batch install a `RemoteResultChannel` instead would swap this loud bug for a silent one: `InitResponseStream` does not clear `r.result`, and `ReadResult` returns `r.result` before reading the stream — a reused Remote channel would return the batch's stale result on retry.

## Tests

- `TestAppendOp_Retry_RebuildsResultChannelForRemoteClient` (new regression): pre-populates `op.resultChannels[0]` with a `LocalResultChannel` (simulating the batch), runs a retry against a remote mock client, and asserts the channel handed to `AppendEntry` is a `*RemoteResultChannel`. Fails on the pre-fix code, passes after.
- `TestAppendOp_Execute_RetryIdempotency_WithNilChannels`: updated. It pre-populated a slot with a `LocalResultChannel` under a remote client and asserted that channel was preserved — which is exactly the buggy behavior. Its intent (nil slot recreated, existing matching slot preserved) is kept by using a `RemoteResultChannel` that matches the remote client.
- The existing `TestRemoteClient_AppendEntry_Buffered_WrongChannelType` already proves the remote client rejects a Local channel with `ErrInternalError` — this PR removes the path that fed it one.

Full `go test ./woodpecker/segment/` passes; `go build ./...` and `go vet` are clean.

## Scope

Only finding #1. Findings #2 (LAC syncer timeout) and #3/#4 (batch stream leak + shared read timeout) from #225 are separate follow-up PRs.

Part of #225.
