### PR TITLE
fix(segment): bound the background LAC syncer so a hung node can't stall LAC forever

### DIFF
--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -1218,10 +1218,24 @@ func (s *segmentHandleImpl) lacSyncLoop() {
 	}
 }
 
+// lacSyncTimeout bounds a single LAC-sync fan-out so a hung node (connected but
+// unresponsive) can't wedge the single background LAC syncer forever. Package var
+// so tests can shrink it. TODO make configurable (like the 30s waits in the
+// append path).
+var lacSyncTimeout = 30 * time.Second
+
 // syncLACToQuorumAsync asynchronously syncs LAC to all quorum nodes
 func (s *segmentHandleImpl) syncLACToQuorumAsync(ctx context.Context, lac int64) {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, SegmentHandleScopeName, "syncLACToQuorumAsync")
 	defer sp.End()
+
+	// Bound the fan-out: the caller (lacSyncLoop) passes a deadline-less context,
+	// so without this a node that is connected but unresponsive would block the
+	// collection loop forever and stall LAC for the whole segment. On timeout the
+	// collection loop's ctx.Done() case unblocks and cancel() releases any
+	// still-in-flight per-node RPCs (their results land in the buffered channel).
+	ctx, cancel := context.WithTimeout(ctx, lacSyncTimeout)
+	defer cancel()
 
 	// Get quorum info
 	quorumInfo, err := s.GetQuorumInfo(ctx)

--- a/woodpecker/segment/segment_handle_test.go
+++ b/woodpecker/segment/segment_handle_test.go
@@ -6281,3 +6281,60 @@ func TestFenceSegmentQuorum_CtxTimeout(t *testing.T) {
 	assert.Equal(t, int64(-1), lastEntryId)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
+
+// TestSyncLACToQuorumAsync_BoundedWhenNodeHangs is a regression test for issue
+// #225 (#2): the background LAC syncer calls syncLACToQuorumAsync with a
+// deadline-less context, so a node that is connected but never responds
+// (UpdateLastAddConfirmed hangs) permanently wedges the syncer and LAC stops
+// advancing for the whole segment. syncLACToQuorumAsync must bound its fan-out
+// and return even when a node never replies.
+func TestSyncLACToQuorumAsync_BoundedWhenNodeHangs(t *testing.T) {
+	// Shrink the fan-out timeout so the test doesn't wait the production default.
+	oldTimeout := lacSyncTimeout
+	lacSyncTimeout = 200 * time.Millisecond
+	defer func() { lacSyncTimeout = oldTimeout }()
+
+	mockMetadata := mocks_meta.NewMetadataProvider(t)
+	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil).Maybe()
+	// A node that is connected but never responds: block until the request
+	// context is cancelled, which the fan-out timeout is responsible for doing.
+	mockClient.EXPECT().
+		UpdateLastAddConfirmed(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(rpcCtx context.Context, _ string, _ string, _ int64, _ int64, _ int64) error {
+			<-rpcCtx.Done()
+			return rpcCtx.Err()
+		}).Maybe()
+
+	cfg := &config.Configuration{
+		Woodpecker: config.WoodpeckerConfig{
+			Client: config.ClientConfig{
+				SegmentAppend: config.SegmentAppendConfig{QueueSize: 10, MaxRetries: 2},
+			},
+		},
+	}
+	segmentMeta := &meta.SegmentMeta{
+		Metadata: &proto.SegmentMetadata{
+			SegNo:       1,
+			State:       proto.SegmentState_Active,
+			LastEntryId: -1,
+			Quorum:      &proto.QuorumInfo{Id: 1, Es: 1, Wq: 1, Aq: 1, Nodes: []string{"127.0.0.1"}},
+		},
+		Revision: 1,
+	}
+	// canWrite=false: don't start the background loop/executor; call the fan-out directly.
+	sh := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, false, nil).(*segmentHandleImpl)
+
+	done := make(chan struct{})
+	go func() {
+		sh.syncLACToQuorumAsync(context.Background(), 5)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("syncLACToQuorumAsync did not return: a hung node wedged the LAC syncer")
+	}
+}


### PR DESCRIPTION
## What

Fixes finding #2 of #225: a hung LAC-sync RPC permanently stalls LAC advancement for a whole segment.

`lacSyncLoop` is the single background LAC syncer for a writable segment and calls `syncLACToQuorumAsync(context.Background(), lac)` **synchronously** with a deadline-less context (`segment_handle.go:1216`). The fan-out sends `UpdateLastAddConfirmed` to each quorum node on that context (`:1307`), and the result-collection loop's only escape is `case <-ctx.Done()` — which never fires on a background context. So a node that is *connected but unresponsive* blocks the RPC forever, wedges the single `lacSyncLoop` goroutine, and newer LAC values only coalesce into `lacSyncLatest` with nobody draining them.

Effect: writes keep succeeding, but LAC stops advancing → all tail readers stall silently (for Milvus: build-index / query-sync quietly wedge) with no write-side signal, until the process restarts.

(The missing timeout predates this code, but the earlier design spawned a fresh `go syncLACToQuorumAsync` per ack round — a hang leaked one goroutine while LAC kept advancing. The single-syncer loop turned "leak one goroutine" into "permanent stall", which is what this fixes.)

## Fix

Bound the fan-out inside `syncLACToQuorumAsync` so a hung node can't wedge it:

```go
ctx, cancel := context.WithTimeout(ctx, lacSyncTimeout)
defer cancel()
```

On timeout the collection loop's existing `case <-ctx.Done(): return` unblocks (so `lacSyncLoop` proceeds to the next coalesced LAC), and `cancel()` releases any still-in-flight per-node RPCs — their late results land in the buffered `resultChan` (capacity `len(nodes)`), so no goroutine leaks. Fixing it inside the function covers every caller (the background `lacSyncLoop` and the read-only `go syncLACToQuorumAsync` path) at one point.

`lacSyncTimeout` is a package var defaulting to `30 * time.Second` — the same order as the existing `// TODO configurable` waits in the append path (`append_op.go`, `batch_append_op.go`). It's a `var` (not a literal) purely so the regression test can shrink it; a real config knob is left as the shared TODO.

## Test

`TestSyncLACToQuorumAsync_BoundedWhenNodeHangs` (regression): a mock node whose `UpdateLastAddConfirmed` blocks until its request context is cancelled, `lacSyncTimeout` shrunk to 200ms, and `syncLACToQuorumAsync` invoked with `context.Background()` (mirroring `lacSyncLoop`). Asserts it returns within 2s. Without the fix the call never returns (the background context is never done) and the test fails at its 2s guard; with the fix it returns in ~200ms.

Full `go test ./woodpecker/segment/` passes; `go build ./...` and `go vet` are clean.

## Scope

Only finding #2. Finding #1 landed in #226; findings #3/#4 (batch stream leak + shared read timeout) are the remaining follow-up PR.

Part of #225.
