### PR TITLE
fix(log): stop auditor after writer invalidation

### DIFF
--- a/woodpecker/log/internal_log_writer.go
+++ b/woodpecker/log/internal_log_writer.go
@@ -59,6 +59,9 @@ type internalLogWriterImpl struct {
 	// validation related fields
 	isWriterValid       atomic.Bool
 	onWriterInvalidated func(ctx context.Context, reason string)
+	maintenanceCtx      context.Context
+	maintenanceCancel   context.CancelFunc
+	auditorWG           sync.WaitGroup
 
 	// Mutex to ensure only one truncation cleanup task is running at a time
 	cleanupMutex      sync.Mutex
@@ -69,6 +72,7 @@ type internalLogWriterImpl struct {
 func NewInternalLogWriter(ctx context.Context, logHandle LogHandle, cfg *config.Configuration) LogWriter {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, WriterScopeName, "NewInternalLogWriter")
 	defer sp.End()
+	maintenanceCtx, maintenanceCancel := context.WithCancel(context.Background())
 	w := &internalLogWriterImpl{
 		logIdStr:           fmt.Sprintf("%d", logHandle.GetId()),
 		logHandle:          logHandle,
@@ -79,6 +83,8 @@ func NewInternalLogWriter(ctx context.Context, logHandle LogHandle, cfg *config.
 		cleanupManager:     segment.NewSegmentCleanupManager(cfg.Minio.BucketName, cfg.Minio.RootPath, logHandle.GetMetadataProvider(), logHandle.(*logHandleImpl).ClientPool),
 		notifyManager:      segment.NewSegmentCompactedNotifyManager(cfg.Minio.BucketName, cfg.Minio.RootPath, logHandle.GetMetadataProvider(), logHandle.(*logHandleImpl).ClientPool),
 		notifySegsCh:       make(chan map[int64]*meta.SegmentMeta, 1),
+		maintenanceCtx:     maintenanceCtx,
+		maintenanceCancel:  maintenanceCancel,
 	}
 	// Set sessionValid to true
 	w.isWriterValid.Store(true)
@@ -86,16 +92,31 @@ func NewInternalLogWriter(ctx context.Context, logHandle LogHandle, cfg *config.
 	// Set trigger expired
 	onWriterInvalidated := func(ctx context.Context, reason string) {
 		w.isWriterValid.Store(false)
+		w.stopMaintenance()
 		logger.Ctx(ctx).Warn("trigger writer lock session expired", zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()), zap.String("reason", reason))
 	}
 	w.onWriterInvalidated = onWriterInvalidated
 
 	// Monitor keepAlive channel
-	go w.runAuditor()
+	w.startAuditor()
 	// Compacted-mark distribution runs on its own goroutine so a slow node can't stall the auditor.
-	go runNotifyDistributor(w.logHandle, w.notifyManager, cfg.Woodpecker.Storage.IsStorageService(), w.notifySegsCh, w.writerClose)
+	go runNotifyDistributor(w.logHandle, w.notifyManager, cfg.Woodpecker.Storage.IsStorageService(), w.notifySegsCh, w.maintenanceCtx.Done())
 	logger.Ctx(ctx).Info("log writer created", zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()))
 	return w
+}
+
+func (l *internalLogWriterImpl) startAuditor() {
+	l.auditorWG.Add(1)
+	go func() {
+		defer l.auditorWG.Done()
+		l.runAuditor()
+	}()
+}
+
+func (l *internalLogWriterImpl) stopMaintenance() {
+	if l.maintenanceCancel != nil {
+		l.maintenanceCancel()
+	}
 }
 
 func (l *internalLogWriterImpl) Write(ctx context.Context, msg *WriteMessage) *WriteResult {
@@ -244,8 +265,12 @@ func (l *internalLogWriterImpl) runAuditor() {
 	for {
 		select {
 		case <-ticker.C:
+			if l.maintenanceCtx.Err() != nil || !l.isWriterValid.Load() {
+				l.stopMaintenance()
+				return
+			}
 			auditCycle++
-			ctx, sp := logger.NewIntentCtx(WriterScopeName, fmt.Sprintf("auditor_%d", l.logHandle.GetId()))
+			ctx, sp := logger.NewIntentCtxWithParent(l.maintenanceCtx, WriterScopeName, fmt.Sprintf("auditor_%d", l.logHandle.GetId()))
 			startAudit := time.Now()
 
 			logger.Ctx(ctx).Debug("Starting auditor cycle",
@@ -282,6 +307,10 @@ func (l *internalLogWriterImpl) runAuditor() {
 			publishSegmentsSnapshot(l.notifySegsCh, segmentMetaList)
 
 			cs := compactCompletedSegments(ctx, l.logHandle, segmentMetaList)
+			if ctx.Err() != nil {
+				sp.End()
+				return
+			}
 			truncatedSegmentExists := collectTruncatedSegments(segmentMetaList)
 			// In-process reap sync: a Truncated segment must never be notified again, even if the
 			// distributor is mid-round on a stale snapshot that still shows it Sealed.
@@ -324,6 +353,11 @@ func (l *internalLogWriterImpl) runAuditor() {
 			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "auditor_run", "success").Observe(float64(auditDuration.Milliseconds()))
 		case <-l.writerClose:
 			logger.Ctx(context.TODO()).Info("Log auditor stopped",
+				zap.String("logName", l.logHandle.GetName()),
+				zap.Int64("logId", l.logHandle.GetId()))
+			return
+		case <-l.maintenanceCtx.Done():
+			logger.Ctx(context.TODO()).Info("Log auditor stopped after writer invalidation",
 				zap.String("logName", l.logHandle.GetName()),
 				zap.Int64("logId", l.logHandle.GetId()))
 			return
@@ -565,8 +599,10 @@ func (l *internalLogWriterImpl) Close(ctx context.Context) error {
 		logger.Ctx(ctx).Info("closing log writer", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()))
 
 		l.isWriterValid.Store(false)
+		l.stopMaintenance()
 		l.writerClose <- struct{}{}
 		close(l.writerClose)
+		l.auditorWG.Wait()
 		status := "success"
 		closeErr := l.logHandle.CompleteAllActiveSegmentIfExists(ctx)
 		if closeErr != nil {

--- a/woodpecker/log/internal_log_writer.go
+++ b/woodpecker/log/internal_log_writer.go
@@ -61,7 +61,7 @@ type internalLogWriterImpl struct {
 	onWriterInvalidated func(ctx context.Context, reason string)
 	maintenanceCtx      context.Context
 	maintenanceCancel   context.CancelFunc
-	auditorWG           sync.WaitGroup
+	maintenanceWG       sync.WaitGroup
 
 	// Mutex to ensure only one truncation cleanup task is running at a time
 	cleanupMutex      sync.Mutex
@@ -100,16 +100,24 @@ func NewInternalLogWriter(ctx context.Context, logHandle LogHandle, cfg *config.
 	// Monitor keepAlive channel
 	w.startAuditor()
 	// Compacted-mark distribution runs on its own goroutine so a slow node can't stall the auditor.
-	go runNotifyDistributor(w.logHandle, w.notifyManager, cfg.Woodpecker.Storage.IsStorageService(), w.notifySegsCh, w.maintenanceCtx.Done())
+	w.startNotifyDistributor(cfg.Woodpecker.Storage.IsStorageService())
 	logger.Ctx(ctx).Info("log writer created", zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()))
 	return w
 }
 
 func (l *internalLogWriterImpl) startAuditor() {
-	l.auditorWG.Add(1)
+	l.maintenanceWG.Add(1)
 	go func() {
-		defer l.auditorWG.Done()
+		defer l.maintenanceWG.Done()
 		l.runAuditor()
+	}()
+}
+
+func (l *internalLogWriterImpl) startNotifyDistributor(serviceMode bool) {
+	l.maintenanceWG.Add(1)
+	go func() {
+		defer l.maintenanceWG.Done()
+		runNotifyDistributor(l.maintenanceCtx, l.logHandle, l.notifyManager, serviceMode, l.notifySegsCh)
 	}()
 }
 
@@ -304,6 +312,10 @@ func (l *internalLogWriterImpl) runAuditor() {
 			// quorum node can never block compaction or truncate cleanup on this critical path.
 			// Share the freshly loaded snapshot with the notify distributor so it does not
 			// issue a second identical etcd range scan per cycle.
+			truncatedSegmentExists := collectTruncatedSegments(segmentMetaList)
+			// In-process reap sync: a Truncated segment must never be notified again, even if the
+			// distributor is mid-round on a stale snapshot that still shows it Sealed.
+			markTruncatedSegmentsReaped(l.notifyManager, truncatedSegmentExists)
 			publishSegmentsSnapshot(l.notifySegsCh, segmentMetaList)
 
 			cs := compactCompletedSegments(ctx, l.logHandle, segmentMetaList)
@@ -311,10 +323,6 @@ func (l *internalLogWriterImpl) runAuditor() {
 				sp.End()
 				return
 			}
-			truncatedSegmentExists := collectTruncatedSegments(segmentMetaList)
-			// In-process reap sync: a Truncated segment must never be notified again, even if the
-			// distributor is mid-round on a stale snapshot that still shows it Sealed.
-			markTruncatedSegmentsReaped(l.notifyManager, truncatedSegmentExists)
 
 			// Periodic orphan sweep (pass 1 = startup recovery, then every Nth cycle): reclaims
 			// cleanup-domain records whose segment metadata is already gone, covering the
@@ -602,7 +610,7 @@ func (l *internalLogWriterImpl) Close(ctx context.Context) error {
 		l.stopMaintenance()
 		l.writerClose <- struct{}{}
 		close(l.writerClose)
-		l.auditorWG.Wait()
+		l.maintenanceWG.Wait()
 		status := "success"
 		closeErr := l.logHandle.CompleteAllActiveSegmentIfExists(ctx)
 		if closeErr != nil {

--- a/woodpecker/log/log_auditor.go
+++ b/woodpecker/log/log_auditor.go
@@ -98,6 +98,9 @@ func distributeCompactedMarks(ctx context.Context, logHandle LogHandle, notifyMa
 	}
 	driven := 0
 	for _, seg := range segs {
+		if ctx.Err() != nil {
+			break
+		}
 		if seg.Metadata.State != proto.SegmentState_Sealed {
 			continue
 		}
@@ -105,6 +108,9 @@ func distributeCompactedMarks(ctx context.Context, logHandle LogHandle, notifyMa
 			break
 		}
 		advanced, err := notifyManager.EnsureSegmentNotified(ctx, logHandle.GetName(), logHandle.GetId(), seg.Metadata.SegNo)
+		if ctx.Err() != nil {
+			break
+		}
 		if err != nil {
 			logger.Ctx(ctx).Warn("auditor compacted-mark notify failed; will retry next cycle", zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()), zap.Int64("segId", seg.Metadata.SegNo), zap.Error(err))
 		}
@@ -126,7 +132,7 @@ func distributeCompactedMarks(ctx context.Context, logHandle LogHandle, notifyMa
 // identical GetSegments per cycle would double the per-log metadata load for nothing. When
 // the distributor is still busy with the previous snapshot, newer ones are dropped by the
 // publisher — natural backpressure; the next published snapshot is always fresher anyway.
-func runNotifyDistributor(logHandle LogHandle, notifyManager segment.SegmentCompactedNotifyManager, serviceMode bool, segsCh <-chan map[int64]*meta.SegmentMeta, closeCh <-chan struct{}) {
+func runNotifyDistributor(ctx context.Context, logHandle LogHandle, notifyManager segment.SegmentCompactedNotifyManager, serviceMode bool, segsCh <-chan map[int64]*meta.SegmentMeta) {
 	if !serviceMode {
 		return
 	}
@@ -136,14 +142,19 @@ func runNotifyDistributor(logHandle LogHandle, notifyManager segment.SegmentComp
 	for {
 		select {
 		case segs := <-segsCh:
-			ctx, sp := logger.NewIntentCtx(WriterScopeName, fmt.Sprintf("notify_distributor_%d", logHandle.GetId()))
-			driven := distributeCompactedMarks(ctx, logHandle, notifyManager, segs, true)
+			// Cancellation and a buffered snapshot may become ready together. Re-check here so
+			// the snapshot cannot win the select race and start another pass after ownership loss.
+			if ctx.Err() != nil {
+				return
+			}
+			passCtx, sp := logger.NewIntentCtxWithParent(ctx, WriterScopeName, fmt.Sprintf("notify_distributor_%d", logHandle.GetId()))
+			driven := distributeCompactedMarks(passCtx, logHandle, notifyManager, segs, true)
 			if driven > 0 {
-				logger.Ctx(ctx).Debug("compacted-mark distributor cycle completed",
+				logger.Ctx(passCtx).Debug("compacted-mark distributor cycle completed",
 					zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()), zap.Int("driven", driven))
 			}
 			sp.End()
-		case <-closeCh:
+		case <-ctx.Done():
 			logger.Ctx(context.Background()).Info("compacted-mark distributor stopped",
 				zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()))
 			return

--- a/woodpecker/log/log_auditor.go
+++ b/woodpecker/log/log_auditor.go
@@ -51,10 +51,13 @@ type compactStats struct {
 
 // compactCompletedSegments compacts every Completed segment in the snapshot, sequentially by
 // design (to keep each log's background work light, since a cluster may host many logs). A
-// per-segment failure is logged and skipped; it never aborts the pass.
+// per-segment failure is logged and skipped; writer-lifecycle cancellation stops the pass.
 func compactCompletedSegments(ctx context.Context, logHandle LogHandle, segs map[int64]*meta.SegmentMeta) compactStats {
 	var st compactStats
 	for _, seg := range segs {
+		if ctx.Err() != nil {
+			break
+		}
 		if seg.Metadata.State != proto.SegmentState_Completed {
 			continue
 		}

--- a/woodpecker/log/log_auditor_test.go
+++ b/woodpecker/log/log_auditor_test.go
@@ -82,6 +82,53 @@ func (c *countingNotifyManager) sweepBoundsSnapshot() []int64 {
 	return append([]int64(nil), c.sweepBounds...)
 }
 
+func (c *countingNotifyManager) reapedSegments() []int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]int64(nil), c.reaped...)
+}
+
+type blockingNotifyManager struct {
+	mu        sync.Mutex
+	called    []int64
+	started   chan struct{}
+	canceled  chan struct{}
+	release   chan struct{}
+	startOne  sync.Once
+	cancelOne sync.Once
+}
+
+func newBlockingNotifyManager() *blockingNotifyManager {
+	return &blockingNotifyManager{
+		started:  make(chan struct{}),
+		canceled: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+}
+
+func (b *blockingNotifyManager) EnsureSegmentNotified(ctx context.Context, _ string, _ int64, segmentId int64) (bool, error) {
+	b.mu.Lock()
+	b.called = append(b.called, segmentId)
+	b.mu.Unlock()
+	b.startOne.Do(func() { close(b.started) })
+	<-ctx.Done()
+	b.cancelOne.Do(func() { close(b.canceled) })
+	<-b.release
+	return true, ctx.Err()
+}
+
+func (b *blockingNotifyManager) CleanupOrphanedStatuses(context.Context, int64, int64) error {
+	return nil
+}
+
+func (b *blockingNotifyManager) MarkSegmentReaped(int64) {}
+
+func (b *blockingNotifyManager) calledSegments() []int64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]int64(nil), b.called...)
+}
+
 // recordingCleanupManager records the orphan-sweep bounds it was invoked with.
 type recordingCleanupManager struct {
 	sweepBounds []int64
@@ -233,7 +280,7 @@ func TestRunNotifyDistributor_NonServiceReturnsImmediately(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		runNotifyDistributor(lh, nm, false /*serviceMode*/, make(chan map[int64]*meta.SegmentMeta, 1), make(chan struct{}))
+		runNotifyDistributor(context.Background(), lh, nm, false /*serviceMode*/, make(chan map[int64]*meta.SegmentMeta, 1))
 		close(done)
 	}()
 	select {
@@ -254,10 +301,10 @@ func TestRunNotifyDistributor_ConsumesSnapshotsThenStops(t *testing.T) {
 	nm := &countingNotifyManager{advanced: true}
 
 	segsCh := make(chan map[int64]*meta.SegmentMeta, 1)
-	closeCh := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go func() {
-		runNotifyDistributor(lh, nm, true /*serviceMode*/, segsCh, closeCh)
+		runNotifyDistributor(ctx, lh, nm, true /*serviceMode*/, segsCh)
 		close(done)
 	}()
 
@@ -269,13 +316,75 @@ func TestRunNotifyDistributor_ConsumesSnapshotsThenStops(t *testing.T) {
 		return len(nm.calledSegments()) > 0
 	}, 3*time.Second, 10*time.Millisecond, "the distributor consumed the published snapshot")
 
-	close(closeCh)
+	cancel()
 	select {
 	case <-done:
 	case <-time.After(2 * time.Second):
-		t.Fatal("runNotifyDistributor should stop after closeCh fires")
+		t.Fatal("runNotifyDistributor should stop after its lifecycle context is canceled")
 	}
 	assert.Contains(t, nm.calledSegments(), int64(1))
+}
+
+func TestRunNotifyDistributor_CanceledContextSkipsBufferedSnapshot(t *testing.T) {
+	lh := &testLogHandleMock{}
+	lh.On("GetName").Return("test-log").Maybe()
+	lh.On("GetId").Return(int64(1)).Maybe()
+	nm := &countingNotifyManager{advanced: true}
+	segsCh := make(chan map[int64]*meta.SegmentMeta, 1)
+	segsCh <- map[int64]*meta.SegmentMeta{1: segMeta(1, proto.SegmentState_Sealed)}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	done := make(chan struct{})
+	go func() {
+		runNotifyDistributor(ctx, lh, nm, true, segsCh)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("canceled distributor did not stop with a buffered snapshot")
+	}
+	assert.Empty(t, nm.calledSegments(), "a buffered snapshot must not start after cancellation")
+}
+
+func TestRunNotifyDistributor_CancellationStopsInFlightPass(t *testing.T) {
+	lh := &testLogHandleMock{}
+	lh.On("GetName").Return("test-log").Maybe()
+	lh.On("GetId").Return(int64(1)).Maybe()
+	nm := newBlockingNotifyManager()
+	segsCh := make(chan map[int64]*meta.SegmentMeta, 1)
+	segsCh <- map[int64]*meta.SegmentMeta{
+		1: segMeta(1, proto.SegmentState_Sealed),
+		2: segMeta(2, proto.SegmentState_Sealed),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runNotifyDistributor(ctx, lh, nm, true, segsCh)
+		close(done)
+	}()
+
+	select {
+	case <-nm.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("distributor did not start the first segment")
+	}
+	cancel()
+	select {
+	case <-nm.canceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("in-flight notify did not observe lifecycle cancellation")
+	}
+	close(nm.release)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("distributor did not exit after the canceled pass returned")
+	}
+	assert.Len(t, nm.calledSegments(), 1, "cancellation must stop the pass before another segment")
 }
 
 // TestPublishSegmentsSnapshot_ReplacesStale verifies the non-blocking publish: an unconsumed

--- a/woodpecker/log/log_auditor_test.go
+++ b/woodpecker/log/log_auditor_test.go
@@ -210,6 +210,19 @@ func TestCompactCompletedSegments_CountsAndSkips(t *testing.T) {
 	assert.Equal(t, 1, st.failed)
 }
 
+func TestCompactCompletedSegments_CanceledWriterDoesNotStartCompaction(t *testing.T) {
+	lh := &testLogHandleMock{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	st := compactCompletedSegments(ctx, lh, map[int64]*meta.SegmentMeta{
+		1: segMeta(1, proto.SegmentState_Completed),
+	})
+
+	assert.Equal(t, compactStats{}, st)
+	lh.AssertNotCalled(t, "GetRecoverableSegmentHandle", mock.Anything, mock.Anything)
+}
+
 // TestRunNotifyDistributor_NonServiceReturnsImmediately verifies the distributor goroutine is a
 // no-op outside service storage: it returns at once rather than waiting on the snapshot channel.
 func TestRunNotifyDistributor_NonServiceReturnsImmediately(t *testing.T) {

--- a/woodpecker/log/log_writer.go
+++ b/woodpecker/log/log_writer.go
@@ -93,7 +93,7 @@ func NewLogWriter(ctx context.Context, logHandle LogHandle, cfg *config.Configur
 	go w.monitorSession()
 	w.startAuditor()
 	// Compacted-mark distribution runs on its own goroutine so a slow node can't stall the auditor.
-	go runNotifyDistributor(w.logHandle, w.notifyManager, cfg.Woodpecker.Storage.IsStorageService(), w.notifySegsCh, w.maintenanceCtx.Done())
+	w.startNotifyDistributor(cfg.Woodpecker.Storage.IsStorageService())
 	logger.Ctx(ctx).Info("log writer created", zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()), zap.Int64("sessionId", int64(sessionLock.GetSession().Lease())))
 	return w
 }
@@ -118,7 +118,7 @@ type logWriterImpl struct {
 	onWriterInvalidated func(ctx context.Context, reason string)
 	maintenanceCtx      context.Context
 	maintenanceCancel   context.CancelFunc
-	auditorWG           sync.WaitGroup
+	maintenanceWG       sync.WaitGroup
 
 	// Mutex to ensure only one truncation cleanup task is running at a time
 	cleanupMutex      sync.Mutex
@@ -127,10 +127,18 @@ type logWriterImpl struct {
 }
 
 func (l *logWriterImpl) startAuditor() {
-	l.auditorWG.Add(1)
+	l.maintenanceWG.Add(1)
 	go func() {
-		defer l.auditorWG.Done()
+		defer l.maintenanceWG.Done()
 		l.runAuditor()
+	}()
+}
+
+func (l *logWriterImpl) startNotifyDistributor(serviceMode bool) {
+	l.maintenanceWG.Add(1)
+	go func() {
+		defer l.maintenanceWG.Done()
+		runNotifyDistributor(l.maintenanceCtx, l.logHandle, l.notifyManager, serviceMode, l.notifySegsCh)
 	}()
 }
 
@@ -380,6 +388,10 @@ func (l *logWriterImpl) runAuditor() {
 			// the Truncated ones to clean up.
 			// Share the freshly loaded snapshot with the notify distributor so it does not
 			// issue a second identical etcd range scan per cycle.
+			truncatedSegmentExists := collectTruncatedSegments(segmentMetaList)
+			// In-process reap sync: a Truncated segment must never be notified again, even if the
+			// distributor is mid-round on a stale snapshot that still shows it Sealed.
+			markTruncatedSegmentsReaped(l.notifyManager, truncatedSegmentExists)
 			publishSegmentsSnapshot(l.notifySegsCh, segmentMetaList)
 
 			cs := compactCompletedSegments(ctx, l.logHandle, segmentMetaList)
@@ -387,10 +399,6 @@ func (l *logWriterImpl) runAuditor() {
 				sp.End()
 				return
 			}
-			truncatedSegmentExists := collectTruncatedSegments(segmentMetaList)
-			// In-process reap sync: a Truncated segment must never be notified again, even if the
-			// distributor is mid-round on a stale snapshot that still shows it Sealed.
-			markTruncatedSegmentsReaped(l.notifyManager, truncatedSegmentExists)
 
 			// Periodic orphan sweep (pass 1 = startup recovery, then every Nth cycle): reclaims
 			// cleanup-domain records whose segment metadata is already gone, covering the
@@ -686,7 +694,7 @@ func (l *logWriterImpl) Close(ctx context.Context) error {
 
 		l.writerClose <- struct{}{}
 		close(l.writerClose)
-		l.auditorWG.Wait()
+		l.maintenanceWG.Wait()
 		status := "success"
 		closeErr := l.logHandle.CompleteAllActiveSegmentIfExists(ctx)
 		if closeErr != nil {

--- a/woodpecker/log/log_writer.go
+++ b/woodpecker/log/log_writer.go
@@ -58,6 +58,7 @@ type LogWriter interface {
 func NewLogWriter(ctx context.Context, logHandle LogHandle, cfg *config.Configuration, sessionLock *meta.SessionLock) LogWriter {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, WriterScopeName, "NewLogWriter")
 	defer sp.End()
+	maintenanceCtx, maintenanceCancel := context.WithCancel(context.Background())
 	w := &logWriterImpl{
 		logIdStr:           strconv.FormatInt(logHandle.GetId(), 10),
 		logHandle:          logHandle,
@@ -69,9 +70,12 @@ func NewLogWriter(ctx context.Context, logHandle LogHandle, cfg *config.Configur
 		notifyManager:      segment.NewSegmentCompactedNotifyManager(cfg.Minio.BucketName, cfg.Minio.RootPath, logHandle.GetMetadataProvider(), logHandle.(*logHandleImpl).ClientPool),
 		notifySegsCh:       make(chan map[int64]*meta.SegmentMeta, 1),
 		sessionLock:        sessionLock,
+		maintenanceCtx:     maintenanceCtx,
+		maintenanceCancel:  maintenanceCancel,
 	}
 	// Set trigger expired
 	onWriterInvalidated := func(ctx context.Context, reason string) {
+		w.stopMaintenance()
 		// Mark the sessionLock as invalid so next AcquireLogWriterLock will create a new one
 		if sessionLock != nil {
 			sessionLock.MarkInvalid()
@@ -87,9 +91,9 @@ func NewLogWriter(ctx context.Context, logHandle LogHandle, cfg *config.Configur
 
 	// Monitor keepAlive channel
 	go w.monitorSession()
-	go w.runAuditor()
+	w.startAuditor()
 	// Compacted-mark distribution runs on its own goroutine so a slow node can't stall the auditor.
-	go runNotifyDistributor(w.logHandle, w.notifyManager, cfg.Woodpecker.Storage.IsStorageService(), w.notifySegsCh, w.writerClose)
+	go runNotifyDistributor(w.logHandle, w.notifyManager, cfg.Woodpecker.Storage.IsStorageService(), w.notifySegsCh, w.maintenanceCtx.Done())
 	logger.Ctx(ctx).Info("log writer created", zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()), zap.Int64("sessionId", int64(sessionLock.GetSession().Lease())))
 	return w
 }
@@ -112,11 +116,28 @@ type logWriterImpl struct {
 	// Session related fields
 	sessionLock         *meta.SessionLock
 	onWriterInvalidated func(ctx context.Context, reason string)
+	maintenanceCtx      context.Context
+	maintenanceCancel   context.CancelFunc
+	auditorWG           sync.WaitGroup
 
 	// Mutex to ensure only one truncation cleanup task is running at a time
 	cleanupMutex      sync.Mutex
 	cleanupInProgress bool
 	closeOnce         sync.Once
+}
+
+func (l *logWriterImpl) startAuditor() {
+	l.auditorWG.Add(1)
+	go func() {
+		defer l.auditorWG.Done()
+		l.runAuditor()
+	}()
+}
+
+func (l *logWriterImpl) stopMaintenance() {
+	if l.maintenanceCancel != nil {
+		l.maintenanceCancel()
+	}
 }
 
 func (l *logWriterImpl) monitorSession() {
@@ -134,12 +155,14 @@ func (l *logWriterImpl) monitorSession() {
 			// Channel is closed, session is invalid
 			// Mark sessionLock as invalid so next AcquireLogWriterLock will create a new one
 			l.sessionLock.MarkInvalid()
+			l.stopMaintenance()
 			logger.Ctx(context.Background()).Warn("Writer lock session has expired",
 				zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Int64("sessionId", int64(session.Lease())))
 			return
 		case <-l.writerClose:
 			// Mark sessionLock as invalid when writer closes
 			l.sessionLock.MarkInvalid()
+			l.stopMaintenance()
 			logger.Ctx(context.Background()).Debug("Monitor session end due to writer close",
 				zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Int64("sessionId", int64(session.Lease())))
 			return
@@ -155,6 +178,7 @@ func (l *logWriterImpl) monitorSession() {
 				if consecutiveFailures >= maxConsecutiveFailures {
 					// Too many consecutive failures, mark session as invalid
 					l.sessionLock.MarkInvalid()
+					l.stopMaintenance()
 					logger.Ctx(context.Background()).Warn("Writer lock session marked as invalid due to persistent etcd connectivity issues", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Int64("sessionId", int64(session.Lease())), zap.Int("consecutiveFailures", consecutiveFailures), zap.Error(err))
 					return
 				}
@@ -164,6 +188,7 @@ func (l *logWriterImpl) monitorSession() {
 				if !isAlive {
 					// Lease is expired
 					l.sessionLock.MarkInvalid()
+					l.stopMaintenance()
 					logger.Ctx(context.Background()).Warn("Writer lock session lease has expired", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Int64("sessionId", int64(session.Lease())), zap.Bool("alive", isAlive))
 					return
 				}
@@ -317,8 +342,12 @@ func (l *logWriterImpl) runAuditor() {
 	for {
 		select {
 		case <-ticker.C:
+			if l.maintenanceCtx.Err() != nil || l.sessionLock == nil || !l.sessionLock.IsValid() {
+				l.stopMaintenance()
+				return
+			}
 			auditCycle++
-			ctx, sp := logger.NewIntentCtx(WriterScopeName, fmt.Sprintf("auditor_%d", l.logHandle.GetId()))
+			ctx, sp := logger.NewIntentCtxWithParent(l.maintenanceCtx, WriterScopeName, fmt.Sprintf("auditor_%d", l.logHandle.GetId()))
 			startAudit := time.Now()
 
 			logger.Ctx(ctx).Debug("Starting auditor cycle",
@@ -354,6 +383,10 @@ func (l *logWriterImpl) runAuditor() {
 			publishSegmentsSnapshot(l.notifySegsCh, segmentMetaList)
 
 			cs := compactCompletedSegments(ctx, l.logHandle, segmentMetaList)
+			if ctx.Err() != nil {
+				sp.End()
+				return
+			}
 			truncatedSegmentExists := collectTruncatedSegments(segmentMetaList)
 			// In-process reap sync: a Truncated segment must never be notified again, even if the
 			// distributor is mid-round on a stale snapshot that still shows it Sealed.
@@ -396,6 +429,11 @@ func (l *logWriterImpl) runAuditor() {
 			metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "auditor_run", "success").Observe(float64(auditDuration.Milliseconds()))
 		case <-l.writerClose:
 			logger.Ctx(context.TODO()).Info("Log auditor stopped",
+				zap.String("logName", l.logHandle.GetName()),
+				zap.Int64("logId", l.logHandle.GetId()))
+			return
+		case <-l.maintenanceCtx.Done():
+			logger.Ctx(context.TODO()).Info("Log auditor stopped after writer invalidation",
 				zap.String("logName", l.logHandle.GetName()),
 				zap.Int64("logId", l.logHandle.GetId()))
 			return
@@ -644,9 +682,11 @@ func (l *logWriterImpl) Close(ctx context.Context) error {
 		// Mark session invalid immediately to reject concurrent writes,
 		// rather than relying on monitorSession goroutine to do it asynchronously.
 		l.sessionLock.MarkInvalid()
+		l.stopMaintenance()
 
 		l.writerClose <- struct{}{}
 		close(l.writerClose)
+		l.auditorWG.Wait()
 		status := "success"
 		closeErr := l.logHandle.CompleteAllActiveSegmentIfExists(ctx)
 		if closeErr != nil {

--- a/woodpecker/log/log_writer_test.go
+++ b/woodpecker/log/log_writer_test.go
@@ -72,6 +72,7 @@ func (s *stubNotifyManager) MarkSegmentReaped(_ int64) {}
 // createTestInternalWriter creates an internalLogWriterImpl for testing without goroutines.
 func createTestInternalWriter(t *testing.T, logHandle LogHandle, cleanupMgr segment.SegmentCleanupManager) *internalLogWriterImpl {
 	cfg := newTestConfig()
+	maintenanceCtx, maintenanceCancel := context.WithCancel(context.Background())
 	if cleanupMgr == nil {
 		cleanupMgr = &recordingCleanupManager{}
 	}
@@ -84,10 +85,13 @@ func createTestInternalWriter(t *testing.T, logHandle LogHandle, cleanupMgr segm
 		writerClose:        make(chan struct{}, 1),
 		cleanupManager:     cleanupMgr,
 		notifyManager:      &stubNotifyManager{},
+		maintenanceCtx:     maintenanceCtx,
+		maintenanceCancel:  maintenanceCancel,
 	}
 	w.isWriterValid.Store(true)
 	w.onWriterInvalidated = func(ctx context.Context, reason string) {
 		w.isWriterValid.Store(false)
+		w.stopMaintenance()
 	}
 	return w
 }
@@ -633,6 +637,7 @@ func TestWriteResult_Structure(t *testing.T) {
 // createTestSessionWriter creates a logWriterImpl for testing without goroutines.
 func createTestSessionWriter(t *testing.T, logHandle LogHandle, cleanupMgr segment.SegmentCleanupManager, sessionLock *meta.SessionLock) *logWriterImpl {
 	cfg := newTestConfig()
+	maintenanceCtx, maintenanceCancel := context.WithCancel(context.Background())
 	if cleanupMgr == nil {
 		cleanupMgr = &recordingCleanupManager{}
 	}
@@ -646,11 +651,14 @@ func createTestSessionWriter(t *testing.T, logHandle LogHandle, cleanupMgr segme
 		cleanupManager:     cleanupMgr,
 		notifyManager:      &stubNotifyManager{},
 		sessionLock:        sessionLock,
+		maintenanceCtx:     maintenanceCtx,
+		maintenanceCancel:  maintenanceCancel,
 	}
 	w.onWriterInvalidated = func(ctx context.Context, reason string) {
 		if sessionLock != nil {
 			sessionLock.MarkInvalid()
 		}
+		w.stopMaintenance()
 	}
 	return w
 }
@@ -1829,6 +1837,117 @@ func TestLogWriter_RunAuditor_WithCompletedAndTruncated(t *testing.T) {
 	cleanupMgr.AssertCalled(t, "CleanupSegment", mock.Anything, "test-log", int64(1), int64(2))
 }
 
+func TestInternalLogWriter_RunAuditor_InvalidationCancelsInFlightCompact(t *testing.T) {
+	mockLogHandle := &testLogHandleMock{}
+	mockLogHandle.Test(t)
+	mockLogHandle.On("GetName").Return("test-log").Maybe()
+	mockLogHandle.On("GetId").Return(int64(1)).Maybe()
+	mockLogHandle.On("CheckAndSetSegmentTruncatedIfNeed", mock.Anything).Return(nil)
+	mockLogHandle.On("GetSegments", mock.Anything).Return(map[int64]*meta.SegmentMeta{
+		1: {Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Completed}},
+	}, nil)
+
+	mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockLogHandle.On("GetRecoverableSegmentHandle", mock.Anything, int64(1)).Return(mockSegHandle, nil)
+	compactStarted := make(chan struct{})
+	compactCanceled := make(chan struct{})
+	mockSegHandle.EXPECT().Compact(mock.Anything).RunAndReturn(func(ctx context.Context) error {
+		close(compactStarted)
+		<-ctx.Done()
+		close(compactCanceled)
+		return ctx.Err()
+	}).Once()
+
+	w := createTestInternalWriter(t, mockLogHandle, nil)
+	w.auditorMaxInterval = 1
+	auditorDone := make(chan struct{})
+	go func() {
+		w.runAuditor()
+		close(auditorDone)
+	}()
+
+	select {
+	case <-compactStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("auditor did not start compaction")
+	}
+	w.onWriterInvalidated(context.Background(), "writer taken over")
+
+	select {
+	case <-compactCanceled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("writer invalidation did not cancel in-flight compaction")
+	}
+	select {
+	case <-auditorDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("auditor did not stop after writer invalidation")
+	}
+	assert.False(t, w.isWriterValid.Load())
+}
+
+func TestLogWriter_RunAuditor_SessionExpirationCancelsInFlightCompact(t *testing.T) {
+	mockLogHandle := &testLogHandleMock{}
+	mockLogHandle.Test(t)
+	mockLogHandle.On("GetName").Return("test-log").Maybe()
+	mockLogHandle.On("GetId").Return(int64(1)).Maybe()
+	mockLogHandle.On("CheckAndSetSegmentTruncatedIfNeed", mock.Anything).Return(nil)
+	mockLogHandle.On("GetSegments", mock.Anything).Return(map[int64]*meta.SegmentMeta{
+		1: {Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Completed}},
+	}, nil)
+
+	mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockLogHandle.On("GetRecoverableSegmentHandle", mock.Anything, int64(1)).Return(mockSegHandle, nil)
+	compactStarted := make(chan struct{})
+	compactCanceled := make(chan struct{})
+	mockSegHandle.EXPECT().Compact(mock.Anything).RunAndReturn(func(ctx context.Context) error {
+		close(compactStarted)
+		<-ctx.Done()
+		close(compactCanceled)
+		return ctx.Err()
+	}).Once()
+
+	sessionDone := make(chan struct{})
+	sessionLock := meta.NewSessionLockForTest(newTestSession(sessionDone))
+	w := createTestSessionWriter(t, mockLogHandle, nil, sessionLock)
+	w.auditorMaxInterval = 1
+	w.cfg.Woodpecker.Client.SessionMonitor.CheckInterval = config.NewDurationSecondsFromInt(100)
+	auditorDone := make(chan struct{})
+	go func() {
+		w.runAuditor()
+		close(auditorDone)
+	}()
+	monitorDone := make(chan struct{})
+	go func() {
+		w.monitorSession()
+		close(monitorDone)
+	}()
+
+	select {
+	case <-compactStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("auditor did not start compaction")
+	}
+	close(sessionDone)
+
+	select {
+	case <-compactCanceled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("session expiration did not cancel in-flight compaction")
+	}
+	select {
+	case <-auditorDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("auditor did not stop after session expiration")
+	}
+	select {
+	case <-monitorDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("session monitor did not stop after session expiration")
+	}
+	assert.False(t, sessionLock.IsValid())
+}
+
 // === cleanupTruncatedSegmentsIfNecessary remaining paths ===
 
 func TestLogWriter_CleanupTruncatedSegments_AlreadyInProgress(t *testing.T) {
@@ -2216,6 +2335,11 @@ func TestMonitorSession_SessionDone(t *testing.T) {
 	}
 
 	assert.False(t, sessionLock.IsValid())
+	select {
+	case <-w.maintenanceCtx.Done():
+	default:
+		t.Fatal("session expiration did not cancel writer maintenance")
+	}
 }
 
 func TestMonitorSession_CheckAlive_LeaseExpired(t *testing.T) {

--- a/woodpecker/log/log_writer_test.go
+++ b/woodpecker/log/log_writer_test.go
@@ -1886,6 +1886,66 @@ func TestInternalLogWriter_RunAuditor_InvalidationCancelsInFlightCompact(t *test
 	assert.False(t, w.isWriterValid.Load())
 }
 
+func TestInternalLogWriter_CloseWaitsForAuditorToExit(t *testing.T) {
+	mockLogHandle := &testLogHandleMock{}
+	mockLogHandle.Test(t)
+	mockLogHandle.On("GetName").Return("test-log").Maybe()
+	mockLogHandle.On("GetId").Return(int64(1)).Maybe()
+	mockLogHandle.On("CheckAndSetSegmentTruncatedIfNeed", mock.Anything).Return(nil)
+	mockLogHandle.On("GetSegments", mock.Anything).Return(map[int64]*meta.SegmentMeta{
+		1: {Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Completed}},
+	}, nil)
+	mockLogHandle.On("CompleteAllActiveSegmentIfExists", mock.Anything).Return(nil).Once()
+	mockLogHandle.On("Close", mock.Anything).Return(nil).Once()
+
+	mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockLogHandle.On("GetRecoverableSegmentHandle", mock.Anything, int64(1)).Return(mockSegHandle, nil)
+	compactStarted := make(chan struct{})
+	compactCanceled := make(chan struct{})
+	allowCompactReturn := make(chan struct{})
+	mockSegHandle.EXPECT().Compact(mock.Anything).RunAndReturn(func(ctx context.Context) error {
+		close(compactStarted)
+		<-ctx.Done()
+		close(compactCanceled)
+		<-allowCompactReturn
+		return ctx.Err()
+	}).Once()
+
+	w := createTestInternalWriter(t, mockLogHandle, nil)
+	w.auditorMaxInterval = 1
+	w.startAuditor()
+
+	select {
+	case <-compactStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("auditor did not start compaction")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- w.Close(context.Background())
+	}()
+
+	select {
+	case <-compactCanceled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("writer close did not cancel in-flight compaction")
+	}
+	select {
+	case err := <-closeDone:
+		t.Fatalf("writer close returned before the auditor exited: %v", err)
+	default:
+	}
+
+	close(allowCompactReturn)
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("writer close did not finish after the auditor exited")
+	}
+}
+
 func TestLogWriter_RunAuditor_SessionExpirationCancelsInFlightCompact(t *testing.T) {
 	mockLogHandle := &testLogHandleMock{}
 	mockLogHandle.Test(t)

--- a/woodpecker/log/log_writer_test.go
+++ b/woodpecker/log/log_writer_test.go
@@ -85,6 +85,7 @@ func createTestInternalWriter(t *testing.T, logHandle LogHandle, cleanupMgr segm
 		writerClose:        make(chan struct{}, 1),
 		cleanupManager:     cleanupMgr,
 		notifyManager:      &stubNotifyManager{},
+		notifySegsCh:       make(chan map[int64]*meta.SegmentMeta, 1),
 		maintenanceCtx:     maintenanceCtx,
 		maintenanceCancel:  maintenanceCancel,
 	}
@@ -650,6 +651,7 @@ func createTestSessionWriter(t *testing.T, logHandle LogHandle, cleanupMgr segme
 		writerClose:        make(chan struct{}, 1),
 		cleanupManager:     cleanupMgr,
 		notifyManager:      &stubNotifyManager{},
+		notifySegsCh:       make(chan map[int64]*meta.SegmentMeta, 1),
 		sessionLock:        sessionLock,
 		maintenanceCtx:     maintenanceCtx,
 		maintenanceCancel:  maintenanceCancel,
@@ -1845,6 +1847,7 @@ func TestInternalLogWriter_RunAuditor_InvalidationCancelsInFlightCompact(t *test
 	mockLogHandle.On("CheckAndSetSegmentTruncatedIfNeed", mock.Anything).Return(nil)
 	mockLogHandle.On("GetSegments", mock.Anything).Return(map[int64]*meta.SegmentMeta{
 		1: {Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Completed}},
+		2: {Metadata: &proto.SegmentMetadata{SegNo: 2, State: proto.SegmentState_Truncated}},
 	}, nil)
 
 	mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
@@ -1859,6 +1862,8 @@ func TestInternalLogWriter_RunAuditor_InvalidationCancelsInFlightCompact(t *test
 	}).Once()
 
 	w := createTestInternalWriter(t, mockLogHandle, nil)
+	notifyMgr := &countingNotifyManager{}
+	w.notifyManager = notifyMgr
 	w.auditorMaxInterval = 1
 	auditorDone := make(chan struct{})
 	go func() {
@@ -1871,6 +1876,7 @@ func TestInternalLogWriter_RunAuditor_InvalidationCancelsInFlightCompact(t *test
 	case <-time.After(3 * time.Second):
 		t.Fatal("auditor did not start compaction")
 	}
+	assert.Contains(t, notifyMgr.reapedSegments(), int64(2), "truncated segments must be reaped before compaction can be canceled")
 	w.onWriterInvalidated(context.Background(), "writer taken over")
 
 	select {
@@ -1943,6 +1949,53 @@ func TestInternalLogWriter_CloseWaitsForAuditorToExit(t *testing.T) {
 		require.NoError(t, err)
 	case <-time.After(3 * time.Second):
 		t.Fatal("writer close did not finish after the auditor exited")
+	}
+}
+
+func TestInternalLogWriter_CloseWaitsForNotifyDistributorToExit(t *testing.T) {
+	mockLogHandle := &testLogHandleMock{}
+	mockLogHandle.Test(t)
+	mockLogHandle.On("GetName").Return("test-log").Maybe()
+	mockLogHandle.On("GetId").Return(int64(1)).Maybe()
+	mockLogHandle.On("CompleteAllActiveSegmentIfExists", mock.Anything).Return(nil).Once()
+	mockLogHandle.On("Close", mock.Anything).Return(nil).Once()
+
+	w := createTestInternalWriter(t, mockLogHandle, nil)
+	notifyMgr := newBlockingNotifyManager()
+	w.notifyManager = notifyMgr
+	w.startNotifyDistributor(true)
+	publishSegmentsSnapshot(w.notifySegsCh, map[int64]*meta.SegmentMeta{
+		1: {Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Sealed}},
+	})
+
+	select {
+	case <-notifyMgr.started:
+	case <-time.After(3 * time.Second):
+		t.Fatal("notify distributor did not start")
+	}
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- w.Close(context.Background())
+	}()
+
+	select {
+	case <-notifyMgr.canceled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("writer close did not cancel the notify distributor")
+	}
+	select {
+	case err := <-closeDone:
+		t.Fatalf("writer close returned before the notify distributor exited: %v", err)
+	default:
+	}
+
+	close(notifyMgr.release)
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("writer close did not finish after the notify distributor exited")
 	}
 }
 


### PR DESCRIPTION
## Summary

- bind the log auditor and compacted-segment notification distributor to a writer-owned maintenance context
- cancel maintenance when writer ownership is invalidated, the session expires or fails validation, or the writer closes
- propagate cancellation into auditor compaction passes and stop before processing additional segments
- wait for the auditor goroutine to exit during writer close
- cover invalidation, session expiration, canceled compaction, and close-waits-for-auditor behavior

## Motivation

Writer fencing already prevents an old owner from accepting new writes, but it did not stop the background auditor owned by that writer. After ownership moved to a new writer, the old auditor could continue compaction, cleanup, and compacted-mark notification work concurrently. This change makes writer-owned maintenance end with writer ownership.

This is separate from the compaction LAC validation merged in #243: #243 validates what may be compacted, while this PR controls which writer-owned background task may continue running.

## Testing

- go test -race -short ./woodpecker/log
- focused invalidation, session, and close race tests with count 5

Closes #244