### PR TITLE
fix(ci): retry the dependency image pull a bounded number of times

### DIFF
--- a/.github/workflows/integration-test-components.yaml
+++ b/.github/workflows/integration-test-components.yaml
@@ -36,17 +36,34 @@ jobs:
 
       - name: Start dependencies (etcd + MinIO)
         run: |
+          # Pull before `up` so a registry hiccup can be retried on its own: a Docker Hub
+          # timeout used to fail the job before a single test ran (#256). Bounded — three
+          # attempts with backoff, then give up. Never retry indefinitely.
+          for attempt in 1 2 3; do
+            if docker compose -f .github/docker-compose-ci.yaml pull; then break; fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::docker compose pull failed after 3 attempts"
+              exit 1
+            fi
+            echo "pull attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
           docker compose -f .github/docker-compose-ci.yaml up -d
-          echo "Waiting for etcd..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-etcd 2>/dev/null | grep -q healthy; do
-            sleep 2
+          # Bounded health waits too. An unbounded `until` loop here would burn the whole
+          # job timeout and surface as a cancelled job rather than a clear error.
+          for svc in ci-etcd ci-minio; do
+            echo "Waiting for $svc..."
+            for i in $(seq 60); do
+              if [ "$(docker inspect --format='{{.State.Health.Status}}' "$svc" 2>/dev/null)" = healthy ]; then break; fi
+              if [ "$i" = 60 ]; then
+                echo "::error::$svc did not become healthy within 120s"
+                docker logs "$svc" 2>&1 | tail -50
+                exit 1
+              fi
+              sleep 2
+            done
+            echo "$svc is ready"
           done
-          echo "etcd is ready"
-          echo "Waiting for MinIO..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-minio 2>/dev/null | grep -q healthy; do
-            sleep 2
-          done
-          echo "MinIO is ready"
 
       - name: Create MinIO bucket
         run: |

--- a/.github/workflows/integration-test-e2e-local.yaml
+++ b/.github/workflows/integration-test-e2e-local.yaml
@@ -36,17 +36,34 @@ jobs:
 
       - name: Start dependencies (etcd + MinIO)
         run: |
+          # Pull before `up` so a registry hiccup can be retried on its own: a Docker Hub
+          # timeout used to fail the job before a single test ran (#256). Bounded — three
+          # attempts with backoff, then give up. Never retry indefinitely.
+          for attempt in 1 2 3; do
+            if docker compose -f .github/docker-compose-ci.yaml pull; then break; fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::docker compose pull failed after 3 attempts"
+              exit 1
+            fi
+            echo "pull attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
           docker compose -f .github/docker-compose-ci.yaml up -d
-          echo "Waiting for etcd..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-etcd 2>/dev/null | grep -q healthy; do
-            sleep 2
+          # Bounded health waits too. An unbounded `until` loop here would burn the whole
+          # job timeout and surface as a cancelled job rather than a clear error.
+          for svc in ci-etcd ci-minio; do
+            echo "Waiting for $svc..."
+            for i in $(seq 60); do
+              if [ "$(docker inspect --format='{{.State.Health.Status}}' "$svc" 2>/dev/null)" = healthy ]; then break; fi
+              if [ "$i" = 60 ]; then
+                echo "::error::$svc did not become healthy within 120s"
+                docker logs "$svc" 2>&1 | tail -50
+                exit 1
+              fi
+              sleep 2
+            done
+            echo "$svc is ready"
           done
-          echo "etcd is ready"
-          echo "Waiting for MinIO..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-minio 2>/dev/null | grep -q healthy; do
-            sleep 2
-          done
-          echo "MinIO is ready"
 
       - name: Create MinIO bucket
         run: |

--- a/.github/workflows/integration-test-e2e-objectstorage.yaml
+++ b/.github/workflows/integration-test-e2e-objectstorage.yaml
@@ -36,17 +36,34 @@ jobs:
 
       - name: Start dependencies (etcd + MinIO)
         run: |
+          # Pull before `up` so a registry hiccup can be retried on its own: a Docker Hub
+          # timeout used to fail the job before a single test ran (#256). Bounded — three
+          # attempts with backoff, then give up. Never retry indefinitely.
+          for attempt in 1 2 3; do
+            if docker compose -f .github/docker-compose-ci.yaml pull; then break; fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::docker compose pull failed after 3 attempts"
+              exit 1
+            fi
+            echo "pull attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
           docker compose -f .github/docker-compose-ci.yaml up -d
-          echo "Waiting for etcd..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-etcd 2>/dev/null | grep -q healthy; do
-            sleep 2
+          # Bounded health waits too. An unbounded `until` loop here would burn the whole
+          # job timeout and surface as a cancelled job rather than a clear error.
+          for svc in ci-etcd ci-minio; do
+            echo "Waiting for $svc..."
+            for i in $(seq 60); do
+              if [ "$(docker inspect --format='{{.State.Health.Status}}' "$svc" 2>/dev/null)" = healthy ]; then break; fi
+              if [ "$i" = 60 ]; then
+                echo "::error::$svc did not become healthy within 120s"
+                docker logs "$svc" 2>&1 | tail -50
+                exit 1
+              fi
+              sleep 2
+            done
+            echo "$svc is ready"
           done
-          echo "etcd is ready"
-          echo "Waiting for MinIO..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-minio 2>/dev/null | grep -q healthy; do
-            sleep 2
-          done
-          echo "MinIO is ready"
 
       - name: Create MinIO bucket
         run: |

--- a/.github/workflows/integration-test-e2e-service.yaml
+++ b/.github/workflows/integration-test-e2e-service.yaml
@@ -36,17 +36,34 @@ jobs:
 
       - name: Start dependencies (etcd + MinIO)
         run: |
+          # Pull before `up` so a registry hiccup can be retried on its own: a Docker Hub
+          # timeout used to fail the job before a single test ran (#256). Bounded — three
+          # attempts with backoff, then give up. Never retry indefinitely.
+          for attempt in 1 2 3; do
+            if docker compose -f .github/docker-compose-ci.yaml pull; then break; fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::docker compose pull failed after 3 attempts"
+              exit 1
+            fi
+            echo "pull attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
           docker compose -f .github/docker-compose-ci.yaml up -d
-          echo "Waiting for etcd..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-etcd 2>/dev/null | grep -q healthy; do
-            sleep 2
+          # Bounded health waits too. An unbounded `until` loop here would burn the whole
+          # job timeout and surface as a cancelled job rather than a clear error.
+          for svc in ci-etcd ci-minio; do
+            echo "Waiting for $svc..."
+            for i in $(seq 60); do
+              if [ "$(docker inspect --format='{{.State.Health.Status}}' "$svc" 2>/dev/null)" = healthy ]; then break; fi
+              if [ "$i" = 60 ]; then
+                echo "::error::$svc did not become healthy within 120s"
+                docker logs "$svc" 2>&1 | tail -50
+                exit 1
+              fi
+              sleep 2
+            done
+            echo "$svc is ready"
           done
-          echo "etcd is ready"
-          echo "Waiting for MinIO..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-minio 2>/dev/null | grep -q healthy; do
-            sleep 2
-          done
-          echo "MinIO is ready"
 
       - name: Create MinIO bucket
         run: |

--- a/.github/workflows/integration-test-upgrade-local.yaml
+++ b/.github/workflows/integration-test-upgrade-local.yaml
@@ -42,17 +42,34 @@ jobs:
 
       - name: Start dependencies (etcd + MinIO)
         run: |
+          # Pull before `up` so a registry hiccup can be retried on its own: a Docker Hub
+          # timeout used to fail the job before a single test ran (#256). Bounded — three
+          # attempts with backoff, then give up. Never retry indefinitely.
+          for attempt in 1 2 3; do
+            if docker compose -f .github/docker-compose-ci.yaml pull; then break; fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::docker compose pull failed after 3 attempts"
+              exit 1
+            fi
+            echo "pull attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
           docker compose -f .github/docker-compose-ci.yaml up -d
-          echo "Waiting for etcd..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-etcd 2>/dev/null | grep -q healthy; do
-            sleep 2
+          # Bounded health waits too. An unbounded `until` loop here would burn the whole
+          # job timeout and surface as a cancelled job rather than a clear error.
+          for svc in ci-etcd ci-minio; do
+            echo "Waiting for $svc..."
+            for i in $(seq 60); do
+              if [ "$(docker inspect --format='{{.State.Health.Status}}' "$svc" 2>/dev/null)" = healthy ]; then break; fi
+              if [ "$i" = 60 ]; then
+                echo "::error::$svc did not become healthy within 120s"
+                docker logs "$svc" 2>&1 | tail -50
+                exit 1
+              fi
+              sleep 2
+            done
+            echo "$svc is ready"
           done
-          echo "etcd is ready"
-          echo "Waiting for MinIO..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-minio 2>/dev/null | grep -q healthy; do
-            sleep 2
-          done
-          echo "MinIO is ready"
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/integration-test-upgrade-objectstorage.yaml
+++ b/.github/workflows/integration-test-upgrade-objectstorage.yaml
@@ -42,17 +42,34 @@ jobs:
 
       - name: Start dependencies (etcd + MinIO)
         run: |
+          # Pull before `up` so a registry hiccup can be retried on its own: a Docker Hub
+          # timeout used to fail the job before a single test ran (#256). Bounded — three
+          # attempts with backoff, then give up. Never retry indefinitely.
+          for attempt in 1 2 3; do
+            if docker compose -f .github/docker-compose-ci.yaml pull; then break; fi
+            if [ "$attempt" = 3 ]; then
+              echo "::error::docker compose pull failed after 3 attempts"
+              exit 1
+            fi
+            echo "pull attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
           docker compose -f .github/docker-compose-ci.yaml up -d
-          echo "Waiting for etcd..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-etcd 2>/dev/null | grep -q healthy; do
-            sleep 2
+          # Bounded health waits too. An unbounded `until` loop here would burn the whole
+          # job timeout and surface as a cancelled job rather than a clear error.
+          for svc in ci-etcd ci-minio; do
+            echo "Waiting for $svc..."
+            for i in $(seq 60); do
+              if [ "$(docker inspect --format='{{.State.Health.Status}}' "$svc" 2>/dev/null)" = healthy ]; then break; fi
+              if [ "$i" = 60 ]; then
+                echo "::error::$svc did not become healthy within 120s"
+                docker logs "$svc" 2>&1 | tail -50
+                exit 1
+              fi
+              sleep 2
+            done
+            echo "$svc is ready"
           done
-          echo "etcd is ready"
-          echo "Waiting for MinIO..."
-          until docker inspect --format='{{.State.Health.Status}}' ci-minio 2>/dev/null | grep -q healthy; do
-            sleep 2
-          done
-          echo "MinIO is ready"
 
       - name: Create MinIO bucket
         run: |


### PR DESCRIPTION
Fixes #256. Independent of #258 / #260 — branches off `master`.

## What was wrong

`docker compose up -d` pulled and started in a single command, so a registry hiccup had nothing to retry and took the whole job down before a single test ran ([run 30712769213](https://github.com/zilliztech/woodpecker/actions/runs/30712769213)):

```
 etcd Pulling
 minio Pulling
 minio Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
 etcd  Interrupted
##[error]Process completed with exit code 1.
```

## What this changes

**1. Pull separately, with bounded retries.** Three attempts with 10s/20s backoff, then fail. Deliberately bounded — a transient registry failure is retried, a real outage stops after three tries instead of spinning.

**2. Bound the health waits too.** These were unbounded `until` loops:

```bash
until docker inspect --format='{{.State.Health.Status}}' ci-etcd 2>/dev/null | grep -q healthy; do
  sleep 2
done
```

These jobs carry `timeout-minutes: 30`–`45`. A container that never goes healthy would burn the entire budget and then surface as a **cancelled** job with no explanation — the same misleading signal that made #255/#259 take so long to diagnose. They now give up after 120s, dump the container's last 50 log lines, and fail with a message naming the service.

Applied to the six workflows that share this step. The block was byte-identical in all six (verified by hashing the matched region before patching), and remains identical after.

`upgrade-service` is untouched — it uses a different compose setup and does not have this step.

## Verification

The step's `run:` script was extracted from the patched YAML and executed under `bash -e` (matching the GitHub runner's default shell) against a stubbed `docker`, so the real text is what ran rather than a copy:

| case | result |
|---|---|
| pull succeeds first try, services healthy | 1 attempt, `up -d`, both ready, **exit 0** |
| pull fails 2× then succeeds | attempts 1,2 retried with backoff, 3rd succeeds, **exit 0** |
| pull fails persistently | stops at exactly **3** attempts, `::error::docker compose pull failed after 3 attempts`, **exit 1** |
| pull ok but service never healthy | `::error::ci-etcd did not become healthy within 120s`, **exit 1** |

The third case is the one that matters for the "bounded, not indefinite" requirement.

All six files parse as valid YAML and the step survives round-tripping (`yaml.safe_load`).

Unlike #258/#260, this PR does trigger CI — each of these workflows path-filters on its own file — so the happy path gets exercised for real here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
