### PR TITLE
enhance(server): disk-watermark backpressure + storage-expansion warning for WAL log store (#215)

### DIFF
--- a/common/config/configuration.go
+++ b/common/config/configuration.go
@@ -392,6 +392,7 @@ type DiskWatermarkPolicyConfig struct {
 	HardThresholdRatio float64         `yaml:"hardThresholdRatio"` // block watermark; default 0.90; >=1.0 means warn-only
 	MinFreeBytes       ByteSize        `yaml:"minFreeBytes"`       // absolute free floor that also blocks; default 1Gi
 	SampleInterval     DurationSeconds `yaml:"sampleInterval"`     // default 10s
+	ThrottleEnabled    bool            `yaml:"throttleEnabled"`    // probabilistic rejection between soft and hard; default true
 }
 
 type StorageConfig struct {
@@ -901,6 +902,7 @@ func getDefaultWoodpeckerConfig() WoodpeckerConfig {
 				HardThresholdRatio: 0.90,
 				MinFreeBytes:       ByteSize(1 * 1024 * 1024 * 1024), // 1Gi
 				SampleInterval:     DurationSeconds{Duration: Duration{duration: 10 * time.Second}},
+				ThrottleEnabled:    true,
 			},
 		},
 		Storage: StorageConfig{

--- a/common/config/configuration.go
+++ b/common/config/configuration.go
@@ -350,6 +350,7 @@ type LogstoreConfig struct {
 	ProcessorCleanupPolicy  ProcessorCleanupPolicyConfig `yaml:"processorCleanupPolicy"`
 	MaintenanceStrategy     MaintenanceStrategyConfig    `yaml:"maintenanceStrategy"`
 	NodeSelectionPolicy     NodeSelectionPolicyConfig    `yaml:"nodeSelectionPolicy"`
+	DiskWatermarkPolicy     DiskWatermarkPolicyConfig    `yaml:"diskWatermarkPolicy"`
 }
 
 // ProcessorCleanupPolicyConfig stores the background segment processor cleanup and shutdown configuration.
@@ -380,6 +381,17 @@ type NodeSelectionPolicyConfig struct {
 	LoadTTL            DurationSeconds `yaml:"loadTTL"`            // load older than this is treated as unknown; default 30s
 	MemSoftThreshold   float64         `yaml:"memSoftThreshold"`   // memory ratio above which memory escalates load; default 0.85
 	EWMAAlpha          float64         `yaml:"ewmaAlpha"`          // EWMA weight on newest sample; default 0.5
+}
+
+// DiskWatermarkPolicyConfig controls local-WAL-disk watermark warning and write
+// backpressure (issue #215). Active only for service/local storage (nodes that keep
+// WAL data on a local disk). Ratio semantics are used/(used+free), matching df.
+type DiskWatermarkPolicyConfig struct {
+	Enabled            bool            `yaml:"enabled"`            // master switch; default true
+	SoftThresholdRatio float64         `yaml:"softThresholdRatio"` // warn watermark; default 0.80
+	HardThresholdRatio float64         `yaml:"hardThresholdRatio"` // block watermark; default 0.90; >=1.0 means warn-only
+	MinFreeBytes       ByteSize        `yaml:"minFreeBytes"`       // absolute free floor that also blocks; default 1Gi
+	SampleInterval     DurationSeconds `yaml:"sampleInterval"`     // default 10s
 }
 
 type StorageConfig struct {
@@ -752,6 +764,17 @@ func (c *Configuration) validateLogstoreConfig() error {
 		}
 	}
 
+	dw := logstore.DiskWatermarkPolicy
+	if dw.Enabled {
+		if dw.SoftThresholdRatio <= 0 || dw.SoftThresholdRatio > dw.HardThresholdRatio {
+			return fmt.Errorf("diskWatermarkPolicy: require 0 < softThresholdRatio <= hardThresholdRatio, got soft=%v hard=%v",
+				dw.SoftThresholdRatio, dw.HardThresholdRatio)
+		}
+		if dw.MinFreeBytes < 0 {
+			return fmt.Errorf("diskWatermarkPolicy.minFreeBytes must be >= 0, got %d", dw.MinFreeBytes.Int64())
+		}
+	}
+
 	return nil
 }
 
@@ -871,6 +894,13 @@ func getDefaultWoodpeckerConfig() WoodpeckerConfig {
 				LoadTTL:            DurationSeconds{Duration: Duration{duration: 30 * time.Second}},
 				MemSoftThreshold:   0.85,
 				EWMAAlpha:          0.5,
+			},
+			DiskWatermarkPolicy: DiskWatermarkPolicyConfig{
+				Enabled:            true,
+				SoftThresholdRatio: 0.80,
+				HardThresholdRatio: 0.90,
+				MinFreeBytes:       ByteSize(1 * 1024 * 1024 * 1024), // 1Gi
+				SampleInterval:     DurationSeconds{Duration: Duration{duration: 10 * time.Second}},
 			},
 		},
 		Storage: StorageConfig{

--- a/common/config/configuration_test.go
+++ b/common/config/configuration_test.go
@@ -1233,6 +1233,7 @@ func TestDiskWatermarkPolicyConfig_DefaultsAndValidation(t *testing.T) {
 	assert.Equal(t, 0.90, dw.HardThresholdRatio)
 	assert.Equal(t, int64(1024*1024*1024), dw.MinFreeBytes.Int64())
 	assert.Equal(t, 10*time.Second, dw.SampleInterval.Duration.Duration())
+	assert.True(t, dw.ThrottleEnabled)
 	assert.NoError(t, cfg.Validate())
 
 	// invalid: soft > hard

--- a/common/config/configuration_test.go
+++ b/common/config/configuration_test.go
@@ -19,6 +19,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -1220,4 +1221,30 @@ func TestQuorumConfig_DynamicReplicasAffectsEnsembleSize(t *testing.T) {
 
 	current = 4 // invalid -> clamps to 3
 	assert.Equal(t, 3, q.GetEnsembleSize())
+}
+
+func TestDiskWatermarkPolicyConfig_DefaultsAndValidation(t *testing.T) {
+	cfg, err := NewConfiguration()
+	assert.NoError(t, err)
+
+	dw := cfg.Woodpecker.Logstore.DiskWatermarkPolicy
+	assert.True(t, dw.Enabled)
+	assert.Equal(t, 0.80, dw.SoftThresholdRatio)
+	assert.Equal(t, 0.90, dw.HardThresholdRatio)
+	assert.Equal(t, int64(1024*1024*1024), dw.MinFreeBytes.Int64())
+	assert.Equal(t, 10*time.Second, dw.SampleInterval.Duration.Duration())
+	assert.NoError(t, cfg.Validate())
+
+	// invalid: soft > hard
+	cfg.Woodpecker.Logstore.DiskWatermarkPolicy.SoftThresholdRatio = 0.95
+	assert.Error(t, cfg.Validate())
+
+	// invalid: negative minFreeBytes
+	cfg.Woodpecker.Logstore.DiskWatermarkPolicy.SoftThresholdRatio = 0.80
+	cfg.Woodpecker.Logstore.DiskWatermarkPolicy.MinFreeBytes = ByteSize(-1)
+	assert.Error(t, cfg.Validate())
+
+	// disabled: validation skipped
+	cfg.Woodpecker.Logstore.DiskWatermarkPolicy.Enabled = false
+	assert.NoError(t, cfg.Validate())
 }

--- a/common/hardware/hardware_info.go
+++ b/common/hardware/hardware_info.go
@@ -110,6 +110,21 @@ func GetDiskUsage(path string) (float64, float64, error) {
 	return usedGB, totalGB, nil
 }
 
+// GetDiskStats returns used/total/free bytes for the filesystem containing path.
+// free is the space available to unprivileged processes (statfs Bavail): on ext4
+// this excludes root-reserved blocks, so compute a df-style usage ratio as
+// used/(used+free), NOT used/total. A non-existent path returns zeros, nil.
+func GetDiskStats(path string) (used, total, free uint64, err error) {
+	diskStats, err := disk.Usage(path)
+	if err != nil {
+		if errors.Is(err, oserror.ErrNotExist) {
+			return 0, 0, 0, nil
+		}
+		return 0, 0, 0, err
+	}
+	return diskStats.Used, diskStats.Total, diskStats.Free, nil
+}
+
 // GetIOWait Get IO Wait Percentage
 func GetIOWait() (float64, error) {
 	cpuTimes, err := cpu.Times(false)

--- a/common/hardware/hardware_info_test.go
+++ b/common/hardware/hardware_info_test.go
@@ -118,3 +118,19 @@ func Test_GetUsedMemoryCount_Positive(t *testing.T) {
 	used := GetUsedMemoryCount()
 	assert.Greater(t, used, uint64(0))
 }
+
+func TestGetDiskStats(t *testing.T) {
+	used, total, free, err := GetDiskStats("/tmp")
+	assert.NoError(t, err)
+	assert.Greater(t, total, uint64(0))
+	assert.Greater(t, used+free, uint64(0))
+	assert.LessOrEqual(t, used, total)
+}
+
+func TestGetDiskStats_NotExist(t *testing.T) {
+	used, total, free, err := GetDiskStats("/definitely/not/exist/wp-215")
+	assert.NoError(t, err)
+	assert.Zero(t, used)
+	assert.Zero(t, total)
+	assert.Zero(t, free)
+}

--- a/common/metrics/service_metrics.go
+++ b/common/metrics/service_metrics.go
@@ -98,6 +98,32 @@ var (
 		Help:      "Number of active segment processors in log store",
 	}, []string{"node_id", "log_ns", "log_id"})
 
+	// Disk watermark backpressure metrics (issue #215)
+	WpLogStoreDiskUsageRatio = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "logstore_disk_usage_ratio",
+		Help:      "Local WAL disk usage ratio, used/(used+free) (df semantics)",
+	}, []string{"node_id", "path"})
+	WpLogStoreDiskFreeBytes = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "logstore_disk_free_bytes",
+		Help:      "Local WAL disk free bytes available to the process (statfs Bavail)",
+	}, []string{"node_id", "path"})
+	WpLogStoreWriteBackpressureState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "logstore_write_backpressure_state",
+		Help:      "Disk watermark backpressure state: 0=normal, 1=warn, 2=blocked",
+	}, []string{"node_id"})
+	WpLogStoreWriteRejectedTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "logstore_write_rejected_total",
+		Help:      "Total writes rejected by node-level admission gates",
+	}, []string{"node_id", "reason"})
+
 	// Buffer wait latency
 	WpServerBufferWaitLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
@@ -274,6 +300,11 @@ func RegisterServerMetricsWithRegisterer(registerer prometheus.Registerer) {
 		registerer.MustRegister(WpLogStoreOperationsTotal)
 		registerer.MustRegister(WpLogStoreOperationLatency)
 		registerer.MustRegister(WpLogStoreActiveSegmentProcessors)
+		// Disk watermark backpressure metrics (issue #215)
+		registerer.MustRegister(WpLogStoreDiskUsageRatio)
+		registerer.MustRegister(WpLogStoreDiskFreeBytes)
+		registerer.MustRegister(WpLogStoreWriteBackpressureState)
+		registerer.MustRegister(WpLogStoreWriteRejectedTotal)
 		// Buffer wait latency
 		registerer.MustRegister(WpServerBufferWaitLatency)
 		// Segment File Impl metrics

--- a/common/metrics/service_metrics.go
+++ b/common/metrics/service_metrics.go
@@ -123,6 +123,12 @@ var (
 		Name:      "logstore_write_rejected_total",
 		Help:      "Total writes rejected by node-level admission gates",
 	}, []string{"node_id", "reason"})
+	WpLogStoreWriteRejectProbability = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "logstore_write_reject_probability",
+		Help:      "Current probability that a new append is rejected by the disk watermark policy (0..1)",
+	}, []string{"node_id"})
 
 	// Buffer wait latency
 	WpServerBufferWaitLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -305,6 +311,7 @@ func RegisterServerMetricsWithRegisterer(registerer prometheus.Registerer) {
 		registerer.MustRegister(WpLogStoreDiskFreeBytes)
 		registerer.MustRegister(WpLogStoreWriteBackpressureState)
 		registerer.MustRegister(WpLogStoreWriteRejectedTotal)
+		registerer.MustRegister(WpLogStoreWriteRejectProbability)
 		// Buffer wait latency
 		registerer.MustRegister(WpServerBufferWaitLatency)
 		// Segment File Impl metrics

--- a/common/werr/errors.go
+++ b/common/werr/errors.go
@@ -96,6 +96,7 @@ var (
 	ErrLogStoreInvalidAddress = newWoodpeckerError("invalid logstore address", 2004, false)
 	ErrLogBeingDeleted        = newWoodpeckerError("log is being deleted", 2005, false)
 	ErrMarkDeleteFailed       = newWoodpeckerError("failed to durably mark log/instance deleted", 2006, true)
+	ErrLogStoreDiskPressure   = newWoodpeckerError("logstore local disk above hard watermark, write backpressure active", 2007, true)
 
 	// segment_processor errors (2100-2199)
 	ErrSegmentProcessorNotFound          = newWoodpeckerError("segment processor not found", 2100, false)

--- a/common/werr/errors_test.go
+++ b/common/werr/errors_test.go
@@ -258,3 +258,16 @@ func containsSubstring(s, substr string) bool {
 	}
 	return false
 }
+
+func TestErrLogStoreDiskPressure_Retryable(t *testing.T) {
+	if !IsRetryableErr(ErrLogStoreDiskPressure) {
+		t.Error("ErrLogStoreDiskPressure must be retryable")
+	}
+	st := Status(ErrLogStoreDiskPressure)
+	if !st.Retriable {
+		t.Error("Status.Retriable must be true")
+	}
+	if st.Code != 2007 {
+		t.Errorf("expected code 2007, got %d", st.Code)
+	}
+}

--- a/config/woodpecker.yaml
+++ b/config/woodpecker.yaml
@@ -130,6 +130,12 @@ woodpecker:
       loadTTL: 30               # Seconds; a node's load older than this is treated as unknown
       memSoftThreshold: 0.85    # Memory ratio above which memory escalates the load factor
       ewmaAlpha: 0.5            # EWMA weight on the newest load sample (0,1]
+    diskWatermarkPolicy:
+      enabled: true             # Local WAL disk watermark monitoring + backpressure (service/local storage only)
+      softThresholdRatio: 0.80  # Used ratio (used/(used+free), df semantics) above which a rate-limited WARN recommends expanding the PVC or lowering retentionPolicy.ttl
+      hardThresholdRatio: 0.90  # Used ratio above which new appends are rejected with a retriable error; set >= 1.0 (with minFreeBytes: 0) for warn-only
+      minFreeBytes: 1GB         # Absolute free-space floor; free space at or below this also blocks appends
+      sampleInterval: 10        # Seconds between disk samples
   # Configuration of Woodpecker Storage Backend.
   storage:
     # The default value is "default", which configures Woodpecker to use MinIO-compatible storage.

--- a/config/woodpecker.yaml
+++ b/config/woodpecker.yaml
@@ -132,7 +132,7 @@ woodpecker:
       ewmaAlpha: 0.5            # EWMA weight on the newest load sample (0,1]
     diskWatermarkPolicy:
       enabled: true             # Local WAL disk watermark monitoring + backpressure (service/local storage only)
-      softThresholdRatio: 0.80  # Used ratio (used/(used+free), df semantics) above which a rate-limited WARN recommends expanding the PVC or lowering retentionPolicy.ttl
+      softThresholdRatio: 0.80  # Used ratio (used/(used+free), df semantics) above which a rate-limited WARN recommends expanding the PVC or scaling out logstore nodes
       hardThresholdRatio: 0.90  # Used ratio above which new appends are rejected with a retriable error; set >= 1.0 (with minFreeBytes: 0) for warn-only
       throttleEnabled: true     # Between soft and hard, reject appends with probability ramping 0%→100% (retriable); false = warn-only until hard
       minFreeBytes: 1GB         # Absolute free-space floor; free space at or below this also blocks appends

--- a/config/woodpecker.yaml
+++ b/config/woodpecker.yaml
@@ -134,6 +134,7 @@ woodpecker:
       enabled: true             # Local WAL disk watermark monitoring + backpressure (service/local storage only)
       softThresholdRatio: 0.80  # Used ratio (used/(used+free), df semantics) above which a rate-limited WARN recommends expanding the PVC or lowering retentionPolicy.ttl
       hardThresholdRatio: 0.90  # Used ratio above which new appends are rejected with a retriable error; set >= 1.0 (with minFreeBytes: 0) for warn-only
+      throttleEnabled: true     # Between soft and hard, reject appends with probability ramping 0%→100% (retriable); false = warn-only until hard
       minFreeBytes: 1GB         # Absolute free-space floor; free space at or below this also blocks appends
       sampleInterval: 10        # Seconds between disk samples
   # Configuration of Woodpecker Storage Backend.

--- a/docs/admin-guides/disk-watermark.md
+++ b/docs/admin-guides/disk-watermark.md
@@ -43,10 +43,13 @@ WAL disk demand ≈ peak ingest rate × `woodpecker.logstore.retentionPolicy.ttl
 steady state, either:
 
 1. **Expand the PVC** (preferred for sustained higher ingest), or
-2. **Lower `woodpecker.logstore.retentionPolicy.ttl`** so truncated segments are
+2. **Scale out logstore nodes** — new nodes bind fresh PVCs, quorum selection
+   places new segments on them, and the pressured node drains naturally as its
+   existing segments compact to object storage and get reclaimed, or
+3. **Lower `woodpecker.logstore.retentionPolicy.ttl`** so truncated segments are
    reclaimed sooner (data already compacted to object storage does not need long
-   local retention), or
-3. Reduce ingest (upstream rate limiting).
+   local retention) — note this shortens local retention, or
+4. Reduce ingest (upstream rate limiting).
 
 To disable write rejection entirely and keep only the warn stage, set
 `throttleEnabled: false`, `hardThresholdRatio: 1.0`, and `minFreeBytes: 0`;

--- a/docs/admin-guides/disk-watermark.md
+++ b/docs/admin-guides/disk-watermark.md
@@ -1,0 +1,40 @@
+# WAL Disk Watermarks: Sizing, Warning, and Write Backpressure
+
+In service mode each LogStore node stages WAL data on a local disk/PVC
+(`woodpecker.storage.rootPath`) before it is uploaded/compacted to object storage.
+If that disk fills, appends fail with `no space left on device` and clients see
+opaque timeouts. Woodpecker monitors the WAL disk and applies two watermarks
+(`woodpecker.logstore.diskWatermarkPolicy`):
+
+| Watermark | Default | Behaviour |
+|---|---|---|
+| Soft (`softThresholdRatio`) | 0.80 | Rate-limited WARN log + `backpressure_state=1`. Writes still accepted. |
+| Hard (`hardThresholdRatio` **or** `minFreeBytes`) | 0.90 / 1GB | New appends rejected with a **retriable** error (`logstore local disk above hard watermark`, code 2007). Clients treat it as a transient rate-limit and retry. |
+
+The usage ratio is `used/(used+free)` with `free` = space available to the process
+(df semantics — on ext4 this excludes root-reserved blocks). Sampling runs every
+`sampleInterval` (default 10s); recovery clears the gate on the next sample after
+usage drops below the thresholds. Reads, segment fence/complete/compact/clean are
+never gated — those operations free disk.
+
+## Metrics to alert on
+
+- `woodpecker_server_logstore_disk_usage_ratio{node_id,path}` — alert at >= 0.80
+- `woodpecker_server_logstore_disk_free_bytes{node_id,path}` — alert near `minFreeBytes`
+- `woodpecker_server_logstore_write_backpressure_state{node_id}` — 0 normal / 1 warn / 2 blocked
+- `woodpecker_server_logstore_write_rejected_total{node_id,reason="disk_pressure"}` — rejection rate
+
+## Sizing the PVC / tuning retention
+
+WAL disk demand ≈ peak ingest rate × `woodpecker.logstore.retentionPolicy.ttl`
+(default 72h), plus compaction headroom. If nodes sit above the soft watermark in
+steady state, either:
+
+1. **Expand the PVC** (preferred for sustained higher ingest), or
+2. **Lower `woodpecker.logstore.retentionPolicy.ttl`** so truncated segments are
+   reclaimed sooner (data already compacted to object storage does not need long
+   local retention), or
+3. Reduce ingest (upstream rate limiting).
+
+`hardThresholdRatio: 1.0` together with `minFreeBytes: 0` turns blocking off
+(warn-only); `enabled: false` disables watermark monitoring entirely.

--- a/docs/admin-guides/disk-watermark.md
+++ b/docs/admin-guides/disk-watermark.md
@@ -3,13 +3,14 @@
 In service mode each LogStore node stages WAL data on a local disk/PVC
 (`woodpecker.storage.rootPath`) before it is uploaded/compacted to object storage.
 If that disk fills, appends fail with `no space left on device` and clients see
-opaque timeouts. Woodpecker monitors the WAL disk and applies two watermarks
+opaque timeouts. Woodpecker monitors the WAL disk and applies three stages
 (`woodpecker.logstore.diskWatermarkPolicy`):
 
-| Watermark | Default | Behaviour |
-|---|---|---|
-| Soft (`softThresholdRatio`) | 0.80 | Rate-limited WARN log + `backpressure_state=1`. Writes still accepted. |
-| Hard (`hardThresholdRatio` **or** `minFreeBytes`) | 0.90 / 1GB | New appends rejected with a **retriable** error (`logstore local disk above hard watermark`, code 2007). Clients treat it as a transient rate-limit and retry. |
+| Stage | Range | Default | Behaviour |
+|---|---|---|---|
+| Soft (`softThresholdRatio`) | `ratio == softThresholdRatio` boundary | 0.80 | Rate-limited WARN log + `backpressure_state=1`. Writes still accepted. |
+| Throttle | `softThresholdRatio < ratio < hardThresholdRatio` | ramps 0%→100% | New appends are rejected with a **retriable** error with a probability that ramps linearly from 0% at soft to 100% at hard (`logstore_write_reject_probability`). Each append is an independent coin flip, so writers slow down proportionally to disk pressure instead of hitting a hard cliff. Controlled by `throttleEnabled` (default `true`); when `false`, no rejections happen until the hard watermark. |
+| Hard (`hardThresholdRatio` **or** `minFreeBytes`) | `ratio >= hardThresholdRatio` or `free <= minFreeBytes` | 0.90 / 1GB | New appends always rejected with a **retriable** error (`logstore local disk above hard watermark`, code 2007). Clients treat it as a transient rate-limit and retry. Applies regardless of `throttleEnabled`. |
 
 The usage ratio is `used/(used+free)` with `free` = space available to the process
 (df semantics — on ext4 this excludes root-reserved blocks). Sampling runs every
@@ -17,12 +18,23 @@ The usage ratio is `used/(used+free)` with `free` = space available to the proce
 usage drops below the thresholds. Reads, segment fence/complete/compact/clean are
 never gated — those operations free disk.
 
+## Config notes
+
+- `throttleEnabled` (default `true`) turns the probabilistic throttle band on or
+  off. When `true`, appends between soft and hard are rejected with probability
+  `(ratio - soft) / (hard - soft)`. When `false`, the policy behaves as a
+  two-stage warn/block gate: nothing is rejected until the hard watermark (or
+  the `minFreeBytes` floor) is reached.
+- If `hardThresholdRatio <= softThresholdRatio` the throttle band is empty (no
+  ramp is computed); only the hard rule can reject.
+
 ## Metrics to alert on
 
 - `woodpecker_server_logstore_disk_usage_ratio{node_id,path}` — alert at >= 0.80
 - `woodpecker_server_logstore_disk_free_bytes{node_id,path}` — alert near `minFreeBytes`
 - `woodpecker_server_logstore_write_backpressure_state{node_id}` — 0 normal / 1 warn / 2 blocked
 - `woodpecker_server_logstore_write_rejected_total{node_id,reason="disk_pressure"}` — rejection rate
+- `woodpecker_server_logstore_write_reject_probability{node_id}` — current reject probability (0..1) applied by the throttle stage
 
 ## Sizing the PVC / tuning retention
 
@@ -36,5 +48,6 @@ steady state, either:
    local retention), or
 3. Reduce ingest (upstream rate limiting).
 
-`hardThresholdRatio: 1.0` together with `minFreeBytes: 0` turns blocking off
-(warn-only); `enabled: false` disables watermark monitoring entirely.
+To disable write rejection entirely and keep only the warn stage, set
+`throttleEnabled: false`, `hardThresholdRatio: 1.0`, and `minFreeBytes: 0`;
+`enabled: false` disables watermark monitoring entirely.

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -117,6 +117,14 @@ func NewLogStore(ctx context.Context, cfg *config.Configuration, storageClient s
 	logStore.maintenance.Register(newIdleProcessorCleanupTask(logStore))
 	logStore.maintenance.Register(newDeletedLogReclaimTask(logStore, cfg.Woodpecker.Logstore.MaintenanceStrategy.DeleteGracePeriod.Duration.Duration()))
 
+	// Disk-watermark backpressure (issue #215): only meaningful when this node keeps
+	// WAL data on a local disk (service/local storage modes).
+	dwPolicy := cfg.Woodpecker.Logstore.DiskWatermarkPolicy
+	if dwPolicy.Enabled && cfg.Woodpecker.Storage.RootPath != "" &&
+		(cfg.Woodpecker.Storage.IsStorageService() || cfg.Woodpecker.Storage.IsStorageLocal()) {
+		logStore.maintenance.Register(newDiskWatermarkTask(logStore))
+	}
+
 	logger.Ctx(ctx).Info("LogStore created successfully",
 		zap.String("address", logStore.address))
 
@@ -208,6 +216,10 @@ func (l *logStore) AddEntry(ctx context.Context, bucketName string, rootPath str
 	if l.stopped.Load() || l.rejectWrites.Load() {
 		return -1, werr.ErrLogStoreShutdown
 	}
+	if l.diskBlocked.Load() {
+		metrics.WpLogStoreWriteRejectedTotal.WithLabelValues(metrics.NodeID, "disk_pressure").Inc()
+		return -1, werr.ErrLogStoreDiskPressure
+	}
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, LogStoreScopeName, "AddEntry")
 	defer sp.End()
 	logIdStr := strconv.FormatInt(logId, 10)
@@ -239,6 +251,10 @@ func (l *logStore) AddEntry(ctx context.Context, bucketName string, rootPath str
 func (l *logStore) AddEntryBatch(ctx context.Context, bucketName string, rootPath string, logId int64, segmentId int64, entries []*proto.LogEntry, resultChs []channel.ResultChannel) ([]int64, error) {
 	if l.stopped.Load() || l.rejectWrites.Load() {
 		return nil, werr.ErrLogStoreShutdown
+	}
+	if l.diskBlocked.Load() {
+		metrics.WpLogStoreWriteRejectedTotal.WithLabelValues(metrics.NodeID, "disk_pressure").Inc()
+		return nil, werr.ErrLogStoreDiskPressure
 	}
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, LogStoreScopeName, "AddEntryBatch")
 	defer sp.End()

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -96,6 +96,7 @@ type logStore struct {
 	maintenance  *NodeMaintenanceManager
 	stopped      atomic.Bool
 	rejectWrites atomic.Bool // separate from stopped: only blocks new writes during decommission, not reads
+	diskBlocked  atomic.Bool // set by diskWatermarkTask when the local WAL disk crosses the hard watermark; gates new appends only
 }
 
 func NewLogStore(ctx context.Context, cfg *config.Configuration, storageClient storageclient.ObjectStorage) LogStore {

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -20,6 +20,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -93,10 +94,25 @@ type logStore struct {
 	deletingLogs      map[string]struct{} // logKey set
 	deletingInstances map[string]struct{} // instanceKey set
 
-	maintenance  *NodeMaintenanceManager
-	stopped      atomic.Bool
-	rejectWrites atomic.Bool // separate from stopped: only blocks new writes during decommission, not reads
-	diskBlocked  atomic.Bool // set by diskWatermarkTask when the local WAL disk crosses the hard watermark; gates new appends only
+	maintenance   *NodeMaintenanceManager
+	stopped       atomic.Bool
+	rejectWrites  atomic.Bool  // separate from stopped: only blocks new writes during decommission, not reads
+	diskRejectBps atomic.Int32 // rejection probability in basis points (0..10000), set by diskWatermarkTask; gates new appends only
+}
+
+// admitAppend returns false when the disk-watermark policy rejects this append.
+// bps==0 admits everything, bps==diskRejectBpsMax rejects everything; in the
+// throttle band each admission is an independent Bernoulli trial, so retriable
+// rejections slow writers proportionally to disk pressure without a hard cliff.
+func (l *logStore) admitAppend() bool {
+	bps := l.diskRejectBps.Load()
+	if bps <= 0 {
+		return true
+	}
+	if bps >= diskRejectBpsMax {
+		return false
+	}
+	return rand.Int32N(diskRejectBpsMax) >= bps
 }
 
 func NewLogStore(ctx context.Context, cfg *config.Configuration, storageClient storageclient.ObjectStorage) LogStore {
@@ -216,7 +232,7 @@ func (l *logStore) AddEntry(ctx context.Context, bucketName string, rootPath str
 	if l.stopped.Load() || l.rejectWrites.Load() {
 		return -1, werr.ErrLogStoreShutdown
 	}
-	if l.diskBlocked.Load() {
+	if !l.admitAppend() {
 		metrics.WpLogStoreWriteRejectedTotal.WithLabelValues(metrics.NodeID, "disk_pressure").Inc()
 		return -1, werr.ErrLogStoreDiskPressure
 	}
@@ -252,7 +268,7 @@ func (l *logStore) AddEntryBatch(ctx context.Context, bucketName string, rootPat
 	if l.stopped.Load() || l.rejectWrites.Load() {
 		return nil, werr.ErrLogStoreShutdown
 	}
-	if l.diskBlocked.Load() {
+	if !l.admitAppend() {
 		metrics.WpLogStoreWriteRejectedTotal.WithLabelValues(metrics.NodeID, "disk_pressure").Inc()
 		return nil, werr.ErrLogStoreDiskPressure
 	}

--- a/server/logstore_test.go
+++ b/server/logstore_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/zilliztech/woodpecker/common/channel"
 	"github.com/zilliztech/woodpecker/common/config"
 	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/mocks/mocks_server/mocks_segment"
@@ -1242,4 +1243,57 @@ func TestLogStore_EvictLog_MarkerWriteFailure(t *testing.T) {
 	_, marked := store.deletingLogs[GetLogKey(testBucketName, testRootPath, testLogId)]
 	store.spMu.RUnlock()
 	assert.False(t, marked, "log must not be marked in memory when the durable marker write failed")
+}
+
+func TestLogStore_AddEntry_DiskPressureRejected(t *testing.T) {
+	cfg, _ := config.NewConfiguration()
+	ctx := context.Background()
+	ls := NewLogStore(ctx, cfg, nil).(*logStore)
+	ls.stopped.Store(false) // bypass Start(); the gate under test sits after the stopped check
+	ls.diskBlocked.Store(true)
+
+	entry := &proto.LogEntry{SegId: 1, EntryId: 0, Values: []byte("x")}
+	rc := channel.NewLocalResultChannel("test/disk-pressure/0")
+	id, err := ls.AddEntry(ctx, "bucket", "root", 1, entry, rc)
+	assert.Equal(t, int64(-1), id)
+	assert.True(t, werr.ErrLogStoreDiskPressure.Is(err), "expected disk-pressure error, got %v", err)
+	assert.True(t, werr.IsRetryableErr(err), "disk-pressure rejection must be retriable")
+
+	ids, batchErr := ls.AddEntryBatch(ctx, "bucket", "root", 1, 1,
+		[]*proto.LogEntry{entry}, []channel.ResultChannel{rc})
+	assert.Nil(t, ids)
+	assert.True(t, werr.ErrLogStoreDiskPressure.Is(batchErr))
+}
+
+func hasMaintenanceTaskNamed(ls *logStore, name string) bool {
+	for _, task := range ls.maintenance.tasks {
+		if task.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestNewLogStore_DiskWatermarkTaskRegistration(t *testing.T) {
+	ctx := context.Background()
+
+	// service mode with a root path -> registered
+	cfg, _ := config.NewConfiguration()
+	cfg.Woodpecker.Storage.Type = "service"
+	cfg.Woodpecker.Storage.RootPath = t.TempDir()
+	ls := NewLogStore(ctx, cfg, nil).(*logStore)
+	assert.True(t, hasMaintenanceTaskNamed(ls, "disk-watermark"))
+
+	// default (minio) mode: no local WAL accumulation -> not registered
+	cfg2, _ := config.NewConfiguration()
+	ls2 := NewLogStore(ctx, cfg2, nil).(*logStore)
+	assert.False(t, hasMaintenanceTaskNamed(ls2, "disk-watermark"))
+
+	// explicitly disabled -> not registered
+	cfg3, _ := config.NewConfiguration()
+	cfg3.Woodpecker.Storage.Type = "service"
+	cfg3.Woodpecker.Storage.RootPath = t.TempDir()
+	cfg3.Woodpecker.Logstore.DiskWatermarkPolicy.Enabled = false
+	ls3 := NewLogStore(ctx, cfg3, nil).(*logStore)
+	assert.False(t, hasMaintenanceTaskNamed(ls3, "disk-watermark"))
 }

--- a/server/logstore_test.go
+++ b/server/logstore_test.go
@@ -1250,7 +1250,7 @@ func TestLogStore_AddEntry_DiskPressureRejected(t *testing.T) {
 	ctx := context.Background()
 	ls := NewLogStore(ctx, cfg, nil).(*logStore)
 	ls.stopped.Store(false) // bypass Start(); the gate under test sits after the stopped check
-	ls.diskBlocked.Store(true)
+	ls.diskRejectBps.Store(diskRejectBpsMax)
 
 	entry := &proto.LogEntry{SegId: 1, EntryId: 0, Values: []byte("x")}
 	rc := channel.NewLocalResultChannel("test/disk-pressure/0")
@@ -1263,6 +1263,31 @@ func TestLogStore_AddEntry_DiskPressureRejected(t *testing.T) {
 		[]*proto.LogEntry{entry}, []channel.ResultChannel{rc})
 	assert.Nil(t, ids)
 	assert.True(t, werr.ErrLogStoreDiskPressure.Is(batchErr))
+}
+
+func TestLogStore_AdmitAppend_Probabilistic(t *testing.T) {
+	cfg, _ := config.NewConfiguration()
+	ls := NewLogStore(context.Background(), cfg, nil).(*logStore)
+
+	ls.diskRejectBps.Store(0)
+	for i := 0; i < 100; i++ {
+		assert.True(t, ls.admitAppend())
+	}
+	ls.diskRejectBps.Store(diskRejectBpsMax)
+	for i := 0; i < 100; i++ {
+		assert.False(t, ls.admitAppend())
+	}
+	ls.diskRejectBps.Store(5000)
+	rejected := 0
+	const trials = 10000
+	for i := 0; i < trials; i++ {
+		if !ls.admitAppend() {
+			rejected++
+		}
+	}
+	// p=0.5, n=10000: ±10σ bounds — deterministic-in-practice
+	assert.Greater(t, rejected, 4000)
+	assert.Less(t, rejected, 6000)
 }
 
 func hasMaintenanceTaskNamed(ls *logStore, name string) bool {

--- a/server/maintenance.go
+++ b/server/maintenance.go
@@ -27,7 +27,9 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/hardware"
 	"github.com/zilliztech/woodpecker/common/logger"
+	"github.com/zilliztech/woodpecker/common/metrics"
 )
 
 // MaintenanceTask is one periodic, idempotent self-maintenance routine run by the
@@ -246,5 +248,92 @@ func (r *deletedLogReclaimTask) Run(ctx context.Context) error {
 			zap.Int64("earliestDueUnix", earliestDue),
 			zap.Duration("gracePeriod", r.grace))
 	}
+	return nil
+}
+
+// Disk watermark backpressure levels reported via WpLogStoreWriteBackpressureState.
+const (
+	diskLevelNormal  = 0
+	diskLevelWarn    = 1
+	diskLevelBlocked = 2
+)
+
+// diskWatermarkWarnCooldown rate-limits repeated warn logs while the node stays
+// at or above the soft watermark.
+const diskWatermarkWarnCooldown = time.Minute
+
+// diskWatermarkTask samples the local WAL disk once per interval, evaluates the
+// soft/hard watermarks (issue #215) and sets store.diskBlocked so the append path
+// can reject new writes with a retriable error before the disk actually fills.
+// The level is a pure function of the current sample (no hysteresis); lastLevel
+// and lastWarnAt exist only for log rate-limiting and are touched by a single
+// goroutine (the maintenance runner), so they are plain fields.
+type diskWatermarkTask struct {
+	store      *logStore
+	policy     config.DiskWatermarkPolicyConfig
+	path       string
+	usageFn    func(path string) (used, total, free uint64, err error) // injectable for tests
+	lastLevel  int
+	lastWarnAt time.Time
+}
+
+func newDiskWatermarkTask(store *logStore) *diskWatermarkTask {
+	return &diskWatermarkTask{
+		store:   store,
+		policy:  store.cfg.Woodpecker.Logstore.DiskWatermarkPolicy,
+		path:    store.cfg.Woodpecker.Storage.RootPath,
+		usageFn: hardware.GetDiskStats,
+	}
+}
+
+func (t *diskWatermarkTask) Name() string { return "disk-watermark" }
+
+func (t *diskWatermarkTask) Interval() time.Duration {
+	return t.policy.SampleInterval.Duration.Duration()
+}
+
+func (t *diskWatermarkTask) Run(ctx context.Context) error {
+	used, _, free, err := t.usageFn(t.path)
+	if err != nil || used+free == 0 {
+		// Transient stat failure (or empty stats): keep the previous state rather
+		// than flapping the gate; the next successful sample corrects it.
+		logger.Ctx(ctx).Debug("disk watermark sample unavailable, keeping previous state",
+			zap.String("path", t.path), zap.Error(err))
+		return nil
+	}
+	// df semantics: free is statfs Bavail, so used/(used+free) matches what the
+	// operator sees in df/kubectl and accounts for ext4 root-reserved blocks.
+	ratio := float64(used) / float64(used+free)
+	blocked := ratio >= t.policy.HardThresholdRatio || free <= uint64(t.policy.MinFreeBytes.Int64())
+	level := diskLevelNormal
+	if blocked {
+		level = diskLevelBlocked
+	} else if ratio >= t.policy.SoftThresholdRatio {
+		level = diskLevelWarn
+	}
+
+	t.store.diskBlocked.Store(blocked)
+	metrics.WpLogStoreDiskUsageRatio.WithLabelValues(metrics.NodeID, t.path).Set(ratio)
+	metrics.WpLogStoreDiskFreeBytes.WithLabelValues(metrics.NodeID, t.path).Set(float64(free))
+	metrics.WpLogStoreWriteBackpressureState.WithLabelValues(metrics.NodeID).Set(float64(level))
+
+	now := time.Now()
+	switch {
+	case level > diskLevelNormal && (level != t.lastLevel || now.Sub(t.lastWarnAt) >= diskWatermarkWarnCooldown):
+		logger.Ctx(ctx).Warn("local WAL disk usage high: expand the PVC or lower woodpecker.logstore.retentionPolicy.ttl",
+			zap.String("path", t.path),
+			zap.Float64("usedRatio", ratio),
+			zap.Uint64("freeBytes", free),
+			zap.Float64("softThreshold", t.policy.SoftThresholdRatio),
+			zap.Float64("hardThreshold", t.policy.HardThresholdRatio),
+			zap.Bool("writesBlocked", blocked))
+		t.lastWarnAt = now
+	case level == diskLevelNormal && t.lastLevel > diskLevelNormal:
+		logger.Ctx(ctx).Info("local WAL disk usage recovered below watermarks",
+			zap.String("path", t.path),
+			zap.Float64("usedRatio", ratio),
+			zap.Uint64("freeBytes", free))
+	}
+	t.lastLevel = level
 	return nil
 }

--- a/server/maintenance.go
+++ b/server/maintenance.go
@@ -340,7 +340,7 @@ func (t *diskWatermarkTask) Run(ctx context.Context) error {
 	now := time.Now()
 	switch {
 	case level > diskLevelNormal && (level != t.lastLevel || now.Sub(t.lastWarnAt) >= diskWatermarkWarnCooldown):
-		logger.Ctx(ctx).Warn("local WAL disk usage high: expand the PVC or lower woodpecker.logstore.retentionPolicy.ttl",
+		logger.Ctx(ctx).Warn("local WAL disk usage high: expand the PVC or scale out logstore nodes to bind new PVCs",
 			zap.String("path", t.path),
 			zap.Float64("usedRatio", ratio),
 			zap.Uint64("freeBytes", free),

--- a/server/maintenance.go
+++ b/server/maintenance.go
@@ -262,8 +262,26 @@ const (
 // at or above the soft watermark.
 const diskWatermarkWarnCooldown = time.Minute
 
+// diskRejectBpsMax is full rejection in basis points.
+const diskRejectBpsMax = int32(10000)
+
+// diskRejectBpsFor maps a disk sample to an append-rejection probability in
+// basis points: 0 below soft; a linear ramp across the soft→hard band when
+// throttling is enabled; full rejection at/above hard or at/below the
+// absolute free floor (regardless of ThrottleEnabled).
+func diskRejectBpsFor(ratio float64, free uint64, p config.DiskWatermarkPolicyConfig) int32 {
+	if free <= uint64(p.MinFreeBytes.Int64()) || ratio >= p.HardThresholdRatio {
+		return diskRejectBpsMax
+	}
+	if !p.ThrottleEnabled || ratio < p.SoftThresholdRatio || p.HardThresholdRatio <= p.SoftThresholdRatio {
+		return 0
+	}
+	frac := (ratio - p.SoftThresholdRatio) / (p.HardThresholdRatio - p.SoftThresholdRatio)
+	return int32(frac * float64(diskRejectBpsMax))
+}
+
 // diskWatermarkTask samples the local WAL disk once per interval, evaluates the
-// soft/hard watermarks (issue #215) and sets store.diskBlocked so the append path
+// soft/hard watermarks (issue #215) and sets store.diskRejectBps so the append path
 // can reject new writes with a retriable error before the disk actually fills.
 // The level is a pure function of the current sample (no hysteresis); lastLevel
 // and lastWarnAt exist only for log rate-limiting and are touched by a single
@@ -304,7 +322,8 @@ func (t *diskWatermarkTask) Run(ctx context.Context) error {
 	// df semantics: free is statfs Bavail, so used/(used+free) matches what the
 	// operator sees in df/kubectl and accounts for ext4 root-reserved blocks.
 	ratio := float64(used) / float64(used+free)
-	blocked := ratio >= t.policy.HardThresholdRatio || free <= uint64(t.policy.MinFreeBytes.Int64())
+	rejectBps := diskRejectBpsFor(ratio, free, t.policy)
+	blocked := rejectBps >= diskRejectBpsMax
 	level := diskLevelNormal
 	if blocked {
 		level = diskLevelBlocked
@@ -312,10 +331,11 @@ func (t *diskWatermarkTask) Run(ctx context.Context) error {
 		level = diskLevelWarn
 	}
 
-	t.store.diskBlocked.Store(blocked)
+	t.store.diskRejectBps.Store(rejectBps)
 	metrics.WpLogStoreDiskUsageRatio.WithLabelValues(metrics.NodeID, t.path).Set(ratio)
 	metrics.WpLogStoreDiskFreeBytes.WithLabelValues(metrics.NodeID, t.path).Set(float64(free))
 	metrics.WpLogStoreWriteBackpressureState.WithLabelValues(metrics.NodeID).Set(float64(level))
+	metrics.WpLogStoreWriteRejectProbability.WithLabelValues(metrics.NodeID).Set(float64(rejectBps) / float64(diskRejectBpsMax))
 
 	now := time.Now()
 	switch {
@@ -326,7 +346,8 @@ func (t *diskWatermarkTask) Run(ctx context.Context) error {
 			zap.Uint64("freeBytes", free),
 			zap.Float64("softThreshold", t.policy.SoftThresholdRatio),
 			zap.Float64("hardThreshold", t.policy.HardThresholdRatio),
-			zap.Bool("writesBlocked", blocked))
+			zap.Bool("writesBlocked", blocked),
+			zap.Int32("rejectBps", rejectBps))
 		t.lastWarnAt = now
 	case level == diskLevelNormal && t.lastLevel > diskLevelNormal:
 		logger.Ctx(ctx).Info("local WAL disk usage recovered below watermarks",

--- a/server/maintenance_test.go
+++ b/server/maintenance_test.go
@@ -382,25 +382,25 @@ func TestDiskWatermarkTask_Levels(t *testing.T) {
 	// normal: 50% used, plenty free
 	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 15 * testGi, 30 * testGi, 15 * testGi, nil }
 	require.NoError(t, task.Run(ctx))
-	assert.False(t, ls.diskBlocked.Load())
+	assert.Equal(t, int32(0), ls.diskRejectBps.Load())
 	assert.Equal(t, diskLevelNormal, task.lastLevel)
 
-	// warn: 85% used
+	// warn: 85% used (exact midpoint of the 0.80-0.90 throttle band)
 	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 85 * testGi, 100 * testGi, 15 * testGi, nil }
 	require.NoError(t, task.Run(ctx))
-	assert.False(t, ls.diskBlocked.Load())
+	assert.InDelta(t, 5000, ls.diskRejectBps.Load(), 2)
 	assert.Equal(t, diskLevelWarn, task.lastLevel)
 
 	// blocked: 95% used
 	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 95 * testGi, 100 * testGi, 5 * testGi, nil }
 	require.NoError(t, task.Run(ctx))
-	assert.True(t, ls.diskBlocked.Load())
+	assert.Equal(t, diskRejectBpsMax, ls.diskRejectBps.Load())
 	assert.Equal(t, diskLevelBlocked, task.lastLevel)
 
-	// recovery back to normal clears the flag on the next tick
+	// recovery back to normal clears the rejection probability on the next tick
 	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 15 * testGi, 30 * testGi, 15 * testGi, nil }
 	require.NoError(t, task.Run(ctx))
-	assert.False(t, ls.diskBlocked.Load())
+	assert.Equal(t, int32(0), ls.diskRejectBps.Load())
 	assert.Equal(t, diskLevelNormal, task.lastLevel)
 }
 
@@ -411,7 +411,7 @@ func TestDiskWatermarkTask_MinFreeFloorBlocks(t *testing.T) {
 		return 100 * 1024 * 1024, 1 * testGi, 512 * 1024 * 1024, nil
 	}
 	require.NoError(t, task.Run(context.Background()))
-	assert.True(t, ls.diskBlocked.Load())
+	assert.Equal(t, diskRejectBpsMax, ls.diskRejectBps.Load())
 	assert.Equal(t, diskLevelBlocked, task.lastLevel)
 }
 
@@ -422,12 +422,36 @@ func TestDiskWatermarkTask_StatErrorKeepsState(t *testing.T) {
 	// drive to blocked
 	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 95 * testGi, 100 * testGi, 5 * testGi, nil }
 	require.NoError(t, task.Run(ctx))
-	require.True(t, ls.diskBlocked.Load())
+	require.Equal(t, diskRejectBpsMax, ls.diskRejectBps.Load())
 
 	// transient stat error must NOT unblock (keep last state)
 	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 0, 0, 0, fmt.Errorf("statfs boom") }
 	require.NoError(t, task.Run(ctx))
-	assert.True(t, ls.diskBlocked.Load())
+	assert.Equal(t, diskRejectBpsMax, ls.diskRejectBps.Load())
+}
+
+func TestDiskRejectBpsFor(t *testing.T) {
+	p := config.DiskWatermarkPolicyConfig{
+		Enabled: true, SoftThresholdRatio: 0.80, HardThresholdRatio: 0.90,
+		MinFreeBytes: config.ByteSize(1024), ThrottleEnabled: true,
+	}
+	assert.Equal(t, int32(0), diskRejectBpsFor(0.50, 1<<30, p))
+	assert.Equal(t, int32(0), diskRejectBpsFor(0.7999, 1<<30, p))
+	assert.InDelta(t, 0, diskRejectBpsFor(0.80, 1<<30, p), 2)    // ramp start
+	assert.InDelta(t, 5000, diskRejectBpsFor(0.85, 1<<30, p), 2) // midpoint
+	assert.InDelta(t, 9000, diskRejectBpsFor(0.89, 1<<30, p), 2) // near hard
+	assert.Equal(t, diskRejectBpsMax, diskRejectBpsFor(0.90, 1<<30, p))
+	assert.Equal(t, diskRejectBpsMax, diskRejectBpsFor(0.95, 1<<30, p))
+	assert.Equal(t, diskRejectBpsMax, diskRejectBpsFor(0.10, 1024, p)) // min-free floor wins
+
+	p.ThrottleEnabled = false // two-state mode: nothing in the band, hard still blocks
+	assert.Equal(t, int32(0), diskRejectBpsFor(0.85, 1<<30, p))
+	assert.Equal(t, diskRejectBpsMax, diskRejectBpsFor(0.90, 1<<30, p))
+
+	p.ThrottleEnabled = true
+	p.HardThresholdRatio = 0.80 // soft==hard: empty band, no division by zero
+	assert.Equal(t, diskRejectBpsMax, diskRejectBpsFor(0.80, 1<<30, p))
+	assert.Equal(t, int32(0), diskRejectBpsFor(0.79, 1<<30, p))
 }
 
 func TestDiskWatermarkTask_WarnCooldown(t *testing.T) {

--- a/server/maintenance_test.go
+++ b/server/maintenance_test.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -361,4 +362,90 @@ func TestDeletedLogReclaimTask_MinioModeNoLocalButPrunes(t *testing.T) {
 	_, present := store.deletingLogs[logKey]
 	store.spMu.RUnlock()
 	assert.False(t, present, "deletingLogs gate entry should have been pruned in minio mode")
+}
+
+func newDiskWatermarkTestStore(t *testing.T) (*logStore, *diskWatermarkTask) {
+	cfg, err := config.NewConfiguration()
+	require.NoError(t, err)
+	cfg.Woodpecker.Storage.Type = "service"
+	cfg.Woodpecker.Storage.RootPath = t.TempDir()
+	ls := NewLogStore(context.Background(), cfg, nil).(*logStore)
+	return ls, newDiskWatermarkTask(ls)
+}
+
+const testGi = uint64(1024 * 1024 * 1024)
+
+func TestDiskWatermarkTask_Levels(t *testing.T) {
+	ls, task := newDiskWatermarkTestStore(t)
+	ctx := context.Background()
+
+	// normal: 50% used, plenty free
+	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 15 * testGi, 30 * testGi, 15 * testGi, nil }
+	require.NoError(t, task.Run(ctx))
+	assert.False(t, ls.diskBlocked.Load())
+	assert.Equal(t, diskLevelNormal, task.lastLevel)
+
+	// warn: 85% used
+	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 85 * testGi, 100 * testGi, 15 * testGi, nil }
+	require.NoError(t, task.Run(ctx))
+	assert.False(t, ls.diskBlocked.Load())
+	assert.Equal(t, diskLevelWarn, task.lastLevel)
+
+	// blocked: 95% used
+	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 95 * testGi, 100 * testGi, 5 * testGi, nil }
+	require.NoError(t, task.Run(ctx))
+	assert.True(t, ls.diskBlocked.Load())
+	assert.Equal(t, diskLevelBlocked, task.lastLevel)
+
+	// recovery back to normal clears the flag on the next tick
+	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 15 * testGi, 30 * testGi, 15 * testGi, nil }
+	require.NoError(t, task.Run(ctx))
+	assert.False(t, ls.diskBlocked.Load())
+	assert.Equal(t, diskLevelNormal, task.lastLevel)
+}
+
+func TestDiskWatermarkTask_MinFreeFloorBlocks(t *testing.T) {
+	ls, task := newDiskWatermarkTestStore(t)
+	// ratio is low (~16%) but free (512Mi) is under the 1Gi floor -> blocked
+	task.usageFn = func(string) (uint64, uint64, uint64, error) {
+		return 100 * 1024 * 1024, 1 * testGi, 512 * 1024 * 1024, nil
+	}
+	require.NoError(t, task.Run(context.Background()))
+	assert.True(t, ls.diskBlocked.Load())
+	assert.Equal(t, diskLevelBlocked, task.lastLevel)
+}
+
+func TestDiskWatermarkTask_StatErrorKeepsState(t *testing.T) {
+	ls, task := newDiskWatermarkTestStore(t)
+	ctx := context.Background()
+
+	// drive to blocked
+	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 95 * testGi, 100 * testGi, 5 * testGi, nil }
+	require.NoError(t, task.Run(ctx))
+	require.True(t, ls.diskBlocked.Load())
+
+	// transient stat error must NOT unblock (keep last state)
+	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 0, 0, 0, fmt.Errorf("statfs boom") }
+	require.NoError(t, task.Run(ctx))
+	assert.True(t, ls.diskBlocked.Load())
+}
+
+func TestDiskWatermarkTask_WarnCooldown(t *testing.T) {
+	ls, task := newDiskWatermarkTestStore(t)
+	_ = ls
+	ctx := context.Background()
+
+	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 85 * testGi, 100 * testGi, 15 * testGi, nil }
+	require.NoError(t, task.Run(ctx))
+	firstWarnAt := task.lastWarnAt
+	assert.False(t, firstWarnAt.IsZero(), "first warn must stamp lastWarnAt")
+
+	// same level within cooldown: no re-log (lastWarnAt unchanged)
+	require.NoError(t, task.Run(ctx))
+	assert.Equal(t, firstWarnAt, task.lastWarnAt)
+
+	// level escalation logs immediately even within cooldown
+	task.usageFn = func(string) (uint64, uint64, uint64, error) { return 95 * testGi, 100 * testGi, 5 * testGi, nil }
+	require.NoError(t, task.Run(ctx))
+	assert.NotEqual(t, firstWarnAt, task.lastWarnAt, "level change must re-stamp lastWarnAt")
 }

--- a/tests/docker/monitor/grafana/templates/dashboard_server.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_server.json
@@ -277,7 +277,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "Engine Layer \u2014 LogStore",
+      "title": "Engine Layer — LogStore",
       "type": "row"
     },
     {
@@ -734,7 +734,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "Storage Layer \u2014 File I/O & Buffer",
+      "title": "Storage Layer — File I/O & Buffer",
       "type": "row"
     },
     {
@@ -1460,6 +1460,302 @@
         "w": 24,
         "x": 0,
         "y": 4
+      },
+      "id": 59,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "thresholdsStyle": {
+                  "mode": "dashed"
+                }
+              },
+              "unit": "percentunit",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "max": 1,
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 5
+          },
+          "id": 60,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_disk_usage_ratio) by (node_id, path)",
+              "legendFormat": "nodeID={{node_id}} path={{path}}",
+              "refId": "A"
+            }
+          ],
+          "title": "WAL Disk Usage Ratio",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 5
+          },
+          "id": 61,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_disk_free_bytes) by (node_id, path)",
+              "legendFormat": "nodeID={{node_id}} path={{path}}",
+              "refId": "A"
+            }
+          ],
+          "title": "WAL Disk Free Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "lineInterpolation": "stepAfter"
+              },
+              "unit": "short",
+              "max": 2,
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 5
+          },
+          "id": 62,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_write_backpressure_state) by (node_id)",
+              "legendFormat": "nodeID={{node_id}} (0=normal 1=warn 2=blocked)",
+              "refId": "A"
+            }
+          ],
+          "title": "Write Backpressure State",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "percentunit",
+              "max": 1,
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 63,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_write_reject_probability) by (node_id)",
+              "legendFormat": "nodeID={{node_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Write Reject Probability",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 64,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_logstore_write_rejected_total[1m])) by (node_id, reason)",
+              "legendFormat": "nodeID={{node_id}} reason={{reason}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Write Rejected Rate",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Disk Watermark — Backpressure",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
       },
       "id": 32,
       "panels": [
@@ -2370,7 +2666,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 6
       },
       "id": 55,
       "panels": [
@@ -2537,7 +2833,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 7
       },
       "id": 27,
       "panels": [

--- a/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
@@ -277,7 +277,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "Engine Layer \u2014 LogStore",
+      "title": "Engine Layer — LogStore",
       "type": "row"
     },
     {
@@ -734,7 +734,7 @@
           "type": "timeseries"
         }
       ],
-      "title": "Storage Layer \u2014 File I/O & Buffer",
+      "title": "Storage Layer — File I/O & Buffer",
       "type": "row"
     },
     {
@@ -1460,6 +1460,302 @@
         "w": 24,
         "x": 0,
         "y": 4
+      },
+      "id": 59,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "thresholdsStyle": {
+                  "mode": "dashed"
+                }
+              },
+              "unit": "percentunit",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 0.8
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "max": 1,
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 5
+          },
+          "id": 60,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_disk_usage_ratio{namespace=~\"$namespace\"}) by (node_id, path)",
+              "legendFormat": "nodeID={{node_id}} path={{path}}",
+              "refId": "A"
+            }
+          ],
+          "title": "WAL Disk Usage Ratio",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 5
+          },
+          "id": 61,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_disk_free_bytes{namespace=~\"$namespace\"}) by (node_id, path)",
+              "legendFormat": "nodeID={{node_id}} path={{path}}",
+              "refId": "A"
+            }
+          ],
+          "title": "WAL Disk Free Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false,
+                "lineInterpolation": "stepAfter"
+              },
+              "unit": "short",
+              "max": 2,
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 5
+          },
+          "id": 62,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_write_backpressure_state{namespace=~\"$namespace\"}) by (node_id)",
+              "legendFormat": "nodeID={{node_id}} (0=normal 1=warn 2=blocked)",
+              "refId": "A"
+            }
+          ],
+          "title": "Write Backpressure State",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "percentunit",
+              "max": 1,
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "id": 63,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(woodpecker_server_logstore_write_reject_probability{namespace=~\"$namespace\"}) by (node_id)",
+              "legendFormat": "nodeID={{node_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Write Reject Probability",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "id": 64,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_logstore_write_rejected_total{namespace=~\"$namespace\"}[1m])) by (node_id, reason)",
+              "legendFormat": "nodeID={{node_id}} reason={{reason}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Write Rejected Rate",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Disk Watermark — Backpressure",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
       },
       "id": 32,
       "panels": [
@@ -2370,7 +2666,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 6
       },
       "id": 55,
       "panels": [
@@ -2537,7 +2833,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 6
+        "y": 7
       },
       "id": 27,
       "panels": [


### PR DESCRIPTION
Closes #215. Woodpecker-side counterpart of milvus-io/milvus#51032.

## What

Adds **disk-watermark backpressure + storage-expansion warning** for the local WAL disk in service/local storage modes, so a node approaching full rate-limits new appends with a **retriable** error and warns the operator *before* hitting `no space left on device` mid-append.

- A `disk-watermark` `MaintenanceTask` (third sibling of the two existing tasks) samples `woodpecker.storage.rootPath` every `sampleInterval` (default 10s), computes the usage ratio as **`used/(used+free)`** (df semantics — `free` is statfs `Bavail`, so ext4 root-reserved blocks are accounted for), and stateless-evaluates **three stages**:
  - **Soft / warn** (`softThresholdRatio`, default 0.80): rate-limited WARN (1m cooldown) recommending PVC expansion or scaling out logstore nodes (bind new PVCs), plus `backpressure_state=1`.
  - **Throttle** (between soft and hard, `throttleEnabled` default true): each append is rejected with probability ramping **linearly 0%→100%** across the soft→hard band (e.g. 85% disk → 50% rejection with the default 0.80/0.90 band). Rejections are retriable, so writers slow proportionally to disk pressure instead of hitting a 0/100 cliff — this is the server-side rate-limit stage, and it also damps the unblock retry-storm sawtooth.
  - **Hard / block** (`hardThresholdRatio` default 0.90, **or** `minFreeBytes` floor default 1GiB, floor applies regardless of throttleEnabled): all new appends rejected. The task publishes a node-level rejection probability (`diskRejectBps` atomic, basis points); `AddEntry`/`AddEntryBatch` do one admission draw per call and reject with `werr.ErrLogStoreDiskPressure` (**code 2007, retryable=true**) so Milvus surfaces it as a transient rate-limit instead of a hard write failure / opaque `DEADLINE_EXCEEDED`.
- Only appends are gated. Fence/Complete/Compact/Clean/reads are never gated — they are the recovery path that frees disk.
- Recovery is automatic: the flag clears on the first sample below thresholds (no hysteresis by design; rejection is retriable, so boundary oscillation is graceful degradation).
- New metrics (all `woodpecker_server_...`): `logstore_disk_usage_ratio{node_id,path}`, `logstore_disk_free_bytes{node_id,path}`, `logstore_write_backpressure_state{node_id}` (0/1/2), `logstore_write_reject_probability{node_id}` (0..1, current throttle intensity), `logstore_write_rejected_total{node_id,reason="disk_pressure"}`.
- Config block `woodpecker.logstore.diskWatermarkPolicy` (default-on; warn-only = `throttleEnabled: false` + `hardThresholdRatio: 1.0` + `minFreeBytes: 0`; two-state warn→block = `throttleEnabled: false`; `enabled: false` = off). Registered only for service/local storage with a non-empty rootPath.
- Admin guide: `docs/admin-guides/disk-watermark.md` (PVC sizing, `retentionPolicy.ttl` tuning, alerting).
- Grafana: new collapsed row **"Disk Watermark — Backpressure"** (after System) in both server dashboards (`tests/docker/monitor/.../dashboard_server.json`, `tests/k8s/monitor/.../dashboard_server_k8s.json`): WAL disk usage ratio (with 0.80/0.90 threshold lines), free bytes, backpressure state (0/1/2, stepped), reject probability, rejected rate by reason.

## Error code note

The new error is **2007**, not the next-looking 2005: 2005/2006 were already taken (`ErrLogBeingDeleted`/`ErrMarkDeleteFailed`). Existing wire-protocol codes are untouched; 2007 is appended at the end of the logstore band.

## Behavior notes (verified during review)

- **Quorum interaction:** a single replica returning retriable `ErrLogStoreDiskPressure` is retried in place (`segment_handle.go: HandleAppendRequestFailure`) and tolerated by quorum accounting — the append completes at `Aq` acks via healthy replicas. If pressure on that replica persists past `MaxRetries`, the op enters the final-failure path and sets `rollingState=true`: a **segment-rolling side effect**, not an append failure. Expect increased segment rolling on a chronically pressured node.
- **Executor edge:** if a retry re-submission fails (executor closed/full), that op fast-fails with `ErrAppendOpRetrySubmitFailed` (non-retryable) — a shutdown/overload lifecycle edge independent of disk pressure.
- **Mixed-version safety:** old clients reconstruct errors from the wire `status.Retriable` bit (`werr.Error`), not a local code table, so unknown code 2007 is still treated as retriable. No client version floor.
- **Throttle-band retries:** a probabilistically rejected append retries and re-draws, so the throttle stage mainly adds latency/backoff pressure per replica (quorum still completes at Aq acks) — intended: it propagates a graduated slow-down signal upstream rather than precise QPS shaping; precise DML rate limiting stays in Milvus's quota system (milvus-io/milvus#51032).
- **Startup window:** on boot, appends are admissible for one scheduling hop before the first disk sample; on an already-full disk those writes fall through to the pre-existing `ErrFileWriterNoSpace` path (no regression), and the gate engages on the first tick.
- **Test suites:** mini-cluster/docker/integration suites run service mode with `TempDir` rootPath and inherit the default-on gate; it only fires ≥90% used, so CI/dev disks with headroom never trip it.

## Testing

- Unit: config defaults/validation; `GetDiskStats` (incl. non-existent path); error retryability/code/wire round-trip; watermark task level transitions, min-free floor, stat-error keeps state, warn cooldown; ramp mapping (`diskRejectBpsFor`: boundaries, throttle-off, empty band, floor precedence); admission gate (deterministic extremes + statistical n=10000 at p=0.5); gate rejection (both append paths) and registration matrix (service/local vs minio vs disabled).
- `go build ./...`, `go vet`, full `./server/`, `./common/{config,hardware,werr,metrics}` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
