### PR TITLE
fix(operator): wait for decommissioned before scale-down

### DIFF
--- a/deployments/operator/internal/controller/finalizer.go
+++ b/deployments/operator/internal/controller/finalizer.go
@@ -18,10 +18,10 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +42,11 @@ import (
 var httpClient = &http.Client{Timeout: 30 * time.Second}
 
 const finalizerName = "woodpecker.zilliz.io/finalizer"
+
+type nodeDecommissionProgress struct {
+	State           string `json:"state"`
+	SafeToTerminate bool   `json:"safe_to_terminate"`
+}
 
 // reconcileDelete handles CR deletion: decommission all pods, then remove finalizer.
 func (r *WoodpeckerClusterReconciler) reconcileDelete(ctx context.Context, cluster *woodpeckerv1alpha1.WoodpeckerCluster) (ctrl.Result, error) {
@@ -122,19 +127,29 @@ func (r *WoodpeckerClusterReconciler) decommissionPod(ctx context.Context, pod *
 	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
 
-	// Check progress
+	// Reclaim only after the persisted decommissioned state is visible. This
+	// avoids racing PVC cleanup ahead of the terminal lifecycle transition.
 	progressResp, err := httpClient.Get(baseURL + "/admin/node/decommission/progress")
 	if err != nil {
 		return false, fmt.Errorf("checking decommission progress on %s: %w", pod.Name, err)
 	}
 	defer func() { _ = progressResp.Body.Close() }()
-	body, _ := io.ReadAll(progressResp.Body)
+	if progressResp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, progressResp.Body)
+		return false, nil
+	}
 
-	// The response contains "safe_to_terminate":true when ready
-	safe := progressResp.StatusCode == http.StatusOK &&
-		strings.Contains(string(body), "\"safe_to_terminate\":true")
+	var progress nodeDecommissionProgress
+	if err := json.NewDecoder(progressResp.Body).Decode(&progress); err != nil {
+		return false, fmt.Errorf("decoding decommission progress on %s: %w", pod.Name, err)
+	}
+	safe := progress.State == "decommissioned" && progress.SafeToTerminate
 
-	logger.Info("Decommission progress", "pod", pod.Name, "safeToTerminate", safe)
+	logger.Info("Decommission progress",
+		"pod", pod.Name,
+		"state", progress.State,
+		"safeToTerminate", progress.SafeToTerminate,
+		"readyToReclaim", safe)
 	return safe, nil
 }
 

--- a/deployments/operator/internal/controller/finalizer_test.go
+++ b/deployments/operator/internal/controller/finalizer_test.go
@@ -107,6 +107,24 @@ func TestDecommissionPod_NotSafe(t *testing.T) {
 	assert.False(t, safe)
 }
 
+func TestDecommissionPod_RequiresDecommissionedState(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/progress") {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"state":"decommissioning","safe_to_terminate":true}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+	setupTestHTTPClient(t, srv)
+
+	r := &WoodpeckerClusterReconciler{}
+	safe, err := r.decommissionPod(context.Background(), newRunningPod("1.2.3.4"), 9091)
+	require.NoError(t, err)
+	assert.False(t, safe)
+}
+
 func TestDecommissionPod_ProgressNon200(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/progress") {

--- a/deployments/operator/internal/controller/scaling.go
+++ b/deployments/operator/internal/controller/scaling.go
@@ -76,12 +76,33 @@ func (r *WoodpeckerClusterReconciler) checkScaleDown(ctx context.Context, cluste
 		err := r.Get(ctx, types.NamespacedName{Name: podName, Namespace: cluster.Namespace}, pod)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				continue // pod already gone
+				pvcExists, err := r.scaleDownTargetPVCExists(ctx, cluster, ordinal)
+				if err != nil {
+					return scaleDownWaiting, current, err
+				}
+				if pvcExists {
+					logger.Info("Target pod is gone but PVC remains; waiting instead of reclaiming without decommission proof",
+						"pod", podName,
+						"pvc", scaleDownTargetPVCName(cluster, ordinal))
+					allSafe = false
+				}
+				continue
 			}
 			return scaleDownWaiting, current, err
 		}
 
 		if pod.Status.Phase != corev1.PodRunning {
+			pvcExists, err := r.scaleDownTargetPVCExists(ctx, cluster, ordinal)
+			if err != nil {
+				return scaleDownWaiting, current, err
+			}
+			if pvcExists {
+				logger.Info("Target pod is not running but PVC remains; waiting instead of reclaiming without decommission proof",
+					"pod", podName,
+					"phase", pod.Status.Phase,
+					"pvc", scaleDownTargetPVCName(cluster, ordinal))
+				allSafe = false
+			}
 			continue
 		}
 
@@ -110,12 +131,28 @@ func requeueDelay() time.Duration {
 	return 10 * time.Second
 }
 
+func scaleDownTargetPVCName(cluster *woodpeckerv1alpha1.WoodpeckerCluster, ordinal int32) string {
+	return fmt.Sprintf("data-%s-server-%d", cluster.Name, ordinal)
+}
+
+func (r *WoodpeckerClusterReconciler) scaleDownTargetPVCExists(ctx context.Context, cluster *woodpeckerv1alpha1.WoodpeckerCluster, ordinal int32) (bool, error) {
+	pvc := &corev1.PersistentVolumeClaim{}
+	err := r.Get(ctx, types.NamespacedName{Name: scaleDownTargetPVCName(cluster, ordinal), Namespace: cluster.Namespace}, pvc)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // cleanupOrphanedPVCs deletes PVCs left behind after scale-down.
 func (r *WoodpeckerClusterReconciler) cleanupOrphanedPVCs(ctx context.Context, cluster *woodpeckerv1alpha1.WoodpeckerCluster, oldReplicas, newReplicas int32) error {
 	logger := log.FromContext(ctx)
 
 	for ordinal := oldReplicas - 1; ordinal >= newReplicas; ordinal-- {
-		pvcName := fmt.Sprintf("data-%s-server-%d", cluster.Name, ordinal)
+		pvcName := scaleDownTargetPVCName(cluster, ordinal)
 		pvc := &corev1.PersistentVolumeClaim{}
 		err := r.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: cluster.Namespace}, pvc)
 		if err != nil {

--- a/deployments/operator/internal/controller/scaling_test.go
+++ b/deployments/operator/internal/controller/scaling_test.go
@@ -15,6 +15,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -108,6 +109,55 @@ var _ = Describe("cleanupOrphanedPVCs", func() {
 })
 
 var _ = Describe("checkScaleDown", func() {
+	const ns = "default"
+
+	newScaleCluster := func(name string, desired int32) *woodpeckerv1alpha1.WoodpeckerCluster {
+		return &woodpeckerv1alpha1.WoodpeckerCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: woodpeckerv1alpha1.WoodpeckerClusterSpec{
+				Replicas:    ptr.To(desired),
+				Image:       "img",
+				ServicePort: 18080, GossipPort: 17946, MetricsPort: 9091,
+				StorageSize: resource.MustParse("1Gi"),
+			},
+		}
+	}
+
+	newScaleStatefulSet := func(cluster *woodpeckerv1alpha1.WoodpeckerCluster, current int32) *appsv1.StatefulSet {
+		labels := map[string]string{"app": cluster.Name}
+		return &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: serverName(cluster), Namespace: cluster.Namespace},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas:    ptr.To(current),
+				ServiceName: cluster.Name + "-server-headless",
+				Selector:    &metav1.LabelSelector{MatchLabels: labels},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: labels},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "server", Image: "img"}},
+					},
+				},
+			},
+		}
+	}
+
+	newScalePVC := func(cluster *woodpeckerv1alpha1.WoodpeckerCluster, ordinal int32) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      scaleDownTargetPVCName(cluster, ordinal),
+				Namespace: cluster.Namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("100Mi"),
+					},
+				},
+			},
+		}
+	}
+
 	It("returns scaleDownNotNeeded when STS does not exist", func() {
 		ctx := context.Background()
 		cluster := &woodpeckerv1alpha1.WoodpeckerCluster{
@@ -123,6 +173,67 @@ var _ = Describe("checkScaleDown", func() {
 		result, _, err := r.checkScaleDown(ctx, cluster)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(scaleDownNotNeeded))
+	})
+
+	It("waits when the target pod is gone but its PVC remains", func() {
+		ctx := context.Background()
+		cluster := newScaleCluster("scale-missing-pod", 2)
+		sts := newScaleStatefulSet(cluster, 3)
+		pvc := newScalePVC(cluster, 2)
+		Expect(k8sClient.Create(ctx, sts)).To(Succeed())
+		Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, pvc)
+			_ = k8sClient.Delete(ctx, sts)
+		}()
+
+		r := &WoodpeckerClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		result, current, err := r.checkScaleDown(ctx, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(current).To(Equal(int32(3)))
+		Expect(result).To(Equal(scaleDownWaiting))
+	})
+
+	It("waits when the target pod is not running but its PVC remains", func() {
+		ctx := context.Background()
+		cluster := newScaleCluster("scale-pending-pod", 2)
+		sts := newScaleStatefulSet(cluster, 3)
+		pvc := newScalePVC(cluster, 2)
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cluster.Name + "-server-2",
+				Namespace: cluster.Namespace,
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "server", Image: "img"}}},
+		}
+		Expect(k8sClient.Create(ctx, sts)).To(Succeed())
+		Expect(k8sClient.Create(ctx, pvc)).To(Succeed())
+		Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+		defer func() {
+			_ = k8sClient.Delete(ctx, pod)
+			_ = k8sClient.Delete(ctx, pvc)
+			_ = k8sClient.Delete(ctx, sts)
+		}()
+
+		r := &WoodpeckerClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		result, current, err := r.checkScaleDown(ctx, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(current).To(Equal(int32(3)))
+		Expect(result).To(Equal(scaleDownWaiting))
+	})
+
+	It("allows scale-down when the target pod and PVC are both gone", func() {
+		ctx := context.Background()
+		cluster := newScaleCluster("scale-gone-clean", 2)
+		sts := newScaleStatefulSet(cluster, 3)
+		Expect(k8sClient.Create(ctx, sts)).To(Succeed())
+		defer func() { _ = k8sClient.Delete(ctx, sts) }()
+
+		r := &WoodpeckerClusterReconciler{Client: k8sClient, Scheme: k8sClient.Scheme()}
+		result, current, err := r.checkScaleDown(ctx, cluster)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(current).To(Equal(int32(3)))
+		Expect(result).To(Equal(scaleDownReady))
 	})
 })
 


### PR DESCRIPTION
Fixes #240.

## What
- Require operator decommission progress to report both `state=decommissioned` and `safe_to_terminate=true` before allowing pod/PVC reclaim.
- Keep scale-down waiting if the target pod is gone or not running while its PVC still exists, so PVC cleanup cannot bypass the decommission gate.
- Add regression coverage for the stricter progress gate and PVC-present edge cases.

## Context
The Woodpecker server/storage drain path is already safe. Cloud orchestration already waits for the logstore node to reach `decommissioned` before taking it down; this PR aligns the open-source operator with that contract.

## Tests
- `cd deployments/operator && go test -count=1 ./internal/controller`
- `cd deployments/operator && go test -count=1 ./...`