### PR TITLE
fix(test): start chaos verify at the phase's earliest ack, not the log head

### DIFF
--- a/tests/chaos_mesh/workload/main_test.go
+++ b/tests/chaos_mesh/workload/main_test.go
@@ -164,14 +164,21 @@ func runVerifyPhase(ctx context.Context, t *testing.T, cli woodpecker.Client) {
 		sort.Slice(want, func(i, j int) bool { return want[i].Seq < want[j].Seq })
 		h, err := cli.OpenLog(ctx, name)
 		require.NoError(t, err)
-		earliest := log.EarliestLogMessageID()
-		r, err := h.OpenLogReader(ctx, &earliest, "verify-"+name)
-		require.NoError(t, err)
 
 		ackedHash := map[[2]int64]string{}
 		for _, w := range want {
 			ackedHash[[2]int64{w.SegmentId, w.EntryId}] = w.PayloadHash
 		}
+
+		// Start at this phase's earliest ack, not at the head of the log. The logs are reused
+		// across every scenario while the record file is truncated at each warmup, so reading
+		// from EarliestLogMessageID() made scenario k re-read everything scenarios 1..k-1 wrote
+		// just to reach its own records — verify grew 47s -> 556s across five scenarios and the
+		// suite could not finish inside timeout-minutes (#259). The start point is inclusive.
+		fromSeg, fromEntry := earliestAck(want)
+		from := log.LogMessageId{SegmentId: fromSeg, EntryId: fromEntry}
+		r, err := h.OpenLogReader(ctx, &from, "verify-"+name)
+		require.NoError(t, err)
 
 		seen := map[[2]int64]bool{}
 		var lastSeg, lastEntry int64 = -1, -1
@@ -199,6 +206,7 @@ func runVerifyPhase(ctx context.Context, t *testing.T, cli woodpecker.Client) {
 		require.Equal(t, len(ackedHash), len(seen),
 			"I1 VIOLATION: %d acked entries missing in %s", len(ackedHash)-len(seen), name)
 		_ = r.Close(ctx)
-		t.Logf("VERIFY %s: %d acked entries durable, ordered, hash-matched", name, len(seen))
+		t.Logf("VERIFY %s: %d acked entries durable, ordered, hash-matched (from seg=%d entry=%d)",
+			name, len(seen), from.SegmentId, from.EntryId)
 	}
 }

--- a/tests/chaos_mesh/workload/record.go
+++ b/tests/chaos_mesh/workload/record.go
@@ -17,6 +17,20 @@ type AckRecord struct {
 	Seq         int64  `json:"seq"`
 }
 
+// earliestAck returns the lowest (SegmentId, EntryId) in recs — the point a verify reader
+// must start from to still see every ack in recs. Callers pass one phase's records, so this
+// keeps read-back proportional to that phase instead of to the whole reused log (#259).
+// recs must be non-empty.
+func earliestAck(recs []AckRecord) (segmentId, entryId int64) {
+	segmentId, entryId = recs[0].SegmentId, recs[0].EntryId
+	for _, r := range recs[1:] {
+		if r.SegmentId < segmentId || (r.SegmentId == segmentId && r.EntryId < entryId) {
+			segmentId, entryId = r.SegmentId, r.EntryId
+		}
+	}
+	return segmentId, entryId
+}
+
 type recorder struct {
 	mu sync.Mutex
 	f  *os.File

--- a/tests/chaos_mesh/workload/record_test.go
+++ b/tests/chaos_mesh/workload/record_test.go
@@ -25,3 +25,39 @@ func TestRecorderRoundTrip(t *testing.T) {
 	require.Equal(t, in, out)
 	_ = os.Remove(path)
 }
+
+func TestEarliestAck(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		recs             []AckRecord
+		wantSeg, wantEnt int64
+	}{
+		{"single", []AckRecord{{SegmentId: 7, EntryId: 3}}, 7, 3},
+		{"ordered", []AckRecord{{SegmentId: 4, EntryId: 0}, {SegmentId: 4, EntryId: 1}, {SegmentId: 5, EntryId: 0}}, 4, 0},
+		// Records arrive per-writer, so a phase's slice is not guaranteed to be sorted by position.
+		{"unordered", []AckRecord{{SegmentId: 9, EntryId: 2}, {SegmentId: 4, EntryId: 8}, {SegmentId: 6, EntryId: 0}}, 4, 8},
+		{"same segment picks lower entry", []AckRecord{{SegmentId: 3, EntryId: 9}, {SegmentId: 3, EntryId: 2}}, 3, 2},
+		// A later scenario's acks start deep into the reused log — the point of #259.
+		{"offset into reused log", []AckRecord{{SegmentId: 120, EntryId: 5}, {SegmentId: 121, EntryId: 0}}, 120, 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			seg, ent := earliestAck(tc.recs)
+			require.Equal(t, tc.wantSeg, seg)
+			require.Equal(t, tc.wantEnt, ent)
+		})
+	}
+}
+
+// The verify reader must start at or before every ack it has to observe, otherwise read-back
+// silently misses entries and the I1 assertion can never be satisfied.
+func TestEarliestAckIsAtOrBeforeEveryRecord(t *testing.T) {
+	recs := []AckRecord{
+		{SegmentId: 12, EntryId: 4}, {SegmentId: 9, EntryId: 7},
+		{SegmentId: 12, EntryId: 0}, {SegmentId: 30, EntryId: 1}, {SegmentId: 9, EntryId: 9},
+	}
+	seg, ent := earliestAck(recs)
+	for _, r := range recs {
+		require.True(t, seg < r.SegmentId || (seg == r.SegmentId && ent <= r.EntryId),
+			"start (%d,%d) is after record (%d,%d)", seg, ent, r.SegmentId, r.EntryId)
+	}
+}


### PR DESCRIPTION
Fixes #259. Stacked on #258 (base `fix/chaos-restart-sum`) — this defect was invisible until that one was fixed, and **both are needed for nightly to go green**.

## What was wrong

The `chaos-n152-*` logs are reused across all seven scenarios, but the acked-record file is truncated at every scenario's warmup (`runLoadPhase(..., truncate=true)`). `runVerifyPhase` opened its reader at `EarliestLogMessageID()` and discarded every entry not in the current record set — so scenario *k* re-read everything scenarios 1..*k*-1 had written just to reach its own entries.

The three load phases are wall-clock bounded by `-window` and stay flat at ~45s. Verify is not, and grew monotonically:

| scenario | verify duration |
|---|---|
| server-minio-delay | 46.9s |
| server-minio-loss | 142.8s |
| server-etcd-delay | 283.1s |
| client-server-delay | 385.4s |
| client-server-loss | 555.9s |

1414s — 23.6 minutes — of the ~52 minutes available after bringup, spent re-reading data earlier scenarios had already verified. The suite cannot finish inside `timeout-minutes: 60`.

## Evidence

Manual dispatch on the #258 branch: [run 30876228173](https://github.com/zilliztech/woodpecker/actions/runs/30876228173). Killed at exactly 60 minutes (03:57:44 → 04:57:59) — GitHub surfaces a `timeout-minutes` kill as `cancelled`, not `failure`.

All five steady scenarios passed, four of them for the first time ever, before it was killed during the first blip scenario's verify:

```
04:09:00  SCENARIO server-minio-delay   PASSED
04:13:41  SCENARIO server-minio-loss    PASSED
04:20:43  SCENARIO server-etcd-delay    PASSED
04:29:34  SCENARIO client-server-delay  PASSED
04:41:09  SCENARIO client-server-loss   PASSED
```

## What this changes

Start the verify reader at the lowest `(segmentId, entryId)` among the phase's **own** acks rather than at the head of the log. The start point is inclusive, so every acked entry is still read back, order-checked (I2) and hash-checked (I3), and the I1 completeness assertion is unchanged.

What is dropped is the incidental re-verification of earlier scenarios' data — which the per-scenario truncation of the record file already showed was not the intent. The logs still keep growing across scenarios, so segment count and compaction/GC pressure are unchanged; they are simply no longer rescanned.

The min is computed explicitly rather than taken from `want[0]`: `want` is sorted by `Seq`, and although one-writer-per-log makes `Seq` order match position order today, the verify start point should not silently depend on that.

## Verification

`earliestAck` is unit-tested (`go test ./tests/chaos_mesh/workload/`), including the property that actually matters — the chosen start point is at or before *every* record it must observe, since a start point that is too late would silently miss entries and make I1 unsatisfiable:

```
--- PASS: TestEarliestAck/single
--- PASS: TestEarliestAck/ordered
--- PASS: TestEarliestAck/unordered
--- PASS: TestEarliestAck/same_segment_picks_lower_entry
--- PASS: TestEarliestAck/offset_into_reused_log
--- PASS: TestEarliestAckIsAtOrBeforeEveryRecord
--- PASS: TestRecorderRoundTrip
```

`go vet` and `go test -c ./tests/chaos_mesh/workload` are clean. `TestNetworkChaosWorkload` itself is not runnable locally by design — it needs `/tmp/test-config.yaml` and a live in-pod cluster.

End-to-end validation needs another `workflow_dispatch` of `nightly-chaos-mesh.yaml` on this branch; I'll report the timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
