### PR TITLE
fix(server): pin resolved advertise address

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -1024,6 +1024,8 @@ func (s *Server) waitAndStartCurrentNode(ctx context.Context) error {
 
 		resolvedIP := wpNet.ResolveAdvertiseAddr(s.serverConfig.AdvertiseAddr)
 		if resolvedIP != nil {
+			// Pin the resolved IP so memberlist does not perform a second DNS lookup.
+			s.serverConfig.AdvertiseAddr = resolvedIP.String()
 			break
 		}
 

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -211,6 +211,31 @@ func TestWaitAndStartCurrentNode_Success(t *testing.T) {
 	}
 }
 
+func TestWaitAndStartCurrentNode_UsesResolvedAdvertiseIP(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	s := createTestServer(ctx, &membership.ServerConfig{
+		NodeID:               "test-node-resolved-advertise-ip",
+		AdvertiseAddr:        "localhost",
+		BindPort:             0,
+		AdvertisePort:        0,
+		ServicePort:          0,
+		AdvertiseServicePort: 0,
+		ResourceGroup:        "default",
+		AZ:                   "default",
+		Tags:                 map[string]string{"role": "test"},
+	})
+
+	err := s.waitAndStartCurrentNode(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", s.serverConfig.AdvertiseAddr)
+
+	if s.serverNode != nil {
+		require.NoError(t, s.serverNode.Shutdown())
+	}
+}
+
 func TestGetStartupErrCh(t *testing.T) {
 	s := createTestServer(context.Background(), &membership.ServerConfig{})
 	defer s.cancel()


### PR DESCRIPTION
## Summary

- retain the IP returned by the existing advertise-hostname readiness check
- pass the stable IP to memberlist instead of resolving the hostname a second time
- add a regression test covering hostname-to-IP pinning before node startup

## Root cause

`waitAndStartCurrentNode` waited until the configured gossip advertise hostname resolved, but discarded the resolved IP. `membership.NewServerNode` then performed another DNS lookup. During Kubernetes Headless Service propagation, that second lookup could fail after the readiness lookup had succeeded, leaving a partially initialized memberlist listener and causing subsequent retries to report `address already in use`.

## Test plan

- `go test -race -short ./server ./common/net ./common/membership -count=1`
- `go test -run '^$' ./...`
- `gofmt -d server/service.go server/service_test.go`
- `git diff --check`
