### PR TITLE
fix(client): bound the append send phase's first-response wait so a silent node can't wedge the executor

### DIFF
--- a/woodpecker/client/logstore_client_remote.go
+++ b/woodpecker/client/logstore_client_remote.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -30,6 +31,15 @@ import (
 )
 
 var _ LogStoreClient = (*logStoreClientRemote)(nil)
+
+// appendFirstResponseTimeout bounds the synchronous wait for the first
+// (Buffered) response of AddEntry / AddEntries. The caller passes a
+// deadline-less context, so without this bound a server that accepts the
+// stream but never responds blocks the send forever — wedging the per-segment
+// executor worker and stalling every subsequent append for the log (#232).
+// Package var so tests can shrink it. TODO make configurable; tracked with the
+// timeout audit (#229).
+var appendFirstResponseTimeout = 30 * time.Second
 
 // logStoreClientRemote is a remote implementation of LogStoreClient,
 // which will interact with a remote LogStoreClient instance using gRPC.
@@ -101,11 +111,28 @@ func (l *logStoreClientRemote) AppendEntry(ctx context.Context, bucketName strin
 		streamCancel() // Cancel context on error
 		return -1, err
 	}
-	// First, get the initial AddEntryResponse to check if entry was buffered
+	// First, get the initial AddEntryResponse to check if entry was buffered.
+	// Recv has no per-call deadline and the caller's context is deadline-less,
+	// so bound this synchronous wait with a timer that cancels the stream: a
+	// server that accepted the stream but never responds must not block the
+	// send forever (#232). Only the first response is bounded here — the async
+	// ack phase keeps its own budget (receivedAckCallback / batch drain).
+	firstRespTimer := time.AfterFunc(appendFirstResponseTimeout, streamCancel)
 	addEntryFirstResponse, err := respStream.Recv()
+	firstRespArrived := firstRespTimer.Stop()
 	if err != nil {
 		streamCancel() // Cancel context on error
 		return -1, err
+	}
+	if !firstRespArrived {
+		// The timer already fired: the stream is (being) cancelled and cannot
+		// carry the async ack, so treat the send as timed out even though a
+		// frame arrived at the deadline boundary.
+		streamCancel()
+		logger.Ctx(ctx).Warn("append first response timed out",
+			zap.Int64("logId", logId), zap.Int64("segId", entry.SegId), zap.Int64("entryId", entry.EntryId),
+			zap.Duration("timeout", appendFirstResponseTimeout))
+		return -1, context.DeadlineExceeded
 	}
 	// Then use the stream for async monitoring of the second AddEntryResponse status
 	if addEntryFirstResponse.GetState() == proto.AddEntryState_Buffered {
@@ -182,11 +209,23 @@ func (l *logStoreClientRemote) AppendEntries(ctx context.Context, bucketName str
 
 	// Phase 1: a single Buffered frame carries every id in the batch (the
 	// amortized send round-trip). A Failed frame here means the batch failed to
-	// buffer as a whole.
+	// buffer as a whole. Bound this synchronous wait the same way as the
+	// single-entry path (#232): a silent server must not block the send forever.
+	firstRespTimer := time.AfterFunc(appendFirstResponseTimeout, streamCancel)
 	resp, recvErr := respStream.Recv()
+	firstRespArrived := firstRespTimer.Stop()
 	if recvErr != nil {
 		streamCancel()
 		return nil, recvErr
+	}
+	if !firstRespArrived {
+		// Timer already fired: the stream is (being) cancelled and cannot carry
+		// phase 2; treat the batch send as timed out.
+		streamCancel()
+		logger.Ctx(ctx).Warn("batch append first response timed out",
+			zap.Int64("logId", logId), zap.Int("entries", n),
+			zap.Duration("timeout", appendFirstResponseTimeout))
+		return nil, context.DeadlineExceeded
 	}
 	if resp.GetState() == proto.AddEntryState_Failed {
 		statusErr := werr.Error(resp.GetStatus())

--- a/woodpecker/client/logstore_client_remote_test.go
+++ b/woodpecker/client/logstore_client_remote_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -173,6 +174,112 @@ func newRemoteClientWithMock(_ *testing.T) (*logStoreClientRemote, *mockProtoLog
 	mockClient := &mockProtoLogStoreClient{}
 	client := &logStoreClientRemote{innerClient: mockClient}
 	return client, mockClient
+}
+
+// silentAddEntryStream models a server that accepted the AddEntry stream but
+// never sends the first response. Like real gRPC, Recv unblocks only when the
+// stream's context is cancelled. The stream context is captured from the
+// AddEntry call via the mock's Run hook.
+type silentAddEntryStream struct {
+	ctx context.Context
+}
+
+func (s *silentAddEntryStream) Recv() (*proto.AddEntryResponse, error) {
+	<-s.ctx.Done()
+	return nil, s.ctx.Err()
+}
+
+func (s *silentAddEntryStream) Header() (metadata.MD, error) { return nil, nil }
+func (s *silentAddEntryStream) Trailer() metadata.MD         { return nil }
+func (s *silentAddEntryStream) CloseSend() error             { return nil }
+func (s *silentAddEntryStream) Context() context.Context     { return s.ctx }
+func (s *silentAddEntryStream) SendMsg(m any) error          { return nil }
+func (s *silentAddEntryStream) RecvMsg(m any) error          { return nil }
+
+// silentAddEntriesStream is the AddEntries counterpart of silentAddEntryStream.
+type silentAddEntriesStream struct {
+	ctx context.Context
+}
+
+func (s *silentAddEntriesStream) Recv() (*proto.AddEntriesResponse, error) {
+	<-s.ctx.Done()
+	return nil, s.ctx.Err()
+}
+
+func (s *silentAddEntriesStream) Header() (metadata.MD, error) { return nil, nil }
+func (s *silentAddEntriesStream) Trailer() metadata.MD         { return nil }
+func (s *silentAddEntriesStream) CloseSend() error             { return nil }
+func (s *silentAddEntriesStream) Context() context.Context     { return s.ctx }
+func (s *silentAddEntriesStream) SendMsg(m any) error          { return nil }
+func (s *silentAddEntriesStream) RecvMsg(m any) error          { return nil }
+
+// TestRemoteClient_AppendEntry_FirstResponseTimeout is a regression test for
+// issue #232: the synchronous wait for the first AddEntry response must be
+// bounded. With a deadline-less caller context (which is what the append path
+// passes) and a server that accepts the stream but stays silent, AppendEntry
+// previously blocked forever — wedging the per-segment executor worker.
+func TestRemoteClient_AppendEntry_FirstResponseTimeout(t *testing.T) {
+	oldTimeout := appendFirstResponseTimeout
+	appendFirstResponseTimeout = 200 * time.Millisecond
+	defer func() { appendFirstResponseTimeout = oldTimeout }()
+
+	client, mockClient := newRemoteClientWithMock(t)
+	stream := &silentAddEntryStream{}
+	mockClient.On("AddEntry", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { stream.ctx = args.Get(0).(context.Context) }).
+		Return(stream, nil)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.AppendEntry(context.Background(), "bucket", "root", 1,
+			&proto.LogEntry{SegId: 1, EntryId: 0, Values: []byte("v")},
+			channel.NewRemoteResultChannel("ch"))
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "a silent first response must surface as an error")
+	case <-time.After(2 * time.Second):
+		t.Fatal("AppendEntry is not bounded: still blocked on a silent server")
+	}
+}
+
+// TestRemoteClient_AppendEntries_FirstResponseTimeout is the batched (group
+// commit) counterpart: the phase-1 wait for the batch's Buffered frame must be
+// bounded as well.
+func TestRemoteClient_AppendEntries_FirstResponseTimeout(t *testing.T) {
+	oldTimeout := appendFirstResponseTimeout
+	appendFirstResponseTimeout = 200 * time.Millisecond
+	defer func() { appendFirstResponseTimeout = oldTimeout }()
+
+	client, mockClient := newRemoteClientWithMock(t)
+	stream := &silentAddEntriesStream{}
+	mockClient.On("AddEntries", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { stream.ctx = args.Get(0).(context.Context) }).
+		Return(stream, nil)
+
+	entries := []*proto.LogEntry{
+		{SegId: 1, EntryId: 0, Values: []byte("v0")},
+		{SegId: 1, EntryId: 1, Values: []byte("v1")},
+	}
+	resultChs := []channel.ResultChannel{
+		channel.NewLocalResultChannel("e0"),
+		channel.NewLocalResultChannel("e1"),
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := client.AppendEntries(context.Background(), "bucket", "root", 1, entries, resultChs)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		assert.Error(t, err, "a silent buffered frame must surface as an error")
+	case <-time.After(2 * time.Second):
+		t.Fatal("AppendEntries is not bounded: still blocked on a silent server")
+	}
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

Fixes #232: the append **send phase** had no deadline. `AppendEntry` / `AppendEntries` synchronously `Recv()` the first (Buffered) response on a context the append path passes in deadline-less, so a logstore node that **accepts the stream but never responds** blocked the send forever. Because the send runs on the per-segment `SequentialExecutor` worker, that one silent node wedged the worker and every subsequent append for the log queued behind it indefinitely (empirically demonstrated in #232: client-layer and pipeline-layer tests).

## Fix

Bound exactly the synchronous first-response wait in both methods (`logstore_client_remote.go`), with a timer that cancels the stream:

```go
firstRespTimer := time.AfterFunc(appendFirstResponseTimeout, streamCancel)
resp, err := respStream.Recv()
firstRespArrived := firstRespTimer.Stop()
if err != nil { streamCancel(); return ..., err }
if !firstRespArrived { streamCancel(); return ..., context.DeadlineExceeded }
```

Design notes:

- **Why a timer, not a deadline on `streamCtx`:** `Recv` has no per-call context, and a deadline on `streamCtx` would also kill the *legitimate* async ack phase (the `RemoteResultChannel` stream read for singles, the phase-2 demux for batches), which has its own budgets (`receivedAckCallback` 30s, per-entry batch drain from #230). The timer bounds only phase 1; on firing, `streamCancel()` unblocks the real gRPC `Recv` and simultaneously cancels the server handler's stream context — no server-side leak.
- **Boundary race handled:** if the timer fires just as a frame arrives (`timer.Stop() == false`), the stream is already being cancelled and cannot carry the async phase — the send is uniformly treated as timed out (`context.DeadlineExceeded`); retry/dedup handles the possibly-buffered entry like any post-buffer timeout.
- **On timeout the replica takes the existing failure path.** `DeadlineExceeded` is not a woodpecker-retryable error, so the replica goes to final failure → quorum bookkeeping → segment roll — the same treatment as other transport errors today, and the right call for a silent black-hole node (roll away rather than retry into it).
- `appendFirstResponseTimeout` is a package var defaulting to 30s (aligned with the other send/ack waits); a var only so tests can shrink it. Making it configurable/coherent is #229's job.
- **gRPC keepalive is deliberately out of scope** — it is the complementary per-connection, transport-level defense, but it changes behavior for every RPC on every connection; recorded concretely in #229 (see the category-D comment).

Only the remote client changes; the segment layer is covered transitively (its only blocking point in the send path is this call). The embedded/local client has no network silence problem.

## Tests (TDD)

- `TestRemoteClient_AppendEntry_FirstResponseTimeout`
- `TestRemoteClient_AppendEntries_FirstResponseTimeout`

Both use a silent stream whose `Recv` unblocks only on stream-context cancellation (faithful to real gRPC semantics; the mock captures the stream context from the `AddEntry`/`AddEntries` call). Before the fix both block past the 2s guard and FAIL; after, both return an error at the shrunk 200ms timeout.

The pipeline-layer stall demonstration from #232 is intentionally not ported: it mocks the `LogStoreClient` interface, which would bypass this fix; the pipeline is covered transitively since the executor's only unbounded blocking point was this wait.

`go build ./...`, `go vet`, and the client + segment suites under `-race` are clean.

Fixes #232. Related: #229 (timeout audit, subsumes the knob).
