### PR TITLE
fix(segment): per-entry batch ack timeout and stream teardown on a stalled node

### DIFF
--- a/woodpecker/segment/batch_append_op.go
+++ b/woodpecker/segment/batch_append_op.go
@@ -29,6 +29,11 @@ import (
 
 var _ Operation = (*BatchAppendOp)(nil)
 
+// batchAckReadTimeout bounds how long the drain waits for a single entry's
+// durability ack. Package var so tests can shrink it. TODO make configurable
+// (like the append-path waits); tracked with the timeout audit.
+var batchAckReadTimeout = 30 * time.Second
+
 // BatchAppendOp groups a run of consecutive AppendOps from the same segment and
 // sends their entries to each quorum replica in a single AddEntries request
 // (client-side group commit). It amortizes the per-entry send round-trip that
@@ -122,8 +127,13 @@ func (b *BatchAppendOp) sendBatchToNode(ctx context.Context, entries []*proto.Lo
 	}
 
 	startRequestTime := time.Now()
-	_, err := cli.AppendEntries(ctx, first.bucketName, first.rootPath, first.logId, entries, resultChs)
+	// The drain goroutine below owns the stream's lifetime: streamCtx is cancelled
+	// when the drain exits (normally or on give-up), so a stalled peer can't leave
+	// the client demux goroutine + gRPC stream + server handler hanging.
+	streamCtx, streamCancel := context.WithCancel(ctx)
+	_, err := cli.AppendEntries(streamCtx, first.bucketName, first.rootPath, first.logId, entries, resultChs)
 	if err != nil {
+		streamCancel()
 		b.failNode(ctx, nodeIdx, serverAddr, err)
 		return
 	}
@@ -133,11 +143,24 @@ func (b *BatchAppendOp) sendBatchToNode(ctx context.Context, entries []*proto.Lo
 	// applies quorum inline, instead of spawning a receivedAckCallback goroutine
 	// per op. For a batch of N entries this is 1 goroutine per node instead of N.
 	go func() {
-		readCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TODO configurable
-		defer cancel()
+		defer streamCancel()
 		for i, op := range b.ops {
+			// Per-entry deadline: a slow early entry must not shrink a later
+			// (still-arriving) entry's budget into a false timeout.
+			readCtx, cancel := context.WithTimeout(context.Background(), batchAckReadTimeout)
 			result, readErr := resultChs[i].ReadResult(readCtx)
+			cancel()
 			op.applyNodeAck(ctx, startRequestTime, result, readErr, nodeIdx, serverAddr)
+			if readErr != nil {
+				// The stream stalled (no ack within the deadline). Acks are ordered,
+				// so entries after i won't arrive either — fail them fast instead of
+				// blocking a full deadline each, and let the deferred streamCancel tear
+				// down the hung stream promptly.
+				for j := i + 1; j < len(b.ops); j++ {
+					b.ops[j].applyNodeAck(ctx, startRequestTime, nil, readErr, nodeIdx, serverAddr)
+				}
+				return
+			}
 		}
 	}()
 }

--- a/woodpecker/segment/batch_append_op_test.go
+++ b/woodpecker/segment/batch_append_op_test.go
@@ -305,3 +305,117 @@ func TestBatchAppendOp_AppendEntriesError_AllOpsRoutedToFailure(t *testing.T) {
 		assert.Equal(t, sendErr, op.channelErrors[0], "op %d should record the send error", i)
 	}
 }
+
+// TestBatchAppendOp_StalledNode_FailsRemainingAndCancelsStream is a regression
+// test for issue #225 (#3): when the server acks some entries then stalls, the
+// drain must fail the remaining entries and cancel the context it passed to
+// AppendEntries, so the client demux goroutine + gRPC stream + server handler
+// unwind instead of leaking.
+func TestBatchAppendOp_StalledNode_FailsRemainingAndCancelsStream(t *testing.T) {
+	oldTimeout := batchAckReadTimeout
+	batchAckReadTimeout = 200 * time.Millisecond
+	defer func() { batchAckReadTimeout = oldTimeout }()
+
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}}
+
+	const batchN = 3
+	ops := newBatchOps(t, batchN, mockPool, mockHandle, quorumInfo) // entryIds 10, 11, 12
+
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil)
+
+	var capturedCtx context.Context
+	mockClient.EXPECT().
+		AppendEntries(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(streamCtx context.Context, _ string, _ string, _ int64, entries []*proto.LogEntry, chs []channel.ResultChannel) ([]int64, error) {
+			capturedCtx = streamCtx
+			ids := make([]int64, len(entries))
+			for i, e := range entries {
+				ids[i] = e.EntryId
+			}
+			// Ack only the first entry; the node then stalls (never sends the rest).
+			_ = chs[0].SendResult(context.Background(), &channel.AppendResult{SyncedId: entries[0].EntryId})
+			return ids, nil
+		})
+
+	mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(10)).Return().Once()
+	var failures sync.WaitGroup
+	failures.Add(2) // entries 11 and 12
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, mock.Anything, mock.Anything, 0, "node1").
+		Run(func(_ context.Context, entryId int64, _ error, _ int, _ string) {
+			if entryId == 11 || entryId == 12 {
+				failures.Done()
+			}
+		}).Return().Times(2)
+
+	NewBatchAppendOp(ops).Execute()
+	waitWG(t, &failures, 3*time.Second)
+
+	assert.Eventually(t, func() bool { return capturedCtx != nil && capturedCtx.Err() != nil },
+		2*time.Second, 10*time.Millisecond,
+		"stream context should be cancelled after the drain gives up on the stalled node")
+}
+
+// TestBatchAppendOp_PerEntryTimeout_NoFalseFailOnSlowEarlyEntry is a regression
+// test for issue #225 (#4): each entry must get its own read deadline. A slow
+// early entry must not shrink a later (still-arriving) entry's budget into a
+// false timeout, as the old single shared deadline did.
+func TestBatchAppendOp_PerEntryTimeout_NoFalseFailOnSlowEarlyEntry(t *testing.T) {
+	oldTimeout := batchAckReadTimeout
+	batchAckReadTimeout = 1 * time.Second
+	defer func() { batchAckReadTimeout = oldTimeout }()
+
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}}
+
+	const batchN = 2
+	ops := newBatchOps(t, batchN, mockPool, mockHandle, quorumInfo) // entryIds 10, 11
+
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil)
+	mockClient.EXPECT().
+		AppendEntries(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ string, _ int64, entries []*proto.LogEntry, chs []channel.ResultChannel) ([]int64, error) {
+			ids := make([]int64, len(entries))
+			for i, e := range entries {
+				ids[i] = e.EntryId
+			}
+			// Entry 0 acks slowly (consuming most of a single shared deadline); entry 1
+			// acks a bit later but still within its own per-entry window. Under the old
+			// shared deadline, entry 1 would be false-failed.
+			ch0, ch1 := chs[0], chs[1]
+			id0, id1 := entries[0].EntryId, entries[1].EntryId
+			go func() {
+				time.Sleep(600 * time.Millisecond)
+				_ = ch0.SendResult(context.Background(), &channel.AppendResult{SyncedId: id0})
+			}()
+			go func() {
+				time.Sleep(1200 * time.Millisecond)
+				_ = ch1.SendResult(context.Background(), &channel.AppendResult{SyncedId: id1})
+			}()
+			return ids, nil
+		})
+
+	var wg sync.WaitGroup
+	wg.Add(batchN)
+	for i := 0; i < batchN; i++ {
+		mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(10+i)).
+			Run(func(context.Context, int64) { wg.Done() }).Return().Once()
+	}
+	// Tolerate (but don't require) a failure call so the RED run doesn't panic on a
+	// strict mock; the real assertion is that both entries are acknowledged.
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return().Maybe()
+
+	NewBatchAppendOp(ops).Execute()
+	waitWG(t, &wg, 3*time.Second)
+
+	for i, op := range ops {
+		assert.True(t, op.completed.Load(), "op %d should be acknowledged, not false-failed", i)
+	}
+}


### PR DESCRIPTION
## What

Fixes findings #3 and #4 of #225 in the batched-append drain (`BatchAppendOp.sendBatchToNode`). They are coupled, so they land together.

**#4 — one shared read deadline for the whole batch.** The drain read every entry's durability ack against a single `context.WithTimeout(..., 30s)` (`batch_append_op.go:136`). A slow early entry consumes that shared budget, so later entries — often already persisted — hit `DeadlineExceeded` before their ack is read and are false-failed, which then triggers retries.

**#3 — the append stream is never torn down when the drain gives up.** `AppendEntries` spawns a demux goroutine that loops `respStream.Recv()` until every entry is acked; its stream context derives from the (deadline-less) batch context. If the peer stalls mid-flush, that goroutine — plus the gRPC stream and the server handler — blocks forever, and the batch-side drain giving up does not cancel it.

## Fix (one file, `batch_append_op.go`)

1. **Per-entry deadline (#4).** Each entry's ack is read against its own `batchAckReadTimeout`, mirroring the single-entry path, so an early slow entry can't shrink a later one's budget.
2. **Fail-fast on a stall.** On the first read error/timeout, the remaining entries are failed immediately instead of each blocking a full deadline. Acks are streamed in entry-id order (the server's `AddEntries` sends them sequentially), so if entry `i` didn't arrive, `i+1…` haven't either. This is also what makes the teardown prompt rather than after `N × timeout`.
3. **Drain owns the stream lifetime (#3).** The drain is handed a cancellable `streamCtx` that is passed to `AppendEntries` and cancelled (`defer streamCancel()`) when the drain exits — normally or on give-up. Cancelling it unblocks the demux goroutine's `Recv`, closing the gRPC stream and releasing the server handler. No change to `logstore_client_remote.go` is needed: `AppendEntries` already derives its internal stream context from the one passed in.

`batchAckReadTimeout` is a package var defaulting to `30s` (matching the append-path waits and `lacSyncTimeout`); a `var` only so the tests can shrink it. Making these coherent and configurable is tracked in the timeout audit (#229).

## Tests (TDD)

- `TestBatchAppendOp_StalledNode_FailsRemainingAndCancelsStream` (#3): server acks entry 0 then stalls; asserts the remaining entries fail and the context passed to `AppendEntries` is cancelled once the drain gives up. Fails before the fix (context never cancelled).
- `TestBatchAppendOp_PerEntryTimeout_NoFalseFailOnSlowEarlyEntry` (#4): entry 0 acks slowly, entry 1 acks later but within its own window; asserts both are acknowledged. Fails before the fix (entry 1 false-failed by the shared deadline).

Full `go test ./woodpecker/segment/` passes; `go build ./...` and `go vet` are clean.

## Scope / dependency

Only #3 and #4. Relies on the server streaming acks in entry-id order (`server/service.go` `AddEntries` sends sequentially) — an intentional, documented dependency, not new behavior.

With this, all four #225 findings are addressed (#1 → #226, #2 → #228, #3+#4 → here). The refactor (#227) and timeout audit (#229) remain as optional follow-ups.

Part of #225.
