### PR TITLE
enhance: add compacted cleanup observability

### DIFF
--- a/common/metrics/client_metrics.go
+++ b/common/metrics/client_metrics.go
@@ -199,7 +199,7 @@ var (
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,
 		Name:      "segment_compaction_failures_total",
-		Help:      "Total number of segment compaction failures split by stable reason",
+		Help:      "Total number of failed segment compaction operations split by stable reason",
 	}, []string{"log_ns", "log_id", "reason"})
 
 	// Active (writable) segment -> quorum node membership. One series per node of

--- a/common/metrics/client_metrics.go
+++ b/common/metrics/client_metrics.go
@@ -27,6 +27,10 @@ import (
 // without registration they silently collect data that goes nowhere.
 var (
 	WpClientRegisterOnce sync.Once
+	frontierMu           sync.Mutex
+	writeFrontiers       = make(map[string]progressFrontier)
+	compactionFrontiers  = make(map[string]progressFrontier)
+	truncationFrontiers  = make(map[string]progressFrontier)
 
 	// Log name-id mapping
 	// WARNING: In large-scale deployments with many logs, the "log_name" label
@@ -46,6 +50,42 @@ var (
 		Name:      "segment_state",
 		Help:      "Number of segments in each state per log",
 	}, []string{"log_ns", "log_id", "state"})
+	WpClientWriteFrontierSegment = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "write_frontier_segment",
+		Help:      "Highest segment id acknowledged for writes per log",
+	}, []string{"log_ns", "log_id"})
+	WpClientWriteFrontierEntry = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "write_frontier_entry",
+		Help:      "Highest entry id acknowledged in the write frontier segment per log",
+	}, []string{"log_ns", "log_id"})
+	WpClientCompactionFrontierSegment = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "compaction_frontier_segment",
+		Help:      "Highest segment id successfully sealed by compaction per log",
+	}, []string{"log_ns", "log_id"})
+	WpClientCompactionFrontierEntry = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "compaction_frontier_entry",
+		Help:      "Highest entry id in the highest segment successfully sealed by compaction per log",
+	}, []string{"log_ns", "log_id"})
+	WpClientTruncationFrontierSegment = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "truncation_frontier_segment",
+		Help:      "Current truncated segment id per log",
+	}, []string{"log_ns", "log_id"})
+	WpClientTruncationFrontierEntry = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "truncation_frontier_entry",
+		Help:      "Current truncated entry id per log",
+	}, []string{"log_ns", "log_id"})
 
 	// client append data to log
 	WpClientAppendRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -155,6 +195,12 @@ var (
 		Name:      "segment_handle_pending_append_ops",
 		Help:      "Number of pending append operations in segment handles",
 	}, []string{"log_ns", "log_id"})
+	WpSegmentCompactionFailuresTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "segment_compaction_failures_total",
+		Help:      "Total number of segment compaction failures split by stable reason",
+	}, []string{"log_ns", "log_id", "reason"})
 
 	// Active (writable) segment -> quorum node membership. One series per node of
 	// the current active segment; value is always 1. Series are deleted when the
@@ -198,6 +244,12 @@ var (
 	}, []string{"log_ns", "operation", "status"})
 )
 
+type progressFrontier struct {
+	segmentID   int64
+	entryID     int64
+	initialized bool
+}
+
 // RegisterClientMetricsWithRegisterer registers all client-side metrics with the given registerer.
 // Without calling this, metrics still work but are not scraped by any registry.
 func RegisterClientMetricsWithRegisterer(registerer prometheus.Registerer) {
@@ -206,6 +258,12 @@ func RegisterClientMetricsWithRegisterer(registerer prometheus.Registerer) {
 		registerer.MustRegister(WpLogNameIdMapping)
 		// segment state tracking
 		registerer.MustRegister(WpClientSegmentState)
+		registerer.MustRegister(WpClientWriteFrontierSegment)
+		registerer.MustRegister(WpClientWriteFrontierEntry)
+		registerer.MustRegister(WpClientCompactionFrontierSegment)
+		registerer.MustRegister(WpClientCompactionFrontierEntry)
+		registerer.MustRegister(WpClientTruncationFrontierSegment)
+		registerer.MustRegister(WpClientTruncationFrontierEntry)
 
 		// Client append metrics
 		registerer.MustRegister(WpClientAppendRequestsTotal)
@@ -228,6 +286,7 @@ func RegisterClientMetricsWithRegisterer(registerer prometheus.Registerer) {
 		registerer.MustRegister(WpSegmentHandleOperationsTotal)
 		registerer.MustRegister(WpSegmentHandleOperationLatency)
 		registerer.MustRegister(WpSegmentHandlePendingAppendOps)
+		registerer.MustRegister(WpSegmentCompactionFailuresTotal)
 		// Active segment node membership
 		registerer.MustRegister(WpActiveSegmentNode)
 		// Direct read metrics
@@ -244,6 +303,32 @@ func RegisterClientMetricsWithRegisterer(registerer prometheus.Registerer) {
 func UpdateSegmentState(logNs, logId, oldState, newState string) {
 	WpClientSegmentState.WithLabelValues(logNs, logId, oldState).Dec()
 	WpClientSegmentState.WithLabelValues(logNs, logId, newState).Inc()
+}
+
+func SetWriteFrontier(logNs, logId string, segmentId, entryId int64) {
+	setMonotonicFrontier(writeFrontiers, WpClientWriteFrontierSegment, WpClientWriteFrontierEntry, logNs, logId, segmentId, entryId)
+}
+
+func SetCompactionFrontier(logNs, logId string, segmentId, entryId int64) {
+	setMonotonicFrontier(compactionFrontiers, WpClientCompactionFrontierSegment, WpClientCompactionFrontierEntry, logNs, logId, segmentId, entryId)
+}
+
+func SetTruncationFrontier(logNs, logId string, segmentId, entryId int64) {
+	setMonotonicFrontier(truncationFrontiers, WpClientTruncationFrontierSegment, WpClientTruncationFrontierEntry, logNs, logId, segmentId, entryId)
+}
+
+func setMonotonicFrontier(frontiers map[string]progressFrontier, segmentGauge, entryGauge *prometheus.GaugeVec, logNs, logId string, segmentId, entryId int64) {
+	key := logNs + "\x00" + logId
+	frontierMu.Lock()
+	current := frontiers[key]
+	if current.initialized && (segmentId < current.segmentID || (segmentId == current.segmentID && entryId < current.entryID)) {
+		frontierMu.Unlock()
+		return
+	}
+	frontiers[key] = progressFrontier{segmentID: segmentId, entryID: entryId, initialized: true}
+	segmentGauge.WithLabelValues(logNs, logId).Set(float64(segmentId))
+	entryGauge.WithLabelValues(logNs, logId).Set(float64(entryId))
+	frontierMu.Unlock()
 }
 
 // SetActiveSegmentNodes marks each node of an active (writable) segment's quorum

--- a/common/metrics/metrics_registration_test.go
+++ b/common/metrics/metrics_registration_test.go
@@ -86,6 +86,50 @@ func TestRegisterServerMetricsWithRegisterer(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestRegisterCompactedCleanupAndFrontierMetrics(t *testing.T) {
+	t.Run("client", func(t *testing.T) {
+		WpClientRegisterOnce = sync.Once{}
+		registry := prometheus.NewRegistry()
+		RegisterClientMetricsWithRegisterer(registry)
+
+		SetWriteFrontier("bucket/root", "1", 10, 99)
+		SetCompactionFrontier("bucket/root", "1", 9, 88)
+		SetTruncationFrontier("bucket/root", "1", 3, 7)
+		WpSegmentCompactionFailuresTotal.WithLabelValues("bucket/root", "1", "data_behind").Inc()
+
+		names := gatheredMetricNames(t, registry)
+		assert.True(t, names["woodpecker_client_write_frontier_segment"])
+		assert.True(t, names["woodpecker_client_write_frontier_entry"])
+		assert.True(t, names["woodpecker_client_compaction_frontier_segment"])
+		assert.True(t, names["woodpecker_client_compaction_frontier_entry"])
+		assert.True(t, names["woodpecker_client_truncation_frontier_segment"])
+		assert.True(t, names["woodpecker_client_truncation_frontier_entry"])
+		assert.True(t, names["woodpecker_client_segment_compaction_failures_total"])
+	})
+
+	t.Run("server", func(t *testing.T) {
+		WpServerRegisterOnce = sync.Once{}
+		registry := prometheus.NewRegistry()
+		RegisterServerMetricsWithRegisterer(registry)
+
+		WpCompactedCleanupFooterFailuresTotal.WithLabelValues("node-1", "bucket/root", "1", "transient").Inc()
+		WpCompactedCleanupMarksTotal.WithLabelValues("node-1", "bucket/root", "1", "push").Inc()
+		WpCompactedCleanupReclaimedFilesTotal.WithLabelValues("node-1", "bucket/root", "1", "pull").Inc()
+		WpCompactedCleanupReclaimedBytesTotal.WithLabelValues("node-1", "bucket/root", "1", "pull").Add(128)
+		SetNodeDecommissionProgress("node-1", "decommissioning", 2, true)
+
+		names := gatheredMetricNames(t, registry)
+		assert.True(t, names["woodpecker_server_compacted_cleanup_footer_failures_total"])
+		assert.True(t, names["woodpecker_server_compacted_cleanup_marks_total"])
+		assert.True(t, names["woodpecker_server_compacted_cleanup_reclaimed_files_total"])
+		assert.True(t, names["woodpecker_server_compacted_cleanup_reclaimed_bytes_total"])
+		assert.True(t, names["woodpecker_server_node_lifecycle_state"])
+		assert.True(t, names["woodpecker_server_node_decommission_remaining_processors"])
+		assert.True(t, names["woodpecker_server_node_decommission_has_local_data"])
+		assert.True(t, names["woodpecker_server_node_decommission_safe_to_terminate"])
+	})
+}
+
 func TestRegisterClientMetrics_OnlyOnce(t *testing.T) {
 	// Reset for clean test
 	WpClientRegisterOnce = sync.Once{}
@@ -112,6 +156,18 @@ func TestRegisterServerMetrics_OnlyOnce(t *testing.T) {
 	assert.NotPanics(t, func() {
 		RegisterServerMetricsWithRegisterer(registry2)
 	})
+}
+
+func gatheredMetricNames(t *testing.T, registry *prometheus.Registry) map[string]bool {
+	t.Helper()
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, mf := range metricFamilies {
+		names[mf.GetName()] = true
+	}
+	return names
 }
 
 func TestUpdateSegmentState(t *testing.T) {
@@ -165,6 +221,27 @@ func TestUpdateSegmentState_MultipleTransitions(t *testing.T) {
 	sealedMetric := &dto.Metric{}
 	WpClientSegmentState.WithLabelValues(logNs, logId, "Sealed").Write(sealedMetric)
 	assert.Equal(t, float64(1), sealedMetric.GetGauge().GetValue())
+}
+
+func TestSetFrontierMonotonic(t *testing.T) {
+	logNs := "frontier-test"
+	logId := "100"
+
+	SetCompactionFrontier(logNs, logId, 10, 5)
+	SetCompactionFrontier(logNs, logId, 9, 99)
+
+	segmentMetric := &dto.Metric{}
+	WpClientCompactionFrontierSegment.WithLabelValues(logNs, logId).Write(segmentMetric)
+	assert.Equal(t, float64(10), segmentMetric.GetGauge().GetValue())
+
+	entryMetric := &dto.Metric{}
+	WpClientCompactionFrontierEntry.WithLabelValues(logNs, logId).Write(entryMetric)
+	assert.Equal(t, float64(5), entryMetric.GetGauge().GetValue())
+
+	SetCompactionFrontier(logNs, logId, 10, 6)
+	entryMetric = &dto.Metric{}
+	WpClientCompactionFrontierEntry.WithLabelValues(logNs, logId).Write(entryMetric)
+	assert.Equal(t, float64(6), entryMetric.GetGauge().GetValue())
 }
 
 // TestMetrics_UseLogNsLabel guards the rename of the application namespace

--- a/common/metrics/metrics_registration_test.go
+++ b/common/metrics/metrics_registration_test.go
@@ -39,6 +39,12 @@ func TestBuildLogNs(t *testing.T) {
 	})
 }
 
+func TestBuildLogLabels(t *testing.T) {
+	logNs, logIdStr := BuildLogLabels("mybucket", "myroot", 42)
+	assert.Equal(t, "mybucket/myroot", logNs)
+	assert.Equal(t, "42", logIdStr)
+}
+
 func TestNodeID_Default(t *testing.T) {
 	// NodeID should default to "embed" when NODE_NAME env is not set
 	// or be set to the env value. Just verify it's non-empty.

--- a/common/metrics/service_metrics.go
+++ b/common/metrics/service_metrics.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"os"
+	"strconv"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -42,6 +43,11 @@ var NodeID = func() string {
 // BuildLogNs returns the metrics log_ns string from bucket name and root path.
 func BuildLogNs(bucketName, rootPath string) string {
 	return bucketName + "/" + rootPath
+}
+
+// BuildLogLabels returns the common metrics labels for a log.
+func BuildLogLabels(bucketName, rootPath string, logID int64) (logNs, logIDStr string) {
+	return BuildLogNs(bucketName, rootPath), strconv.FormatInt(logID, 10)
 }
 
 // Server metrics are initialized at package level so they are always safe to use.

--- a/common/metrics/service_metrics.go
+++ b/common/metrics/service_metrics.go
@@ -255,6 +255,54 @@ var (
 		Name:      "file_stored_count",
 		Help:      "Current number of local segment files",
 	}, []string{"node_id", "log_ns", "log_id"})
+	WpCompactedCleanupFooterFailuresTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "compacted_cleanup_footer_failures_total",
+		Help:      "Total number of compacted-file cleanup footer confirmation failures split by stable reason",
+	}, []string{"node_id", "log_ns", "log_id", "reason"})
+	WpCompactedCleanupMarksTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "compacted_cleanup_marks_total",
+		Help:      "Total number of compacted marks created by source",
+	}, []string{"node_id", "log_ns", "log_id", "source"})
+	WpCompactedCleanupReclaimedFilesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "compacted_cleanup_reclaimed_files_total",
+		Help:      "Total number of local data.log files reclaimed after durable compaction",
+	}, []string{"node_id", "log_ns", "log_id", "source"})
+	WpCompactedCleanupReclaimedBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "compacted_cleanup_reclaimed_bytes_total",
+		Help:      "Total bytes reclaimed from local data.log files after durable compaction",
+	}, []string{"node_id", "log_ns", "log_id", "source"})
+	WpNodeLifecycleState = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "node_lifecycle_state",
+		Help:      "Node lifecycle state as a one-hot gauge: 1 for the current state, 0 for other known states",
+	}, []string{"node_id", "state"})
+	WpNodeDecommissionRemainingProcessors = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "node_decommission_remaining_processors",
+		Help:      "Active segment processors remaining while draining a node",
+	}, []string{"node_id"})
+	WpNodeDecommissionHasLocalData = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "node_decommission_has_local_data",
+		Help:      "Whether local segment data remains on the node: 1=true, 0=false",
+	}, []string{"node_id"})
+	WpNodeDecommissionSafeToTerminate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: serverRole,
+		Name:      "node_decommission_safe_to_terminate",
+		Help:      "Whether the node is safe to terminate according to the decommission drain gate: 1=true, 0=false",
+	}, []string{"node_id"})
 
 	WpSyncSchedulerScheduled = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: woodpeckerNamespace,
@@ -334,6 +382,14 @@ func RegisterServerMetricsWithRegisterer(registerer prometheus.Registerer) {
 		registerer.MustRegister(WpObjectStorageStoredObjects)
 		registerer.MustRegister(WpFileStoredBytes)
 		registerer.MustRegister(WpFileStoredCount)
+		registerer.MustRegister(WpCompactedCleanupFooterFailuresTotal)
+		registerer.MustRegister(WpCompactedCleanupMarksTotal)
+		registerer.MustRegister(WpCompactedCleanupReclaimedFilesTotal)
+		registerer.MustRegister(WpCompactedCleanupReclaimedBytesTotal)
+		registerer.MustRegister(WpNodeLifecycleState)
+		registerer.MustRegister(WpNodeDecommissionRemainingProcessors)
+		registerer.MustRegister(WpNodeDecommissionHasLocalData)
+		registerer.MustRegister(WpNodeDecommissionSafeToTerminate)
 		registerer.MustRegister(WpSyncSchedulerScheduled)
 		registerer.MustRegister(WpSyncSchedulerRunning)
 		registerer.MustRegister(WpSyncSchedulerWaiting)
@@ -341,4 +397,21 @@ func RegisterServerMetricsWithRegisterer(registerer prometheus.Registerer) {
 		// Quorum selection skew (load-aware node selection, issue #114)
 		registerer.MustRegister(WpQuorumSelectionSkew)
 	})
+}
+
+func SetNodeDecommissionProgress(nodeID, state string, remainingProcessors int, hasLocalData bool) {
+	for _, known := range []string{"active", "decommissioning", "decommissioned"} {
+		WpNodeLifecycleState.WithLabelValues(nodeID, known).Set(0)
+	}
+	WpNodeLifecycleState.WithLabelValues(nodeID, state).Set(1)
+	WpNodeDecommissionRemainingProcessors.WithLabelValues(nodeID).Set(float64(remainingProcessors))
+	WpNodeDecommissionHasLocalData.WithLabelValues(nodeID).Set(boolGauge(hasLocalData))
+	WpNodeDecommissionSafeToTerminate.WithLabelValues(nodeID).Set(boolGauge(!hasLocalData))
+}
+
+func boolGauge(v bool) float64 {
+	if v {
+		return 1
+	}
+	return 0
 }

--- a/server/compacted_file_cleanup.go
+++ b/server/compacted_file_cleanup.go
@@ -50,6 +50,14 @@ const reconcileEveryNPasses = 60
 // next 5s tick. (The client-side analog is maxCompactedNotifyPerCycle.)
 const maxDrainPerTick = 256
 
+const (
+	compactedCleanupSourcePush = "push"
+	compactedCleanupSourcePull = "pull"
+
+	compactedCleanupFooterFailureTransient     = "transient"
+	compactedCleanupFooterFailureMissingFooter = "missing_footer"
+)
+
 // pendingSeg identifies a segment whose local data.log should be dropped once its compacted
 // footer is confirmed present in object storage. It carries just enough to run the footer HEAD
 // and the drop; the marked state is re-read from disk when the segment is processed.
@@ -327,13 +335,16 @@ func (t *compactedFileCleanupTask) processSegment(ctx context.Context, s pending
 	if _, err := os.Stat(filepath.Join(s.segDir, "data.log")); os.IsNotExist(err) {
 		return // data.log already gone (dropped earlier, or removed by the truncate GC): nothing to do
 	}
+	source := compactedCleanupSource(s)
+	logNs, logIdStr := compactedCleanupLabels(s.bucket, s.rootPath, s.logId)
 	footer := s.footerConfirmed // push path: the notify handler HEADed the footer in this process moments ago
 	if !footer {
 		var statErr error
 		footer, statErr = compactedFooterExists(ctx, t.store.storageClient, s.bucket, s.rootPath, s.logId, s.segId)
 		if statErr != nil {
+			metrics.WpCompactedCleanupFooterFailuresTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupFooterFailureTransient).Inc()
 			logger.Ctx(ctx).Warn("compacted-file-cleanup: failed to stat footer; will retry with backoff",
-				zap.String("segDir", s.segDir), zap.Int("attempts", s.attempts+1), zap.Error(statErr))
+				zap.String("segDir", s.segDir), zap.String("source", source), zap.Int("attempts", s.attempts+1), zap.Error(statErr))
 			t.requeueAfterFailure(s) // transient: retried with exponential backoff, capped at the reconcile cadence
 			return
 		}
@@ -341,8 +352,9 @@ func (t *compactedFileCleanupTask) processSegment(ctx context.Context, s pending
 	marked := hasCompactedMark(s.segDir)
 	if !footer {
 		if marked {
+			metrics.WpCompactedCleanupFooterFailuresTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupFooterFailureMissingFooter).Inc()
 			logger.Ctx(ctx).Warn("compacted-file-cleanup: marked segment has no compacted footer in object storage; leaving data.log AND mark for the truncate/delete GC (unexpected state)",
-				zap.String("segDir", s.segDir), zap.Int64("logId", s.logId), zap.Int64("segId", s.segId))
+				zap.String("segDir", s.segDir), zap.String("source", source), zap.Int64("logId", s.logId), zap.Int64("segId", s.segId))
 		}
 		// unmarked && !footer: not compacted yet; leave alone.
 		return
@@ -357,14 +369,15 @@ func (t *compactedFileCleanupTask) processSegment(ctx context.Context, s pending
 			// retrying every tick would keep hammering an already unhealthy filesystem with a
 			// footer HEAD plus mark I/O per segment.
 			logger.Ctx(ctx).Warn("compacted-file-cleanup: reconcile failed to write compacted mark; will retry with backoff",
-				zap.String("segDir", s.segDir), zap.Error(markErr))
+				zap.String("segDir", s.segDir), zap.String("source", source), zap.Error(markErr))
 			t.requeueAfterFailure(s)
 			return
 		}
+		metrics.WpCompactedCleanupMarksTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, source).Inc()
 		logger.Ctx(ctx).Info("compacted-file-cleanup: reconcile wrote compacted mark for unmarked-but-compacted segment",
-			zap.String("segDir", s.segDir), zap.Int64("logId", s.logId), zap.Int64("segId", s.segId))
+			zap.String("segDir", s.segDir), zap.String("source", source), zap.Int64("logId", s.logId), zap.Int64("segId", s.segId))
 	}
-	if dropErr := t.dropSegmentLocalData(ctx, s.segDir, s.bucket, s.rootPath, s.logId, s.segId); dropErr != nil {
+	if dropErr := t.dropSegmentLocalData(ctx, s.segDir, s.bucket, s.rootPath, s.logId, s.segId, source); dropErr != nil {
 		t.requeueAfterFailure(s)
 	}
 }
@@ -375,7 +388,7 @@ func (t *compactedFileCleanupTask) processSegment(ctx context.Context, s pending
 // "compacted -> serve from object storage" from "no data here" without an object-storage
 // HEAD. The tombstone is removed only when the segment is fully truncated/deleted (the
 // truncate/delete GC path removes the mark and the directory).
-func (t *compactedFileCleanupTask) dropSegmentLocalData(ctx context.Context, segDir, bucket, rootPath string, logId, segId int64) error {
+func (t *compactedFileCleanupTask) dropSegmentLocalData(ctx context.Context, segDir, bucket, rootPath string, logId, segId int64, source string) error {
 	dataLogPath := filepath.Join(segDir, "data.log")
 	// Size the file before removal so we can keep the local-storage gauges accurate. This
 	// push+pull path bypasses deleteLocalFiles' accounting, so without this the "current local
@@ -412,12 +425,13 @@ func (t *compactedFileCleanupTask) dropSegmentLocalData(ctx context.Context, seg
 		// validated at the NotifySegmentCompacted boundary (push) and derived
 		// path.Join-canonicalized from disk (pull reconcile), so both agree and this
 		// decrement hits the writer's exact series.
-		logNs := bucket + "/" + rootPath
-		logIdStr := strconv.FormatInt(logId, 10)
+		logNs, logIdStr := compactedCleanupLabels(bucket, rootPath, logId)
 		if sizeKnown {
 			metrics.WpFileStoredBytes.WithLabelValues(metrics.NodeID, logNs, logIdStr).Sub(float64(dataLogSize))
+			metrics.WpCompactedCleanupReclaimedBytesTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, source).Add(float64(dataLogSize))
 		}
 		metrics.WpFileStoredCount.WithLabelValues(metrics.NodeID, logNs, logIdStr).Dec()
+		metrics.WpCompactedCleanupReclaimedFilesTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, source).Inc()
 	}
 
 	if evictErr := t.store.EvictSegmentReader(ctx, bucket, rootPath, logId, segId); evictErr != nil {
@@ -429,8 +443,25 @@ func (t *compactedFileCleanupTask) dropSegmentLocalData(ctx context.Context, seg
 	// place, so a reader that opens this segment after the data.log is gone can serve it
 	// from object storage without an object-storage HEAD.
 	logger.Ctx(ctx).Info("compacted-file-cleanup: removed local data.log for durably compacted segment (mark kept as tombstone)",
-		zap.String("segDir", segDir), zap.Int64("logId", logId), zap.Int64("segId", segId))
+		zap.String("segDir", segDir),
+		zap.String("source", source),
+		zap.Bool("removed", rmErr == nil),
+		zap.Bool("reclaimedBytesKnown", sizeKnown),
+		zap.Int64("reclaimedBytes", dataLogSize),
+		zap.Int64("logId", logId),
+		zap.Int64("segId", segId))
 	return nil
+}
+
+func compactedCleanupSource(s pendingSeg) string {
+	if s.footerConfirmed {
+		return compactedCleanupSourcePush
+	}
+	return compactedCleanupSourcePull
+}
+
+func compactedCleanupLabels(bucket, rootPath string, logId int64) (string, string) {
+	return bucket + "/" + rootPath, strconv.FormatInt(logId, 10)
 }
 
 // compactedFooterExists checks whether the compacted footer object for (logId, segId)

--- a/server/compacted_file_cleanup.go
+++ b/server/compacted_file_cleanup.go
@@ -284,8 +284,7 @@ func (t *compactedFileCleanupTask) seedStoredGauges(segDir, bucket, rootPath str
 	if err != nil || !info.ModTime().Before(t.startTime) {
 		return
 	}
-	logNs := bucket + "/" + rootPath
-	logIdStr := strconv.FormatInt(logId, 10)
+	logNs, logIdStr := compactedCleanupLabels(bucket, rootPath, logId)
 	metrics.WpFileStoredBytes.WithLabelValues(metrics.NodeID, logNs, logIdStr).Add(float64(info.Size()))
 	metrics.WpFileStoredCount.WithLabelValues(metrics.NodeID, logNs, logIdStr).Inc()
 }
@@ -363,7 +362,8 @@ func (t *compactedFileCleanupTask) processSegment(ctx context.Context, s pending
 		// Reconcile: a compacted-but-unmarked segment. Backfill the durable tombstone before the
 		// drop so a reader can always tell "compacted -> serve from object storage" apart from
 		// "no data here".
-		if markErr := writeCompactedMark(ctx, s.segDir); markErr != nil {
+		markCreated, markErr := writeCompactedMarkCreated(ctx, s.segDir)
+		if markErr != nil {
 			// Backoff like the footer-HEAD failure above (a fresh enqueue would reset the
 			// schedule): a read-only or full staged volume fails this deterministically, and
 			// retrying every tick would keep hammering an already unhealthy filesystem with a
@@ -373,9 +373,11 @@ func (t *compactedFileCleanupTask) processSegment(ctx context.Context, s pending
 			t.requeueAfterFailure(s)
 			return
 		}
-		metrics.WpCompactedCleanupMarksTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, source).Inc()
-		logger.Ctx(ctx).Info("compacted-file-cleanup: reconcile wrote compacted mark for unmarked-but-compacted segment",
-			zap.String("segDir", s.segDir), zap.String("source", source), zap.Int64("logId", s.logId), zap.Int64("segId", s.segId))
+		if markCreated {
+			metrics.WpCompactedCleanupMarksTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, source).Inc()
+			logger.Ctx(ctx).Info("compacted-file-cleanup: reconcile wrote compacted mark for unmarked-but-compacted segment",
+				zap.String("segDir", s.segDir), zap.String("source", source), zap.Int64("logId", s.logId), zap.Int64("segId", s.segId))
+		}
 	}
 	if dropErr := t.dropSegmentLocalData(ctx, s.segDir, s.bucket, s.rootPath, s.logId, s.segId, source); dropErr != nil {
 		t.requeueAfterFailure(s)
@@ -461,7 +463,7 @@ func compactedCleanupSource(s pendingSeg) string {
 }
 
 func compactedCleanupLabels(bucket, rootPath string, logId int64) (string, string) {
-	return bucket + "/" + rootPath, strconv.FormatInt(logId, 10)
+	return metrics.BuildLogLabels(bucket, rootPath, logId)
 }
 
 // compactedFooterExists checks whether the compacted footer object for (logId, segId)

--- a/server/compacted_file_cleanup_test.go
+++ b/server/compacted_file_cleanup_test.go
@@ -121,6 +121,8 @@ func TestCompactedFileCleanup_MarkedButFooterAbsent_NeverDeletesData(t *testing.
 	mockStorage.EXPECT().
 		StatObject(ctx, bucket, footerKeyFor(rp, logId, segId), bucket+"/"+rp, "11").
 		Return(int64(0), false, minio.ErrorResponse{Code: "NoSuchKey"})
+	logNs, logIdStr := bucket+"/"+rp, "11"
+	failuresBefore := testutil.ToFloat64(metrics.WpCompactedCleanupFooterFailuresTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupFooterFailureMissingFooter))
 
 	task := newCompactedFileCleanupTask(store)
 	require.NoError(t, task.runOnce(ctx, true)) // reconcile walk enqueues the marked segment, then drains
@@ -128,6 +130,8 @@ func TestCompactedFileCleanup_MarkedButFooterAbsent_NeverDeletesData(t *testing.
 	_, statErr := os.Stat(filepath.Join(segDir, "data.log"))
 	assert.NoError(t, statErr, "data.log must NOT be deleted without a confirmed footer")
 	assert.True(t, hasCompactedMark(segDir), "the mark is KEPT (removed only by the truncate/delete GC), not cleared here")
+	assert.Equal(t, failuresBefore+1,
+		testutil.ToFloat64(metrics.WpCompactedCleanupFooterFailuresTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupFooterFailureMissingFooter)))
 }
 
 // TestCompactedFileCleanup_UnmarkedAndFooterPresent_ReconcileWritesMark verifies the reconcile
@@ -147,6 +151,9 @@ func TestCompactedFileCleanup_UnmarkedAndFooterPresent_ReconcileWritesMark(t *te
 	mockStorage.EXPECT().
 		StatObject(ctx, bucket, footerKeyFor(rp, logId, segId), bucket+"/"+rp, "12").
 		Return(int64(64), false, nil)
+	logNs, logIdStr := bucket+"/"+rp, "12"
+	marksBefore := testutil.ToFloat64(metrics.WpCompactedCleanupMarksTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupSourcePull))
+	reclaimedBefore := testutil.ToFloat64(metrics.WpCompactedCleanupReclaimedFilesTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupSourcePull))
 
 	task := newCompactedFileCleanupTask(store)
 	require.NoError(t, task.runOnce(ctx, true)) // reconcile pass
@@ -154,6 +161,10 @@ func TestCompactedFileCleanup_UnmarkedAndFooterPresent_ReconcileWritesMark(t *te
 	assert.True(t, hasCompactedMark(segDir), "reconcile should have written the compacted mark (tombstone kept)")
 	_, statErr := os.Stat(filepath.Join(segDir, "data.log"))
 	assert.True(t, os.IsNotExist(statErr), "reconcile marks AND drops the data.log in the same drain")
+	assert.Equal(t, marksBefore+1,
+		testutil.ToFloat64(metrics.WpCompactedCleanupMarksTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupSourcePull)))
+	assert.Equal(t, reclaimedBefore+1,
+		testutil.ToFloat64(metrics.WpCompactedCleanupReclaimedFilesTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupSourcePull)))
 }
 
 // TestCompactedFileCleanup_UnmarkedAndFooterAbsent_NothingChanges verifies row 4:
@@ -790,12 +801,15 @@ func TestCompactedFileCleanup_PushConfirmedEntry_SkipsDuplicateHead(t *testing.T
 	require.NoError(t, writeCompactedMark(ctx, segDir))
 
 	task := newCompactedFileCleanupTask(store)
+	reclaimedBefore := testutil.ToFloat64(metrics.WpCompactedCleanupReclaimedFilesTotal.WithLabelValues(metrics.NodeID, bucket+"/"+rp, "31", compactedCleanupSourcePush))
 	task.enqueueFooterConfirmed(segDir, bucket, rp, logId, segId)
 	require.NoError(t, task.runOnce(ctx, false))
 
 	_, statErr := os.Stat(filepath.Join(segDir, "data.log"))
 	assert.True(t, os.IsNotExist(statErr), "the confirmed entry must be dropped without a duplicate HEAD")
 	assert.True(t, hasCompactedMark(segDir))
+	assert.Equal(t, reclaimedBefore+1,
+		testutil.ToFloat64(metrics.WpCompactedCleanupReclaimedFilesTotal.WithLabelValues(metrics.NodeID, bucket+"/"+rp, "31", compactedCleanupSourcePush)))
 }
 
 // TestCompactedFileCleanup_DrainCappedPerTick pins the per-tick budget: with more due
@@ -861,7 +875,7 @@ func TestCompactedFileCleanup_AlreadyRemovedFile_DoesNotTouchGauges(t *testing.T
 	countBefore := testutil.ToFloat64(metrics.WpFileStoredCount.WithLabelValues(metrics.NodeID, logNs, logIdStr))
 
 	task := newCompactedFileCleanupTask(store)
-	task.dropSegmentLocalData(ctx, segDir, bucket, rp, logId, segId)
+	task.dropSegmentLocalData(ctx, segDir, bucket, rp, logId, segId, compactedCleanupSourcePull)
 
 	assert.Equal(t, bytesBefore,
 		testutil.ToFloat64(metrics.WpFileStoredBytes.WithLabelValues(metrics.NodeID, logNs, logIdStr)),

--- a/server/compacted_mark.go
+++ b/server/compacted_mark.go
@@ -51,34 +51,42 @@ func hasCompactedMark(segmentDir string) bool {
 // existence is meaningful, so there is no content to write — the create + a single parent-dir
 // fsync replaces the old temp-write + rename + double-fsync.
 func writeCompactedMark(ctx context.Context, segmentDir string) error {
+	_, err := writeCompactedMarkCreated(ctx, segmentDir)
+	return err
+}
+
+func writeCompactedMarkCreated(ctx context.Context, segmentDir string) (bool, error) {
 	p := compactedMarkPath(segmentDir)
 	if _, err := os.Stat(p); err == nil {
-		return nil // already marked
+		return false, nil // already marked
 	} else if !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
 	if err := os.MkdirAll(segmentDir, 0o755); err != nil {
-		return err
+		return false, err
 	}
-	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY, 0o644)
+	f, err := os.OpenFile(p, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
 	if err != nil {
-		return err
+		if os.IsExist(err) {
+			return false, nil
+		}
+		return false, err
 	}
 	if err := f.Close(); err != nil {
-		return err
+		return false, err
 	}
 	// Fsync the parent dir so the new directory entry survives a crash.
 	dir, err := os.Open(segmentDir)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if err := dir.Sync(); err != nil {
 		dir.Close()
-		return err
+		return false, err
 	}
 	if err := dir.Close(); err != nil {
-		return err
+		return false, err
 	}
 	logger.Ctx(ctx).Info("compacted mark created", zap.String("path", p))
-	return nil
+	return true, nil
 }

--- a/server/compacted_mark_test.go
+++ b/server/compacted_mark_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,12 +18,44 @@ func TestCompactedMark_WriteHas_Idempotent(t *testing.T) {
 	require.NoError(t, os.MkdirAll(seg, 0o755))
 
 	assert.False(t, hasCompactedMark(seg))
-	require.NoError(t, writeCompactedMark(context.Background(), seg))
+	created, err := writeCompactedMarkCreated(context.Background(), seg)
+	require.NoError(t, err)
+	assert.True(t, created)
 	assert.True(t, hasCompactedMark(seg))
 	// idempotent write
-	require.NoError(t, writeCompactedMark(context.Background(), seg))
+	created, err = writeCompactedMarkCreated(context.Background(), seg)
+	require.NoError(t, err)
+	assert.False(t, created)
 	assert.True(t, hasCompactedMark(seg))
 	assert.FileExists(t, filepath.Join(seg, compactedMarkFileName))
+}
+
+func TestCompactedMark_WriteCreatedConcurrent(t *testing.T) {
+	dir := t.TempDir()
+	seg := filepath.Join(dir, "1", "2")
+
+	var createdCount atomic.Int32
+	errCh := make(chan error, 16)
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			created, err := writeCompactedMarkCreated(context.Background(), seg)
+			if created {
+				createdCount.Add(1)
+			}
+			errCh <- err
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.NoError(t, err)
+	}
+	assert.Equal(t, int32(1), createdCount.Load())
+	assert.True(t, hasCompactedMark(seg))
 }
 
 // TestCompactedMark_WriteStatError covers writeCompactedMark's non-IsNotExist stat error

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -663,6 +663,7 @@ func (l *logStore) NotifySegmentCompacted(ctx context.Context, bucketName, rootP
 	if dir == "" {
 		return nil // no local data dir (e.g. empty RootPath): nothing to mark
 	}
+	logNs, logIdStr := metrics.BuildLogLabels(bucketName, rootPath, logId)
 	// Verify the compaction is actually durable BEFORE writing the tombstone. The mark is
 	// load-bearing — HasLocalSegmentData treats a marked data.log as drained and the cleanup
 	// task reclaims against it — so the "mark ⇒ footer exists" invariant is enforced here,
@@ -671,34 +672,26 @@ func (l *logStore) NotifySegmentCompacted(ctx context.Context, bucketName, rootP
 	// end-to-end: a notify arriving after the truncate GC removed the segment's objects finds
 	// no footer and cannot resurrect the reaped directory.
 	if l.storageClient == nil {
-		logNs := bucketName + "/" + rootPath
-		logIdStr := strconv.FormatInt(logId, 10)
 		metrics.WpCompactedCleanupFooterFailuresTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, "no_storage_client").Inc()
 		return werr.ErrInternalError.WithCauseErrMsg("no object storage client; cannot verify compacted footer")
 	}
 	footerOk, footerErr := compactedFooterExists(ctx, l.storageClient, bucketName, rootPath, logId, segmentId)
 	if footerErr != nil {
-		logNs := bucketName + "/" + rootPath
-		logIdStr := strconv.FormatInt(logId, 10)
 		metrics.WpCompactedCleanupFooterFailuresTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupFooterFailureTransient).Inc()
 		return footerErr
 	}
 	if !footerOk {
-		logNs := bucketName + "/" + rootPath
-		logIdStr := strconv.FormatInt(logId, 10)
 		metrics.WpCompactedCleanupFooterFailuresTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupFooterFailureMissingFooter).Inc()
 		logger.Ctx(ctx).Warn("NotifySegmentCompacted: compacted footer not found; refusing to write mark",
 			zap.String("bucket", bucketName), zap.String("rootPath", rootPath),
 			zap.Int64("logId", logId), zap.Int64("segId", segmentId))
 		return werr.ErrSegmentNotFound.WithCauseErrMsg("compacted footer not found in object storage; segment is not durably compacted")
 	}
-	markedBefore := hasCompactedMark(dir)
-	if err := writeCompactedMark(ctx, dir); err != nil {
+	markCreated, err := writeCompactedMarkCreated(ctx, dir)
+	if err != nil {
 		return err
 	}
-	if !markedBefore {
-		logNs := bucketName + "/" + rootPath
-		logIdStr := strconv.FormatInt(logId, 10)
+	if markCreated {
 		metrics.WpCompactedCleanupMarksTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupSourcePush).Inc()
 		logger.Ctx(ctx).Info("NotifySegmentCompacted: compacted mark written",
 			zap.String("bucket", bucketName),

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -671,20 +671,41 @@ func (l *logStore) NotifySegmentCompacted(ctx context.Context, bucketName, rootP
 	// end-to-end: a notify arriving after the truncate GC removed the segment's objects finds
 	// no footer and cannot resurrect the reaped directory.
 	if l.storageClient == nil {
+		logNs := bucketName + "/" + rootPath
+		logIdStr := strconv.FormatInt(logId, 10)
+		metrics.WpCompactedCleanupFooterFailuresTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, "no_storage_client").Inc()
 		return werr.ErrInternalError.WithCauseErrMsg("no object storage client; cannot verify compacted footer")
 	}
 	footerOk, footerErr := compactedFooterExists(ctx, l.storageClient, bucketName, rootPath, logId, segmentId)
 	if footerErr != nil {
+		logNs := bucketName + "/" + rootPath
+		logIdStr := strconv.FormatInt(logId, 10)
+		metrics.WpCompactedCleanupFooterFailuresTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupFooterFailureTransient).Inc()
 		return footerErr
 	}
 	if !footerOk {
+		logNs := bucketName + "/" + rootPath
+		logIdStr := strconv.FormatInt(logId, 10)
+		metrics.WpCompactedCleanupFooterFailuresTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupFooterFailureMissingFooter).Inc()
 		logger.Ctx(ctx).Warn("NotifySegmentCompacted: compacted footer not found; refusing to write mark",
 			zap.String("bucket", bucketName), zap.String("rootPath", rootPath),
 			zap.Int64("logId", logId), zap.Int64("segId", segmentId))
 		return werr.ErrSegmentNotFound.WithCauseErrMsg("compacted footer not found in object storage; segment is not durably compacted")
 	}
+	markedBefore := hasCompactedMark(dir)
 	if err := writeCompactedMark(ctx, dir); err != nil {
 		return err
+	}
+	if !markedBefore {
+		logNs := bucketName + "/" + rootPath
+		logIdStr := strconv.FormatInt(logId, 10)
+		metrics.WpCompactedCleanupMarksTotal.WithLabelValues(metrics.NodeID, logNs, logIdStr, compactedCleanupSourcePush).Inc()
+		logger.Ctx(ctx).Info("NotifySegmentCompacted: compacted mark written",
+			zap.String("bucket", bucketName),
+			zap.String("rootPath", rootPath),
+			zap.String("source", compactedCleanupSourcePush),
+			zap.Int64("logId", logId),
+			zap.Int64("segId", segmentId))
 	}
 	// Feed the event-driven drop queue so the local data.log is reclaimed on the next
 	// maintenance tick, without waiting for the low-frequency reconcile walk.

--- a/server/service.go
+++ b/server/service.go
@@ -36,6 +36,7 @@ import (
 	"github.com/zilliztech/woodpecker/common/funcutil"
 	"github.com/zilliztech/woodpecker/common/logger"
 	"github.com/zilliztech/woodpecker/common/membership"
+	"github.com/zilliztech/woodpecker/common/metrics"
 	wpNet "github.com/zilliztech/woodpecker/common/net"
 	storageclient "github.com/zilliztech/woodpecker/common/objectstorage"
 	"github.com/zilliztech/woodpecker/common/topology"
@@ -252,6 +253,7 @@ func (s *Server) start() error {
 	if err := s.logStore.Start(); err != nil {
 		return err
 	}
+	s.updateDecommissionMetrics()
 	logger.Ctx(s.ctx).Info("log store started", zap.String("nodeID", s.serverConfig.NodeID), zap.String("address", s.logStore.GetAddress()))
 
 	// If the node was decommissioning before restart, re-apply write rejection and resume monitoring
@@ -807,6 +809,7 @@ func (s *Server) CancelDecommission() error {
 	}
 	// Resume accepting new writes
 	s.logStore.AllowNewWrites()
+	s.updateDecommissionMetrics()
 	// Broadcast active status via gossip so other nodes stop filtering this node out
 	s.serverNodeMu.RLock()
 	node := s.serverNode
@@ -837,6 +840,7 @@ func (s *Server) Decommission() error {
 	}
 	// Stop accepting new writes but allow reads and segment completions
 	s.logStore.RejectNewWrites()
+	s.updateDecommissionMetrics()
 	// Broadcast decommission state via gossip so other nodes filter this node from quorum
 	s.serverNodeMu.RLock()
 	node := s.serverNode
@@ -869,7 +873,14 @@ func (s *Server) GetWriterRegistry() storage.WriterRegistry {
 func (s *Server) GetDecommissionProgress() DecommissionProgress {
 	remaining := s.logStore.GetActiveProcessorCount()
 	hasData := s.logStore.HasLocalSegmentData()
+	metrics.SetNodeDecommissionProgress(metrics.NodeID, string(s.lifecycle.GetState()), remaining, hasData)
 	return s.lifecycle.GetProgress(remaining, hasData)
+}
+
+func (s *Server) updateDecommissionMetrics() {
+	remaining := s.logStore.GetActiveProcessorCount()
+	hasData := s.logStore.HasLocalSegmentData()
+	metrics.SetNodeDecommissionProgress(metrics.NodeID, string(s.lifecycle.GetState()), remaining, hasData)
 }
 
 // decommissionCheckInterval is how often the decommission monitor re-checks
@@ -922,6 +933,7 @@ func (s *Server) decommissionMonitorLoop(checkInterval time.Duration) {
 				return
 			}
 			hasData := s.logStore.HasLocalSegmentData()
+			metrics.SetNodeDecommissionProgress(metrics.NodeID, string(s.lifecycle.GetState()), s.logStore.GetActiveProcessorCount(), hasData)
 			logger.Ctx(s.ctx).Info("decommission monitor check",
 				zap.String("nodeID", s.serverConfig.NodeID),
 				zap.Int("remainingProcessors", s.logStore.GetActiveProcessorCount()),
@@ -940,6 +952,7 @@ func (s *Server) decommissionMonitorLoop(checkInterval time.Duration) {
 						zap.Error(err))
 					continue
 				}
+				metrics.SetNodeDecommissionProgress(metrics.NodeID, string(s.lifecycle.GetState()), s.logStore.GetActiveProcessorCount(), hasData)
 				logger.Ctx(s.ctx).Info("node decommission complete — no local segment data remaining",
 					zap.String("nodeID", s.serverConfig.NodeID))
 				return

--- a/tests/docker/monitor/grafana/templates/dashboard_client.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_client.json
@@ -661,12 +661,196 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 41
+      },
+      "id": 101,
+      "title": "Progress Frontiers",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 102,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "woodpecker_client_write_frontier_segment{log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} write",
+          "refId": "A"
+        },
+        {
+          "expr": "woodpecker_client_compaction_frontier_segment{log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} compacted",
+          "refId": "B"
+        },
+        {
+          "expr": "woodpecker_client_truncation_frontier_segment{log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} truncated",
+          "refId": "C"
+        }
+      ],
+      "title": "Segment Frontiers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 103,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "woodpecker_client_write_frontier_entry{log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} write",
+          "refId": "A"
+        },
+        {
+          "expr": "woodpecker_client_compaction_frontier_entry{log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} compacted",
+          "refId": "B"
+        },
+        {
+          "expr": "woodpecker_client_truncation_frontier_entry{log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} truncated",
+          "refId": "C"
+        }
+      ],
+      "title": "Entry Frontiers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 104,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_segment_compaction_failures_total{log_ns=~\"$log_ns\"}[1m])) by (log_id, reason)",
+          "legendFormat": "logID={{log_id}} reason={{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Compaction Failure Rate by Reason",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
       },
       "id": 8,
       "panels": [
@@ -693,7 +877,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 42
+            "y": 59
           },
           "id": 9,
           "options": {
@@ -744,7 +928,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 42
+            "y": 59
           },
           "id": 10,
           "options": {
@@ -795,7 +979,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 42
+            "y": 59
           },
           "id": 11,
           "options": {

--- a/tests/docker/monitor/grafana/templates/dashboard_server.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_server.json
@@ -3044,6 +3044,290 @@
       ],
       "title": "Cost",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 105,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 9
+          },
+          "id": 106,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
+              "legendFormat": "logID={{log_id}} source={{source}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Compacted Cleanup Reclaimed Bytes Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 9
+          },
+          "id": 107,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
+              "legendFormat": "reclaimed logID={{log_id}} source={{source}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
+              "legendFormat": "marks logID={{log_id}} source={{source}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Compacted Cleanup Files & Marks Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 9
+          },
+          "id": 108,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, reason)",
+              "legendFormat": "logID={{log_id}} reason={{reason}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Compacted Cleanup Footer Failure Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 109,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "woodpecker_server_node_lifecycle_state{job=~\"$server_job\"}",
+              "legendFormat": "node={{node_id}} state={{state}}",
+              "refId": "A"
+            },
+            {
+              "expr": "woodpecker_server_node_decommission_has_local_data{job=~\"$server_job\"}",
+              "legendFormat": "node={{node_id}} has_local_data",
+              "refId": "B"
+            },
+            {
+              "expr": "woodpecker_server_node_decommission_safe_to_terminate{job=~\"$server_job\"}",
+              "legendFormat": "node={{node_id}} safe_to_terminate",
+              "refId": "C"
+            }
+          ],
+          "title": "Node Decommission Progress",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "__DATASOURCE_UID__"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 110,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "woodpecker_server_node_decommission_remaining_processors{job=~\"$server_job\"}",
+              "legendFormat": "node={{node_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Node Decommission Remaining Processors",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Compacted Cleanup & Decommission",
+      "type": "row"
     }
   ],
   "refresh": "5s",

--- a/tests/docker/monitor/grafana/templates/dashboard_server.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_server.json
@@ -3098,8 +3098,8 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
-              "legendFormat": "logID={{log_id}} source={{source}}",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "legendFormat": "node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "A"
             }
           ],
@@ -3149,13 +3149,13 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
-              "legendFormat": "reclaimed logID={{log_id}} source={{source}}",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "legendFormat": "reclaimed node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
-              "legendFormat": "marks logID={{log_id}} source={{source}}",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "legendFormat": "marks node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "B"
             }
           ],
@@ -3205,8 +3205,8 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, reason)",
-              "legendFormat": "logID={{log_id}} reason={{reason}}",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, reason)",
+              "legendFormat": "node={{node_id}} logID={{log_id}} reason={{reason}}",
               "refId": "A"
             }
           ],

--- a/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
@@ -661,12 +661,196 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 41
+      },
+      "id": 101,
+      "title": "Progress Frontiers",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 42
+      },
+      "id": 102,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "woodpecker_client_write_frontier_segment{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} write",
+          "refId": "A"
+        },
+        {
+          "expr": "woodpecker_client_compaction_frontier_segment{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} compacted",
+          "refId": "B"
+        },
+        {
+          "expr": "woodpecker_client_truncation_frontier_segment{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} truncated",
+          "refId": "C"
+        }
+      ],
+      "title": "Segment Frontiers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 42
+      },
+      "id": 103,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "woodpecker_client_write_frontier_entry{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} write",
+          "refId": "A"
+        },
+        {
+          "expr": "woodpecker_client_compaction_frontier_entry{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} compacted",
+          "refId": "B"
+        },
+        {
+          "expr": "woodpecker_client_truncation_frontier_entry{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "legendFormat": "logID={{log_id}} truncated",
+          "refId": "C"
+        }
+      ],
+      "title": "Entry Frontiers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 104,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_segment_compaction_failures_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, reason)",
+          "legendFormat": "logID={{log_id}} reason={{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Compaction Failure Rate by Reason",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
       },
       "id": 8,
       "panels": [
@@ -693,7 +877,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 42
+            "y": 59
           },
           "id": 9,
           "options": {
@@ -744,7 +928,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 42
+            "y": 59
           },
           "id": 10,
           "options": {
@@ -795,7 +979,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 42
+            "y": 59
           },
           "id": 11,
           "options": {

--- a/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
@@ -3098,8 +3098,8 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
-              "legendFormat": "logID={{log_id}} source={{source}}",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "legendFormat": "node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "A"
             }
           ],
@@ -3149,13 +3149,13 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
-              "legendFormat": "reclaimed logID={{log_id}} source={{source}}",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "legendFormat": "reclaimed node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
-              "legendFormat": "marks logID={{log_id}} source={{source}}",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "legendFormat": "marks node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "B"
             }
           ],
@@ -3205,8 +3205,8 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, reason)",
-              "legendFormat": "logID={{log_id}} reason={{reason}}",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, reason)",
+              "legendFormat": "node={{node_id}} logID={{log_id}} reason={{reason}}",
               "refId": "A"
             }
           ],

--- a/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
@@ -3044,6 +3044,290 @@
       ],
       "title": "Cost",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 105,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 9
+          },
+          "id": 106,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
+              "legendFormat": "logID={{log_id}} source={{source}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Compacted Cleanup Reclaimed Bytes Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 9
+          },
+          "id": 107,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
+              "legendFormat": "reclaimed logID={{log_id}} source={{source}}",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, source)",
+              "legendFormat": "marks logID={{log_id}} source={{source}}",
+              "refId": "B"
+            }
+          ],
+          "title": "Compacted Cleanup Files & Marks Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 9
+          },
+          "id": 108,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (log_id, reason)",
+              "legendFormat": "logID={{log_id}} reason={{reason}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Compacted Cleanup Footer Failure Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 17
+          },
+          "id": 109,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "woodpecker_server_node_lifecycle_state{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "node={{node_id}} state={{state}}",
+              "refId": "A"
+            },
+            {
+              "expr": "woodpecker_server_node_decommission_has_local_data{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "node={{node_id}} has_local_data",
+              "refId": "B"
+            },
+            {
+              "expr": "woodpecker_server_node_decommission_safe_to_terminate{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "node={{node_id}} safe_to_terminate",
+              "refId": "C"
+            }
+          ],
+          "title": "Node Decommission Progress",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 17
+          },
+          "id": 110,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "woodpecker_server_node_decommission_remaining_processors{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "legendFormat": "node={{node_id}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Node Decommission Remaining Processors",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Compacted Cleanup & Decommission",
+      "type": "row"
     }
   ],
   "refresh": "5s",

--- a/woodpecker/log/log_handle.go
+++ b/woodpecker/log/log_handle.go
@@ -811,6 +811,7 @@ func (l *logHandleImpl) Truncate(ctx context.Context, recordId *LogMessageId) er
 		zap.Int64("truncatedSegmentId", recordId.SegmentId),
 		zap.Int64("truncatedEntryId", recordId.EntryId))
 
+	metrics.SetTruncationFrontier(l.logNs, logIdStr, recordId.SegmentId, recordId.EntryId)
 	metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, "truncate", "success").Inc()
 	metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "truncate", "success").Observe(float64(time.Since(start).Milliseconds()))
 	return nil
@@ -837,6 +838,7 @@ func (l *logHandleImpl) CheckAndSetSegmentTruncatedIfNeed(ctx context.Context) e
 		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, "check_segment_truncated", "error").Observe(float64(time.Since(start).Milliseconds()))
 		return nil
 	}
+	metrics.SetTruncationFrontier(l.logNs, logIdStr, logMeta.Metadata.TruncatedSegmentId, logMeta.Metadata.TruncatedEntryId)
 
 	// 3. Mark segments as truncated in metadata
 	// Get all segments that are before the truncation point

--- a/woodpecker/log/log_handle.go
+++ b/woodpecker/log/log_handle.go
@@ -129,6 +129,8 @@ func NewLogHandle(name string, logId int64, segments map[int64]*meta.SegmentMeta
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	logNs := metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath)
+	logIdStr := strconv.FormatInt(logId, 10)
 	l := &logHandleImpl{
 		Name:                name,
 		Id:                  logId,
@@ -139,7 +141,7 @@ func NewLogHandle(name string, logId int64, segments map[int64]*meta.SegmentMeta
 		lastRolloverTimeMs:  -1,
 		rollingPolicy:       defaultRollingPolicy,
 		cfg:                 cfg,
-		logNs:               metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath),
+		logNs:               logNs,
 		ctx:                 ctx,
 		cancel:              cancel,
 		cleanupDone:         make(chan struct{}),
@@ -147,9 +149,46 @@ func NewLogHandle(name string, logId int64, segments map[int64]*meta.SegmentMeta
 		objectStorageClient: objectStorageClient,
 	}
 	l.LastSegmentId.Store(lastSegmentNo)
+	seedSegmentFrontierMetrics(logNs, logIdStr, segments)
 
 	l.startBackgroundCleanup()
 	return l
+}
+
+type frontierCandidate struct {
+	segmentID int64
+	entryID   int64
+	ok        bool
+}
+
+func (f *frontierCandidate) observe(segmentID, entryID int64) {
+	if !f.ok || segmentID > f.segmentID || (segmentID == f.segmentID && entryID > f.entryID) {
+		f.segmentID = segmentID
+		f.entryID = entryID
+		f.ok = true
+	}
+}
+
+func seedSegmentFrontierMetrics(logNs, logIdStr string, segments map[int64]*meta.SegmentMeta) {
+	var writeFrontier frontierCandidate
+	var compactionFrontier frontierCandidate
+	for _, segmentMeta := range segments {
+		if segmentMeta == nil || segmentMeta.Metadata == nil {
+			continue
+		}
+		md := segmentMeta.Metadata
+		writeFrontier.observe(md.SegNo, md.LastEntryId)
+		switch md.State {
+		case proto.SegmentState_Sealed, proto.SegmentState_Truncated:
+			compactionFrontier.observe(md.SegNo, md.LastEntryId)
+		}
+	}
+	if writeFrontier.ok {
+		metrics.SetWriteFrontier(logNs, logIdStr, writeFrontier.segmentID, writeFrontier.entryID)
+	}
+	if compactionFrontier.ok {
+		metrics.SetCompactionFrontier(logNs, logIdStr, compactionFrontier.segmentID, compactionFrontier.entryID)
+	}
 }
 
 func (l *logHandleImpl) GetLastRecordId(ctx context.Context) (*LogMessageId, error) {

--- a/woodpecker/log/log_handle_test.go
+++ b/woodpecker/log/log_handle_test.go
@@ -23,12 +23,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/etcd/client/v3/concurrency"
 
 	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/metrics"
 	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/meta"
 	"github.com/zilliztech/woodpecker/mocks/mocks_meta"
@@ -70,6 +72,32 @@ func createMockLogHandle(t *testing.T) (*logHandleImpl, *mocks_meta.MetadataProv
 	})
 
 	return logHandle, mockMeta
+}
+
+func TestNewLogHandle_SeedsSegmentFrontierMetrics(t *testing.T) {
+	cfg, err := config.NewConfiguration()
+	require.NoError(t, err)
+	cfg.Minio.BucketName = "frontier-seed-bucket"
+	cfg.Minio.RootPath = "frontier-seed-root"
+	const logID = int64(91001)
+	segments := map[int64]*meta.SegmentMeta{
+		1: {Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Completed, LastEntryId: 10}},
+		2: {Metadata: &proto.SegmentMetadata{SegNo: 2, State: proto.SegmentState_Sealed, LastEntryId: 20}},
+		3: {Metadata: &proto.SegmentMetadata{SegNo: 3, State: proto.SegmentState_Truncated, LastEntryId: 30}},
+		4: {Metadata: &proto.SegmentMetadata{SegNo: 4, State: proto.SegmentState_Active, LastEntryId: 4}},
+	}
+
+	logHandle := NewLogHandle("frontier-seed-log", logID, segments, mocks_meta.NewMetadataProvider(t), nil, cfg, nil, nil).(*logHandleImpl)
+	t.Cleanup(func() {
+		logHandle.stopBackgroundCleanup()
+		logHandle.cancel()
+	})
+
+	logNs, logIdStr := metrics.BuildLogLabels(cfg.Minio.BucketName, cfg.Minio.RootPath, logID)
+	assert.Equal(t, float64(4), testutil.ToFloat64(metrics.WpClientWriteFrontierSegment.WithLabelValues(logNs, logIdStr)))
+	assert.Equal(t, float64(4), testutil.ToFloat64(metrics.WpClientWriteFrontierEntry.WithLabelValues(logNs, logIdStr)))
+	assert.Equal(t, float64(3), testutil.ToFloat64(metrics.WpClientCompactionFrontierSegment.WithLabelValues(logNs, logIdStr)))
+	assert.Equal(t, float64(30), testutil.ToFloat64(metrics.WpClientCompactionFrontierEntry.WithLabelValues(logNs, logIdStr)))
 }
 
 func TestOpenLogReader_ReaderResourceLeak(t *testing.T) {

--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -19,6 +19,7 @@ package segment
 import (
 	"container/list"
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
@@ -130,6 +131,12 @@ func NewSegmentHandle(ctx context.Context, logId int64, logName string, segmentM
 	segmentHandle.lastAccessTime.Store(time.Now().UnixMilli())
 	if canWrite {
 		segmentHandle.canWriteState.Store(true)
+		metrics.SetWriteFrontier(
+			segmentHandle.logNs,
+			strconv.FormatInt(segmentHandle.logId, 10),
+			segmentHandle.segmentId,
+			segmentMeta.Metadata.LastEntryId,
+		)
 		metrics.SetActiveSegmentNodes(
 			segmentHandle.logNs,
 			strconv.FormatInt(segmentHandle.logId, 10),
@@ -370,6 +377,7 @@ func (s *segmentHandleImpl) SendAppendSuccessCallbacks(ctx context.Context, trig
 	// sync lac for this round
 	if newLac >= 0 {
 		s.syncLAC(ctx, newLac)
+		metrics.SetWriteFrontier(s.logNs, strconv.FormatInt(s.logId, 10), s.segmentId, newLac)
 	}
 	for _, element := range elementsToRemove {
 		s.appendOpsQueue.Remove(element)
@@ -1484,6 +1492,8 @@ func (s *segmentHandleImpl) fenceSegmentOnNode(ctx context.Context, node string,
 // until one succeeds. Returns the result from the first successful node.
 func (s *segmentHandleImpl) compactSegmentQuorum(ctx context.Context, quorumInfo *proto.QuorumInfo, expectedLastEntryId int64) (*proto.SegmentMetadata, error) {
 	var lastError error
+	nodeFailures := make([]string, 0, len(quorumInfo.Nodes))
+	logIdStr := strconv.FormatInt(s.logId, 10)
 
 	// Try each node sequentially until one succeeds
 	for i, node := range quorumInfo.Nodes {
@@ -1497,6 +1507,9 @@ func (s *segmentHandleImpl) compactSegmentQuorum(ctx context.Context, quorumInfo
 
 		cli, err := s.ClientPool.GetLogStoreClient(ctx, node)
 		if err != nil {
+			reason := classifyCompactionFailureReason(err)
+			metrics.WpSegmentCompactionFailuresTotal.WithLabelValues(s.logNs, logIdStr, reason).Inc()
+			nodeFailures = append(nodeFailures, fmt.Sprintf("%s:%s", node, reason))
 			logger.Ctx(ctx).Warn("Failed to get logstore client for compaction",
 				zap.String("logName", s.logName),
 				zap.Int64("logId", s.logId),
@@ -1511,6 +1524,9 @@ func (s *segmentHandleImpl) compactSegmentQuorum(ctx context.Context, quorumInfo
 		// if its local data is behind expectedLastEntryId, so we fall through to the next node.
 		compactSegMetaInfo, compactErr := cli.SegmentCompact(ctx, s.bucketName, s.rootPath, s.logId, s.segmentId, expectedLastEntryId)
 		if compactErr != nil {
+			reason := classifyCompactionFailureReason(compactErr)
+			metrics.WpSegmentCompactionFailuresTotal.WithLabelValues(s.logNs, logIdStr, reason).Inc()
+			nodeFailures = append(nodeFailures, fmt.Sprintf("%s:%s", node, reason))
 			logger.Ctx(ctx).Warn("Segment compaction failed on node, trying next",
 				zap.String("logName", s.logName),
 				zap.Int64("logId", s.logId),
@@ -1542,12 +1558,29 @@ func (s *segmentHandleImpl) compactSegmentQuorum(ctx context.Context, quorumInfo
 		zap.String("logName", s.logName),
 		zap.Int64("logId", s.logId),
 		zap.Int64("segmentId", s.segmentId),
-		zap.Int("totalNodes", len(quorumInfo.Nodes)))
+		zap.Int64("expectedLastEntryId", expectedLastEntryId),
+		zap.Int("totalNodes", len(quorumInfo.Nodes)),
+		zap.Strings("nodeFailures", nodeFailures))
 
 	if lastError != nil {
 		return nil, lastError
 	}
 	return nil, werr.ErrSegmentHandleCompactionFailed.WithCauseErrMsg("all quorum nodes failed compaction")
+}
+
+func classifyCompactionFailureReason(err error) string {
+	switch {
+	case err == nil:
+		return "none"
+	case errors.Is(err, werr.ErrSegmentCompactionDataBehind):
+		return "data_behind"
+	case errors.Is(err, werr.ErrInvalidLACAlignment):
+		return "invalid_lac_alignment"
+	case werr.IsTransportError(err), werr.IsRetryableErr(err), errors.Is(err, context.DeadlineExceeded):
+		return "transient"
+	default:
+		return "other"
+	}
 }
 
 // notifySegmentCompactedTimeout bounds each per-node NotifySegmentCompacted RPC so a node
@@ -1669,6 +1702,9 @@ func (s *segmentHandleImpl) FenceAndComplete(ctx context.Context) (int64, error)
 			zap.Int64("previousLastAddConfirmed", s.lastAddConfirmed.Load()),
 			zap.Int64("newLastAddConfirmed", lastEntryId))
 		s.lastAddConfirmed.Store(lastEntryId)
+	}
+	if lastEntryId >= 0 {
+		metrics.SetWriteFrontier(s.logNs, logIdStr, s.segmentId, lastEntryId)
 	}
 	// Use the actual lastEntryId returned from FenceSegment, even in error cases
 	// because these "errors" indicate the segment was already fenced, not a failure
@@ -1802,6 +1838,7 @@ func (s *segmentHandleImpl) Compact(ctx context.Context) error {
 			zap.Int64("segmentId", s.segmentId),
 			zap.Error(updateMetaErr))
 	} else {
+		metrics.SetCompactionFrontier(s.logNs, logIdStr, s.segmentId, compactSegMetaInfo.LastEntryId)
 		logger.Ctx(ctx).Info("Successfully updated segment metadata after compaction",
 			zap.String("logName", s.logName),
 			zap.Int64("logId", s.logId),

--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -1493,6 +1493,7 @@ func (s *segmentHandleImpl) fenceSegmentOnNode(ctx context.Context, node string,
 func (s *segmentHandleImpl) compactSegmentQuorum(ctx context.Context, quorumInfo *proto.QuorumInfo, expectedLastEntryId int64) (*proto.SegmentMetadata, error) {
 	var lastError error
 	nodeFailures := make([]string, 0, len(quorumInfo.Nodes))
+	failureReasons := make([]string, 0, len(quorumInfo.Nodes))
 	logIdStr := strconv.FormatInt(s.logId, 10)
 
 	// Try each node sequentially until one succeeds
@@ -1508,8 +1509,8 @@ func (s *segmentHandleImpl) compactSegmentQuorum(ctx context.Context, quorumInfo
 		cli, err := s.ClientPool.GetLogStoreClient(ctx, node)
 		if err != nil {
 			reason := classifyCompactionFailureReason(err)
-			metrics.WpSegmentCompactionFailuresTotal.WithLabelValues(s.logNs, logIdStr, reason).Inc()
 			nodeFailures = append(nodeFailures, fmt.Sprintf("%s:%s", node, reason))
+			failureReasons = append(failureReasons, reason)
 			logger.Ctx(ctx).Warn("Failed to get logstore client for compaction",
 				zap.String("logName", s.logName),
 				zap.Int64("logId", s.logId),
@@ -1525,8 +1526,8 @@ func (s *segmentHandleImpl) compactSegmentQuorum(ctx context.Context, quorumInfo
 		compactSegMetaInfo, compactErr := cli.SegmentCompact(ctx, s.bucketName, s.rootPath, s.logId, s.segmentId, expectedLastEntryId)
 		if compactErr != nil {
 			reason := classifyCompactionFailureReason(compactErr)
-			metrics.WpSegmentCompactionFailuresTotal.WithLabelValues(s.logNs, logIdStr, reason).Inc()
 			nodeFailures = append(nodeFailures, fmt.Sprintf("%s:%s", node, reason))
+			failureReasons = append(failureReasons, reason)
 			logger.Ctx(ctx).Warn("Segment compaction failed on node, trying next",
 				zap.String("logName", s.logName),
 				zap.Int64("logId", s.logId),
@@ -1554,11 +1555,14 @@ func (s *segmentHandleImpl) compactSegmentQuorum(ctx context.Context, quorumInfo
 	}
 
 	// All nodes failed
+	failureReason := summarizeCompactionFailureReasons(failureReasons)
+	metrics.WpSegmentCompactionFailuresTotal.WithLabelValues(s.logNs, logIdStr, failureReason).Inc()
 	logger.Ctx(ctx).Warn("Compaction failed on all quorum nodes",
 		zap.String("logName", s.logName),
 		zap.Int64("logId", s.logId),
 		zap.Int64("segmentId", s.segmentId),
 		zap.Int64("expectedLastEntryId", expectedLastEntryId),
+		zap.String("failureReason", failureReason),
 		zap.Int("totalNodes", len(quorumInfo.Nodes)),
 		zap.Strings("nodeFailures", nodeFailures))
 
@@ -1568,19 +1572,48 @@ func (s *segmentHandleImpl) compactSegmentQuorum(ctx context.Context, quorumInfo
 	return nil, werr.ErrSegmentHandleCompactionFailed.WithCauseErrMsg("all quorum nodes failed compaction")
 }
 
+const (
+	compactionFailureReasonNone                = "none"
+	compactionFailureReasonDataBehind          = "data_behind"
+	compactionFailureReasonInvalidLACAlignment = "invalid_lac_alignment"
+	compactionFailureReasonTransient           = "transient"
+	compactionFailureReasonOther               = "other"
+	compactionFailureReasonMixed               = "mixed"
+)
+
 func classifyCompactionFailureReason(err error) string {
 	switch {
 	case err == nil:
-		return "none"
+		return compactionFailureReasonNone
 	case errors.Is(err, werr.ErrSegmentCompactionDataBehind):
-		return "data_behind"
+		return compactionFailureReasonDataBehind
 	case errors.Is(err, werr.ErrInvalidLACAlignment):
-		return "invalid_lac_alignment"
+		return compactionFailureReasonInvalidLACAlignment
 	case werr.IsTransportError(err), werr.IsRetryableErr(err), errors.Is(err, context.DeadlineExceeded):
-		return "transient"
+		return compactionFailureReasonTransient
 	default:
-		return "other"
+		return compactionFailureReasonOther
 	}
+}
+
+func summarizeCompactionFailureReasons(reasons []string) string {
+	var first string
+	for _, reason := range reasons {
+		if reason == "" || reason == compactionFailureReasonNone {
+			continue
+		}
+		if first == "" {
+			first = reason
+			continue
+		}
+		if reason != first {
+			return compactionFailureReasonMixed
+		}
+	}
+	if first == "" {
+		return compactionFailureReasonOther
+	}
+	return first
 }
 
 // notifySegmentCompactedTimeout bounds each per-node NotifySegmentCompacted RPC so a node

--- a/woodpecker/segment/segment_handle_test.go
+++ b/woodpecker/segment/segment_handle_test.go
@@ -5540,6 +5540,46 @@ func TestCompactSegmentQuorum_SkipsLaggingNode(t *testing.T) {
 	assert.Equal(t, expectedLAC, result.LastEntryId)
 }
 
+func TestClassifyCompactionFailureReason(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "data behind",
+			err:  werr.ErrSegmentCompactionDataBehind.WithCauseErrMsg("behind"),
+			want: "data_behind",
+		},
+		{
+			name: "invalid lac alignment",
+			err:  werr.ErrInvalidLACAlignment.WithCauseErrMsg("bad lac"),
+			want: "invalid_lac_alignment",
+		},
+		{
+			name: "retryable",
+			err:  werr.ErrMinioOperationErr.WithCauseErrMsg("timeout"),
+			want: "transient",
+		},
+		{
+			name: "deadline",
+			err:  context.DeadlineExceeded,
+			want: "transient",
+		},
+		{
+			name: "other",
+			err:  errors.New("plain failure"),
+			want: "other",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifyCompactionFailureReason(tt.err))
+		})
+	}
+}
+
 // === doCloseWritingAndUpdateMetaIfNecessaryUnsafe tests ===
 
 func TestDoCloseWriting_NotWritable(t *testing.T) {

--- a/woodpecker/segment/segment_handle_test.go
+++ b/woodpecker/segment/segment_handle_test.go
@@ -25,12 +25,14 @@ import (
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/zilliztech/woodpecker/common/channel"
 	"github.com/zilliztech/woodpecker/common/config"
 	"github.com/zilliztech/woodpecker/common/logger"
+	"github.com/zilliztech/woodpecker/common/metrics"
 	"github.com/zilliztech/woodpecker/common/tracer"
 	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/meta"
@@ -5456,12 +5458,15 @@ func TestCompactSegmentQuorum_AllNodesBehindFails(t *testing.T) {
 	}
 	sh := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, false, nil)
 	impl := sh.(*segmentHandleImpl)
+	failuresBefore := testutil.ToFloat64(metrics.WpSegmentCompactionFailuresTotal.WithLabelValues(impl.logNs, "1", compactionFailureReasonDataBehind))
 
 	quorum := &proto.QuorumInfo{Id: 1, Nodes: []string{"node1", "node2"}}
 	result, err := impl.compactSegmentQuorum(context.Background(), quorum, expectedLAC)
 	assert.Nil(t, result)
 	assert.Error(t, err)
 	assert.True(t, werr.ErrSegmentCompactionDataBehind.Is(err), "surfaced error should be data-behind, got %v", err)
+	assert.Equal(t, failuresBefore+1,
+		testutil.ToFloat64(metrics.WpSegmentCompactionFailuresTotal.WithLabelValues(impl.logNs, "1", compactionFailureReasonDataBehind)))
 }
 
 func TestCompactSegmentQuorum_SecondNodeSucceeds(t *testing.T) {
@@ -5491,11 +5496,14 @@ func TestCompactSegmentQuorum_SecondNodeSucceeds(t *testing.T) {
 	}
 	sh := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, false, nil)
 	impl := sh.(*segmentHandleImpl)
+	failuresBefore := testutil.ToFloat64(metrics.WpSegmentCompactionFailuresTotal.WithLabelValues(impl.logNs, "1", compactionFailureReasonOther))
 
 	quorum := &proto.QuorumInfo{Id: 1, Nodes: []string{"node1", "node2"}}
 	result, err := impl.compactSegmentQuorum(context.Background(), quorum, int64(-1))
 	assert.NoError(t, err)
 	assert.Equal(t, expectedMeta, result)
+	assert.Equal(t, failuresBefore,
+		testutil.ToFloat64(metrics.WpSegmentCompactionFailuresTotal.WithLabelValues(impl.logNs, "1", compactionFailureReasonOther)))
 }
 
 // TestCompactSegmentQuorum_SkipsLaggingNode is the end-to-end guard for the silent data-loss

--- a/woodpecker/woodpecker_client.go
+++ b/woodpecker/woodpecker_client.go
@@ -230,8 +230,13 @@ func openLogUnsafe(ctx context.Context, metadata meta.MetadataProvider, logName 
 		logger.Ctx(ctx).Warn("open log failed", zap.String("logName", logName), zap.Error(err))
 		return nil, err
 	}
-	newLogHandle := log.NewLogHandle(logName, logMeta.Metadata.GetLogId(), segmentsMeta, metadata, clientPool, cfg, selectQuorumFunc, objectStorageClient)
-	metrics.WpLogNameIdMapping.WithLabelValues(metrics.BuildLogNs(cfg.Minio.BucketName, cfg.Minio.RootPath), logName).Set(float64(logMeta.Metadata.GetLogId()))
+	logID := logMeta.Metadata.GetLogId()
+	logNs, logIdStr := metrics.BuildLogLabels(cfg.Minio.BucketName, cfg.Minio.RootPath, logID)
+	if logMeta.Metadata.GetTruncatedSegmentId() >= 0 {
+		metrics.SetTruncationFrontier(logNs, logIdStr, logMeta.Metadata.GetTruncatedSegmentId(), logMeta.Metadata.GetTruncatedEntryId())
+	}
+	newLogHandle := log.NewLogHandle(logName, logID, segmentsMeta, metadata, clientPool, cfg, selectQuorumFunc, objectStorageClient)
+	metrics.WpLogNameIdMapping.WithLabelValues(logNs, logName).Set(float64(logID))
 	return newLogHandle, nil
 }
 

--- a/woodpecker/woodpecker_client_test.go
+++ b/woodpecker/woodpecker_client_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/zilliztech/woodpecker/common/config"
 	etcdutil "github.com/zilliztech/woodpecker/common/etcd"
+	"github.com/zilliztech/woodpecker/common/metrics"
 	"github.com/zilliztech/woodpecker/common/tracer"
 	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/meta"
@@ -158,6 +160,45 @@ func TestOpenLogUnsafe_Success(t *testing.T) {
 	handle, err := openLogUnsafe(ctx, mockMeta, "test-log", mockPool, cfg, selectFunc, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, handle)
+}
+
+func TestOpenLogUnsafe_SeedsTruncationFrontier(t *testing.T) {
+	mockMeta := mocks_meta.NewMetadataProvider(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	ctx := context.Background()
+	cfg := &config.Configuration{
+		Woodpecker: config.WoodpeckerConfig{
+			Client: config.ClientConfig{
+				SegmentRollingPolicy: config.SegmentRollingPolicyConfig{
+					MaxSize:     config.ByteSize(100000000),
+					MaxInterval: config.NewDurationSecondsFromInt(800),
+					MaxBlocks:   1000,
+				},
+			},
+		},
+		Minio: config.MinioConfig{
+			BucketName: "truncation-frontier-bucket",
+			RootPath:   "truncation-frontier-root",
+		},
+	}
+
+	const logID = int64(91002)
+	logMeta := &meta.LogMeta{
+		Metadata: &proto.LogMeta{LogId: logID, TruncatedSegmentId: 7, TruncatedEntryId: 88},
+		Revision: 1,
+	}
+	mockMeta.EXPECT().OpenLog(mock.Anything, "test-log").Return(logMeta, map[int64]*meta.SegmentMeta{}, nil).Once()
+
+	handle, err := openLogUnsafe(ctx, mockMeta, "test-log", mockPool, cfg, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+	t.Cleanup(func() {
+		_ = handle.Close(ctx)
+	})
+
+	logNs, logIdStr := metrics.BuildLogLabels(cfg.Minio.BucketName, cfg.Minio.RootPath, logID)
+	assert.Equal(t, float64(7), testutil.ToFloat64(metrics.WpClientTruncationFrontierSegment.WithLabelValues(logNs, logIdStr)))
+	assert.Equal(t, float64(88), testutil.ToFloat64(metrics.WpClientTruncationFrontierEntry.WithLabelValues(logNs, logIdStr)))
 }
 
 func TestOpenLogUnsafe_Error(t *testing.T) {


### PR DESCRIPTION
issue: #238

## Summary
- Add client progress frontier gauges for write, compaction, and truncation.
- Add compaction failure reason counters plus compacted cleanup footer, mark, and reclaim counters.
- Expose node lifecycle and decommission drain gauges.
- Add source and reclaimed-byte fields to compacted cleanup logs.
- Update both Docker and K8s Grafana dashboard templates with the new panels.

## Notes
- No orphan-mark clear metric is added because data.compacted is a durable tombstone and is cleared by truncate/delete GC, not by compacted cleanup.

## Tests
- go test -count=1 ./common/metrics ./server ./woodpecker/segment ./woodpecker/log
- go test -count=1 ./tests/k8s/monitor -run Dashboard
- go test -count=1 ./tests/docker/monitor -run Dashboard
- jq empty tests/docker/monitor/grafana/templates/dashboard_client.json tests/docker/monitor/grafana/templates/dashboard_server.json tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json