### PR TITLE
fix(segment): hold op.mu across the retry send to close a data race with FastFail

### DIFF
--- a/woodpecker/segment/append_op_test.go
+++ b/woodpecker/segment/append_op_test.go
@@ -181,6 +181,60 @@ func TestAppendOp_applyNodeAck_BelowQuorumThenReached(t *testing.T) {
 	assert.True(t, op.completed.Load(), "second ack reaches Aq=2")
 }
 
+// TestAppendOp_RetryChannelRebuild_RacesWithFastFail is a regression test for
+// issue #231: the retry path (AppendRequestRetryOp.Execute ->
+// sendWriteRequestRetry -> sendWriteRequest) rewrites
+// op.resultChannels[serverIndex] (channel rebuild on client-type mismatch),
+// while FastFail/FastSuccess iterate the same slice under op.mu. The
+// initial-send path is protected because AppendOp.Execute holds op.mu across
+// the fan-out; the retry entry point must hold the same lock. Run with -race:
+// without the lock the detector flags the unsynchronized write/read pair.
+// The concurrency is realistic: an op's per-replica retry (executor worker)
+// can overlap a FastFail triggered by another entry's final failure
+// (HandleAppendRequestFailure fast-fails all queued ops with a larger entryId).
+func TestAppendOp_RetryChannelRebuild_RacesWithFastFail(t *testing.T) {
+	for iter := 0; iter < 30; iter++ {
+		mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+		mockClient := mocks_logstore_client.NewLogStoreClient(t)
+		mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+		quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}}
+
+		op := NewAppendOp("bucket", "root", 1, 2, 10, []byte("v"),
+			func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo)
+		// As installed by a prior batched send: a LocalResultChannel in the slot,
+		// which the retry against a remote client must rebuild (type mismatch).
+		op.resultChannels = make([]channel.ResultChannel, 1)
+		op.resultChannels[0] = channel.NewLocalResultChannel(op.Identifier())
+
+		mockClient.EXPECT().IsRemoteClient().Return(true).Maybe()
+		mockPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil).Maybe()
+		mockClient.EXPECT().
+			AppendEntry(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(int64(-1), werr.ErrInternalError).Maybe()
+		mockHandle.EXPECT().
+			HandleAppendRequestFailure(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return().Maybe()
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { // retry: rewrites op.resultChannels[0]
+			defer wg.Done()
+			<-start
+			NewAppendRequestRetryOp(context.Background(), 0, op).Execute()
+		}()
+		go func() { // fast-fail: iterates op.resultChannels under op.mu
+			defer wg.Done()
+			<-start
+			op.FastFail(context.Background(), werr.ErrSegmentFenced)
+		}()
+		close(start)
+		wg.Wait()
+		// Let the retry's spawned receivedAckCallback finish before mock teardown.
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
 func TestNewAppendOp(t *testing.T) {
 	logId := int64(1)
 	segmentId := int64(2)

--- a/woodpecker/segment/append_request_retry_op.go
+++ b/woodpecker/segment/append_request_retry_op.go
@@ -41,5 +41,13 @@ func (a AppendRequestRetryOp) Identifier() string {
 }
 
 func (a AppendRequestRetryOp) Execute() {
+	// Hold the op's mutex across the retry send, mirroring AppendOp.Execute's
+	// locking for the initial send: sendWriteRequest may rewrite
+	// op.resultChannels[serverIndex] (channel rebuild on client-type mismatch),
+	// which FastFail/FastSuccess iterate under the same mutex. The lock cannot
+	// live inside sendWriteRequest itself — the initial path calls it while
+	// Execute already holds op.mu.
+	a.innerOp.mu.Lock()
+	defer a.innerOp.mu.Unlock()
 	a.innerOp.sendWriteRequestRetry(a.opCtx, a.serverIndex)
 }


### PR DESCRIPTION
## What

Fixes #231: a data race between the append **retry path** and `FastFail`/`FastSuccess`.

- **Write side (no lock):** `AppendRequestRetryOp.Execute` → `sendWriteRequestRetry` → `sendWriteRequest`, which rewrites `op.resultChannels[serverIndex]` when the slot's channel type mismatches the client (`append_op.go:182-189`).
- **Read side (under `op.mu`):** `FastFail`/`FastSuccess` iterate `op.resultChannels` (`append_op.go:306+`).

Race-detector confirmed before the fix (7 reports from the new regression test):

```
WARNING: DATA RACE
Read  at ... (*AppendOp).FastFail()          append_op.go:311
Previous write at ... (*AppendOp).sendWriteRequest()  append_op.go:184
  via (*AppendOp).sendWriteRequestRetry()
```

Realistic interleaving: op X's per-replica retry runs on the executor worker (rebuilding the channel the batch installed, per #226), while another entry's final failure fast-fails all queued ops with a larger entryId — including X — from a different goroutine. The window predates #226 (a retry could write a still-`nil` slot after an initial `GetLogStoreClient` failure) but #226 made rebuild-on-retry the common path for batched ops.

## Fix

Hold `innerOp.mu` in `AppendRequestRetryOp.Execute` — the retry-only entry point — mirroring the locking `AppendOp.Execute` already uses for the initial send (it holds `op.mu` across the whole fan-out, which is exactly what protects the initial path from this race).

Why here and not deeper:
- The lock cannot go inside `sendWriteRequest`/`sendWriteRequestRetry`: the initial path calls them while `Execute` already holds `op.mu` — it would self-deadlock.
- Lock ordering stays acyclic: the system's existing order is `segmentHandle.Lock → op.mu` (via `HandleAppendRequestFailure → FastFail`); the retry path takes `op.mu` and never takes the handle lock synchronously (handle calls it makes are `go`-spawned).
- Holding `op.mu` across the retry's blocking send matches the initial-send behavior, so this introduces no new hazard class. The fact that the send itself can block unboundedly is a separate, pre-existing defect tracked as #232.

## Test

`TestAppendOp_RetryChannelRebuild_RacesWithFastFail`: plants a `LocalResultChannel` in the slot (as a batch does), then races `AppendRequestRetryOp.Execute` against `FastFail` from a start barrier, 30 iterations. Under `-race`: **7 DATA RACE reports / FAIL before the fix, clean after**. Serves as the permanent regression test.

Full `go test ./woodpecker/segment/ -race` passes; `go build ./...` and `go vet` are clean.

Fixes #231. Found in the post-merge re-review of #225.
