### PR TITLE
fix(ci): add missing log import for windows wp CLI build (#261)

### DIFF
--- a/common/hardware/mem_info_windows.go
+++ b/common/hardware/mem_info_windows.go
@@ -18,6 +18,7 @@
 package hardware
 
 import (
+	"github.com/labstack/gommon/log"
 	"github.com/shirou/gopsutil/v3/mem"
 	"go.uber.org/zap"
 )


### PR DESCRIPTION
## What

Add the missing `github.com/labstack/gommon/log` import to `common/hardware/mem_info_windows.go`.

## Why

The `Release wp CLI` workflow fails at **Build release binaries** (`make wpcli-release`), so no `wp` binaries are uploaded to the GitHub Release. The `v0.1.37` release ([run 30616005380](https://github.com/zilliztech/woodpecker/actions/runs/30616005380)) failed for this reason.

`make wpcli-release` cross-compiles for `windows/amd64`. The Windows-only `mem_info_windows.go` (guarded by `//go:build windows`) calls `log.Warn(...)` on line 30 but its import block omitted the `log` package, so the cross-compile failed with:

```
common/hardware/mem_info_windows.go:30: undefined: log
```

Because the build step failed, the **Upload to GitHub Release** step was skipped and the CLI was never published. The bug only surfaces during Windows cross-compilation, which is why local macOS/Linux builds never caught it. The Linux (`mem_info.go`) and Darwin (`mem_info_darwin.go`) siblings already import this package correctly.

## Testing

Reproduced the CI cross-compile locally for every platform in `WPCLI_PLATFORMS`:

```
for p in linux/amd64 linux/arm64 darwin/arm64 windows/amd64; do
  os=${p%%/*}; arch=${p##*/};
  GOOS=$os GOARCH=$arch CGO_ENABLED=0 go build -o /dev/null ./cmd/wpcli && echo "OK $p";
done
# OK linux/amd64
# OK linux/arm64
# OK darwin/arm64
# OK windows/amd64
```

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
