### PR TITLE
fix(fence): require ack-quorum coverage when resolving the completion LAC

### DIFF
--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -1425,42 +1425,44 @@ func (s *segmentHandleImpl) completeSegmentOnNode(ctx context.Context, node stri
 	}
 }
 
-// calculateLAC calculates the Log All Committed (LAC) based on the quorum responses.
-// LAC is the highest entry ID that is guaranteed to be committed on a majority of nodes.
-// For example: if nodes return [4, 6, 7] and ackQuorum is 2, then LAC is 6
-// because entries 1-6 are committed on at least 2 nodes (majority).
-func (s *segmentHandleImpl) calculateLAC(results []int64, ackQuorum int) int64 {
-	// Filter out negative values (e.g. -1 returned by nodes with no data).
-	// Only non-negative entry IDs represent real committed data.
-	validResults := make([]int64, 0, len(results))
-	for _, r := range results {
-		if r >= 0 {
-			validResults = append(validResults, r)
-		}
-	}
-	if len(validResults) == 0 {
-		return -1
+// resolveFenceLAC picks the completion target from the fence responses: the highest
+// entry ID that at least ackQuorum responding replicas hold. Sorted ascending, that is
+// the ackQuorum-th largest element, so exactly ackQuorum replicas cover it and no
+// larger value does.
+//
+// Every element is a successful fence response -- failed nodes take the result.err
+// branch and never reach here -- so a -1 is an honest "I hold nothing" vote against
+// every entry ID >= 0 and must be counted. Dropping it would shrink the sample while
+// ackQuorum stays fixed, and the resulting target could exceed what any ack quorum
+// covers; completion would then retry forever, because a behind replica has no way to
+// catch up to an entry it never received.
+//
+// Fewer than ackQuorum responses means no value can be shown to have quorum coverage,
+// which is a failure to prove rather than a reason to pick a smaller element.
+func (s *segmentHandleImpl) resolveFenceLAC(results []int64, ackQuorum int) (int64, error) {
+	if len(results) < ackQuorum {
+		return -1, werr.ErrAppendOpQuorumFailed.WithCauseErrMsg(
+			fmt.Sprintf("insufficient successful fence responses: got %d, need %d", len(results), ackQuorum))
 	}
 
-	// Sort in ascending order
-	sort.Slice(validResults, func(i, j int) bool {
-		return validResults[i] < validResults[j]
+	// Sort a copy in ascending order, leaving the caller's slice untouched.
+	sorted := make([]int64, len(results))
+	copy(sorted, results)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i] < sorted[j]
 	})
 
-	// LAC is the (len - ackQuorum)th element, ensuring at least ackQuorum nodes
-	// have committed up to this entry.
-	lacIndex := len(validResults) - ackQuorum
-	if lacIndex < 0 {
-		lacIndex = 0
-	}
-	return validResults[lacIndex]
+	return sorted[len(sorted)-ackQuorum], nil
 }
 
 // fenceSegmentQuorum sends FenceSegment requests to all quorum nodes
 // and calculates the Log All Committed (LAC) based on majority consensus
 func (s *segmentHandleImpl) fenceSegmentQuorum(ctx context.Context, quorumInfo *proto.QuorumInfo) (int64, error) {
-	nodeCount := len(quorumInfo.Nodes)                         // always es=len(nodes)
-	ensembleCoverage := int(quorumInfo.Es - quorumInfo.Aq + 1) // currently always es=3=wq,aq=2, so ec=es-aq+1=2=aq
+	nodeCount := len(quorumInfo.Nodes) // always es=len(nodes)
+	// Requiring aq responses subsumes the ensemble-coverage bound ec=es-aq+1: aq >= ec
+	// always holds, so the fence still intersects every possible ack quorum. For the
+	// reachable ensemble sizes (3 and 5) the two are equal, so the threshold is unchanged.
+	ackQuorum := int(quorumInfo.Aq)
 
 	// Channel to collect results from all nodes
 	resultChan := make(chan nodeFenceResult, nodeCount)
@@ -1499,22 +1501,21 @@ func (s *segmentHandleImpl) fenceSegmentQuorum(ctx context.Context, quorumInfo *
 		}
 	}
 
-	// Check if we have enough successful responses for ack quorum
-	if len(successResults) < ensembleCoverage {
+	// Resolve the completion target from the successful responses. This also enforces
+	// that enough nodes responded to prove quorum coverage in the first place.
+	lac, resolveErr := s.resolveFenceLAC(successResults, ackQuorum)
+	if resolveErr != nil {
 		logger.Ctx(ctx).Warn("Insufficient successful responses for quorum fence",
 			zap.String("logName", s.logName),
 			zap.Int64("logId", s.logId),
 			zap.Int64("segmentId", s.segmentId),
 			zap.Int("successCount", len(successResults)),
-			zap.Int("requiredEC", ensembleCoverage))
+			zap.Int("requiredAckQuorum", ackQuorum))
 		if lastError != nil {
 			return -1, lastError
 		}
-		return -1, werr.ErrAppendOpQuorumFailed.WithCauseErrMsg("insufficient successful fence responses")
+		return -1, resolveErr
 	}
-
-	// Calculate LAC (Log All Committed) from successful results
-	lac := s.calculateLAC(successResults, ensembleCoverage)
 
 	logger.Ctx(ctx).Info("Calculated LAC from quorum fence responses",
 		zap.String("logName", s.logName),
@@ -1522,7 +1523,7 @@ func (s *segmentHandleImpl) fenceSegmentQuorum(ctx context.Context, quorumInfo *
 		zap.Int64("segmentId", s.segmentId),
 		zap.Int64("lac", lac),
 		zap.Int("successCount", len(successResults)),
-		zap.Int("ensembleCoverage", ensembleCoverage),
+		zap.Int("ackQuorum", ackQuorum),
 		zap.Int64s("allResults", successResults))
 
 	return lac, nil

--- a/woodpecker/segment/segment_handle_test.go
+++ b/woodpecker/segment/segment_handle_test.go
@@ -3150,7 +3150,7 @@ func TestSegmentHandle_HandleAppendRequestFailure_RetrySubmitFailed(t *testing.T
 	workerBlocked.Done()
 }
 
-func TestCalculateLAC(t *testing.T) {
+func TestResolveFenceLAC(t *testing.T) {
 	s := &segmentHandleImpl{}
 
 	tests := []struct {
@@ -3158,6 +3158,7 @@ func TestCalculateLAC(t *testing.T) {
 		results   []int64
 		ackQuorum int
 		expected  int64
+		wantErr   bool
 	}{
 		{
 			name:      "normal 3 nodes",
@@ -3172,16 +3173,20 @@ func TestCalculateLAC(t *testing.T) {
 			expected:  5,
 		},
 		{
-			name:      "one node empty returns -1",
+			// Entry 0 lives on a single replica, so it was never acked and cannot
+			// become the completion target: only that one replica could ever cover it.
+			name:      "one node empty holds the target back",
 			results:   []int64{0, -1},
 			ackQuorum: 2,
-			expected:  0,
+			expected:  -1,
 		},
 		{
-			name:      "bug scenario: fence with [0, -1] ackQuorum=2",
-			results:   []int64{0, -1},
+			// The production wedge: fence saw [0,-1,-1] and returned 0, which only one
+			// of three replicas could finalize at, so completion never reached quorum.
+			name:      "regression: fence with [0, -1, -1] ackQuorum=2",
+			results:   []int64{0, -1, -1},
 			ackQuorum: 2,
-			expected:  0,
+			expected:  -1,
 		},
 		{
 			name:      "two valid one empty",
@@ -3193,7 +3198,7 @@ func TestCalculateLAC(t *testing.T) {
 			name:      "multiple entries with one empty node",
 			results:   []int64{2, -1},
 			ackQuorum: 2,
-			expected:  2,
+			expected:  -1,
 		},
 		{
 			name:      "all nodes empty",
@@ -3208,10 +3213,10 @@ func TestCalculateLAC(t *testing.T) {
 			expected:  -1,
 		},
 		{
-			name:      "empty results",
+			name:      "empty results cannot prove coverage",
 			results:   []int64{},
 			ackQuorum: 2,
-			expected:  -1,
+			wantErr:   true,
 		},
 		{
 			name:      "single valid node",
@@ -3220,10 +3225,12 @@ func TestCalculateLAC(t *testing.T) {
 			expected:  0,
 		},
 		{
-			name:      "ackQuorum exceeds valid count uses index 0",
+			// Fewer responses than the ack quorum proves nothing; the old clamp
+			// returned 3 here, a target only one replica could ever cover.
+			name:      "fewer responses than ackQuorum cannot prove coverage",
 			results:   []int64{3},
 			ackQuorum: 2,
-			expected:  3,
+			wantErr:   true,
 		},
 		{
 			name:      "three valid nodes ackQuorum=2",
@@ -3251,12 +3258,70 @@ func TestCalculateLAC(t *testing.T) {
 			original := make([]int64, len(tt.results))
 			copy(original, tt.results)
 
-			got := s.calculateLAC(tt.results, tt.ackQuorum)
-			assert.Equal(t, tt.expected, got)
+			got, err := s.resolveFenceLAC(tt.results, tt.ackQuorum)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Equal(t, int64(-1), got)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, got)
+			}
 
 			// verify input slice is not mutated
 			assert.Equal(t, original, tt.results, "input slice should not be mutated")
 		})
+	}
+}
+
+// TestResolveFenceLACCoverageInvariant exhaustively checks the property the completion
+// path depends on: the returned target must be covered by at least ackQuorum responding
+// replicas, and must be the largest value with that coverage. A target above the bound
+// can never be met -- a behind replica has no way to catch up to an entry it never
+// received -- so completion would retry forever and wedge the log.
+func TestResolveFenceLACCoverageInvariant(t *testing.T) {
+	s := &segmentHandleImpl{}
+	values := []int64{-1, 0, 1, 3}
+
+	coveredBy := func(results []int64, v int64) int {
+		n := 0
+		for _, r := range results {
+			if r >= v {
+				n++
+			}
+		}
+		return n
+	}
+
+	var walk func(prefix []int64, depth int)
+	walk = func(prefix []int64, depth int) {
+		if depth == 0 {
+			for ackQuorum := 1; ackQuorum <= len(prefix); ackQuorum++ {
+				lac, err := s.resolveFenceLAC(prefix, ackQuorum)
+				if !assert.NoError(t, err, "results=%v ackQuorum=%d", prefix, ackQuorum) {
+					continue
+				}
+
+				assert.GreaterOrEqual(t, coveredBy(prefix, lac), ackQuorum,
+					"results=%v ackQuorum=%d: lac=%d is covered by too few replicas", prefix, ackQuorum, lac)
+
+				// No larger candidate may reach the same coverage, i.e. lac is maximal
+				// and the fence is not truncating acked data.
+				for _, cand := range prefix {
+					if cand > lac {
+						assert.Less(t, coveredBy(prefix, cand), ackQuorum,
+							"results=%v ackQuorum=%d: lac=%d but %d also has quorum coverage", prefix, ackQuorum, lac, cand)
+					}
+				}
+			}
+			return
+		}
+		for _, v := range values {
+			walk(append(prefix, v), depth-1)
+		}
+	}
+
+	for n := 1; n <= 4; n++ {
+		walk(make([]int64, 0, n), n)
 	}
 }
 

--- a/woodpecker/segment/segment_handle_test.go
+++ b/woodpecker/segment/segment_handle_test.go
@@ -5746,6 +5746,41 @@ func TestFenceSegmentQuorum_InsufficientResponses(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// TestFenceSegmentQuorum_FewerNodesThanAckQuorum covers the case where every node
+// answers successfully yet the responses still cannot prove ack-quorum coverage, so
+// there is no node error to surface. Fence must refuse rather than hand completion a
+// target only a minority of replicas holds.
+func TestFenceSegmentQuorum_FewerNodesThanAckQuorum(t *testing.T) {
+	mockMetadata := mocks_meta.NewMetadataProvider(t)
+	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	cfg := &config.Configuration{
+		Woodpecker: config.WoodpeckerConfig{
+			Client: config.ClientConfig{
+				SegmentAppend: config.SegmentAppendConfig{QueueSize: 10, MaxRetries: 2},
+			},
+		},
+	}
+
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil)
+	mockClient.EXPECT().FenceSegment(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(int64(5), nil)
+
+	segmentMeta := &meta.SegmentMeta{
+		Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Active, LastEntryId: -1},
+		Revision: 1,
+	}
+	sh := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, false, nil)
+	impl := sh.(*segmentHandleImpl)
+
+	// One node cannot establish coverage for an ack quorum of two.
+	quorum := &proto.QuorumInfo{Id: 1, Es: 1, Aq: 2, Wq: 1, Nodes: []string{"node1"}}
+	lastEntryId, err := impl.fenceSegmentQuorum(context.Background(), quorum)
+	assert.Error(t, err)
+	assert.Equal(t, int64(-1), lastEntryId)
+	assert.Contains(t, err.Error(), "insufficient successful fence responses")
+}
+
 // === syncLACToQuorumAsync tests ===
 
 func TestSyncLACToQuorumAsync_GetQuorumInfoError(t *testing.T) {


### PR DESCRIPTION
Fixes #252

## Problem

`calculateLAC` filtered out `-1` responses before applying its order statistic, then clamped the resulting negative index to `0`:

```go
for _, r := range results { if r >= 0 { validResults = append(validResults, r) } }
lacIndex := len(validResults) - ackQuorum
if lacIndex < 0 { lacIndex = 0 }
```

Failed nodes take the `result.err != nil` branch and never reach that slice, so every element is a successful fence response and a `-1` is an honest "I hold nothing" vote — a vote against every entry ID `>= 0`. Discarding it shrinks the sample while `ackQuorum` stays fixed, so the index goes negative and the clamp returns the minimum survivor instead of failing.

With `[0,-1,-1]` and `aq=2` the filter left `[0]`, the index clamped to `0`, and fence returned `0` — a target only one of three replicas could ever cover.

Since #250 the complete phase correctly refuses to publish `Completed` unless `Aq` finalized replicas locally cover the target, and no replica can catch up to an entry it never received. So an over-estimated target wedges the log permanently: `fenceAllActiveSegments` keeps failing, WAL open fails, and every write to that pchannel is blocked. Issue #252 has the production trace — a chaos-killed node left `rootcoord-dml_0` retrying for 3+ hours with `qualifiedCount=1 requiredAckQuorum=2`.

## Change

`calculateLAC` becomes `resolveFenceLAC`, which folds the response-count gate into the computation so the precondition that makes the index safe lives next to the index:

```go
func (s *segmentHandleImpl) resolveFenceLAC(results []int64, ackQuorum int) (int64, error) {
	if len(results) < ackQuorum {
		return -1, werr.ErrAppendOpQuorumFailed.WithCauseErrMsg(...)
	}
	sorted := make([]int64, len(results))
	copy(sorted, results)
	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
	return sorted[len(sorted)-ackQuorum], nil
}
```

- All responses are counted. On an ascending sort, `len - ackQuorum` is the `ackQuorum`-th largest, i.e. the largest value covered by at least `ackQuorum` responders — the index formula was always right, only the input to it was wrong.
- Fewer than `ackQuorum` responses is a failure to prove coverage, not a reason to clamp.
- The input slice is copied, so the caller's slice is still untouched now that there is no filter pass.
- The call site passes `quorumInfo.Aq` instead of `ensembleCoverage`. The parameter was named `ackQuorum` but received `Es-Aq+1`; the two mean different things. `aq >= ec` always holds, so requiring `aq` responses still guarantees the fence intersects every possible ack quorum, and for the reachable ensemble sizes (`GetEnsembleSize()` returns 3 or 5) `ec == aq`, so the threshold value is unchanged.

## Tests

The existing table asserted the buggy answers, so this is not a coverage gap being filled but wrong expectations being corrected:

| results | aq | before | after |
|---|---|---|---|
| `[0,-1]` | 2 | `0` | `-1` |
| `[2,-1]` | 2 | `2` | `-1` |
| `[3]` | 2 | `3` | error |
| `[]` | 2 | `-1` | error |

All other rows are unchanged. Added:

- a regression row for the production shape `[0,-1,-1] aq=2 -> -1`;
- `TestResolveFenceLACCoverageInvariant`, an exhaustive check over all response vectors of length 1..4 drawn from `{-1,0,1,3}` and every valid `ackQuorum`, asserting the target is covered by at least `ackQuorum` responders **and** is the largest value with that coverage — so the fix cannot drift into truncating acked data either.

`go test ./woodpecker/segment/ ./woodpecker/log/ ./woodpecker/client/` passes.

## Relationship to #92

d54940e (#92) added the filter to fix the opposite direction: an empty/restarted node's `-1` dragging LAC down and causing readers to EOF. That traded a truncation bug for an over-estimation bug, which stayed silent until #250 started enforcing qualified coverage.

Removing the filter is correct provided a `-1` from a **successful** fence is truthful. `segmentProcessor.Fence` opens the writer in recover mode (`getOrCreateSegmentWriter(ctx, true)`) and returns an error rather than a value when recovery fails, so a `-1` that reaches this function means the replica genuinely holds nothing. The new property test pins the maximality half of the invariant, which is exactly the direction #92 cared about.

## Rollout note

This does not by itself repair segments already poisoned by the old behaviour. `Finalize` records `footer.LAC = lac` (the requested value, not the local tail), so the behind replicas in #252 hold `footer.LAC=0` while returning `-1`.

- Against a pre-#250 server, a finalized writer returns `(localLastEntryId, nil)` for any later `Finalize`, so once fence computes `-1` those segments complete and self-heal.
- Against a #250 server, `recoveredFooter.LAC != lac` returns `ErrInvalidLACAlignment`, so lowering the target is refused and the segment stays stuck.

Lowering a completion target is always safe — it retracts an assertion that should never have been published — while raising it is not; the server-side check currently refuses both. Tracked separately, along with a `wpcli` metadata-correction tool for existing stuck segments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
