### PR TITLE
fix(server): refuse segment lifecycle operations on a decommissioned node

### DIFF
--- a/common/werr/errors.go
+++ b/common/werr/errors.go
@@ -98,6 +98,10 @@ var (
 	ErrMarkDeleteFailed        = newWoodpeckerError("failed to durably mark log/instance deleted", 2006, true)
 	ErrLogStoreDiskPressure    = newWoodpeckerError("logstore local disk above hard watermark, write backpressure active", 2007, true)
 	ErrLogStoreInvalidRootPath = newWoodpeckerError("invalid rootPath", 2008, false)
+	// ErrLogStoreRetired is returned by a decommissioned node for segment-lifecycle operations.
+	// Non-retryable on purpose: the node is terminally retired, so the caller should drop it from
+	// the quorum and re-discover rather than back off and retry against it.
+	ErrLogStoreRetired = newWoodpeckerError("logstore is retired (node decommissioned)", 2009, false)
 
 	// segment_processor errors (2100-2199)
 	ErrSegmentProcessorNotFound          = newWoodpeckerError("segment processor not found", 2100, false)

--- a/mocks/mocks_server/mock_logstore.go
+++ b/mocks/mocks_server/mock_logstore.go
@@ -934,6 +934,38 @@ func (_c *LogStore_HasLocalSegmentData_Call) RunAndReturn(run func() bool) *LogS
 	return _c
 }
 
+// MarkRetired provides a mock function with no fields
+func (_m *LogStore) MarkRetired() {
+	_m.Called()
+}
+
+// LogStore_MarkRetired_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MarkRetired'
+type LogStore_MarkRetired_Call struct {
+	*mock.Call
+}
+
+// MarkRetired is a helper method to define mock.On call
+func (_e *LogStore_Expecter) MarkRetired() *LogStore_MarkRetired_Call {
+	return &LogStore_MarkRetired_Call{Call: _e.mock.On("MarkRetired")}
+}
+
+func (_c *LogStore_MarkRetired_Call) Run(run func()) *LogStore_MarkRetired_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *LogStore_MarkRetired_Call) Return() *LogStore_MarkRetired_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *LogStore_MarkRetired_Call) RunAndReturn(run func()) *LogStore_MarkRetired_Call {
+	_c.Run(run)
+	return _c
+}
+
 // NotifySegmentCompacted provides a mock function with given fields: ctx, bucketName, rootPath, logId, segmentId
 func (_m *LogStore) NotifySegmentCompacted(ctx context.Context, bucketName string, rootPath string, logId int64, segmentId int64) error {
 	ret := _m.Called(ctx, bucketName, rootPath, logId, segmentId)

--- a/server/lifecycle.go
+++ b/server/lifecycle.go
@@ -101,6 +101,15 @@ func (m *NodeLifecycleManager) IsDecommissioning() bool {
 	return m.state == NodeStateDecommissioning
 }
 
+// IsDecommissioned returns true if the node is in the terminal decommissioned state.
+// Distinct from IsDecommissioning: the two states enforce different things (writes are
+// refused in both, segment-lifecycle operations only once decommissioned).
+func (m *NodeLifecycleManager) IsDecommissioned() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.state == NodeStateDecommissioned
+}
+
 // StartDecommission transitions the node from active to decommissioning.
 // Idempotent if already decommissioning. Returns error if already decommissioned.
 func (m *NodeLifecycleManager) StartDecommission() error {

--- a/server/lifecycle_test.go
+++ b/server/lifecycle_test.go
@@ -165,6 +165,23 @@ func TestNodeLifecycleManager_Persistence_DecommissionedSurvivesRestart(t *testi
 	m2, err := NewNodeLifecycleManagerWithPersistence(dir)
 	require.NoError(t, err)
 	assert.Equal(t, NodeStateDecommissioned, m2.GetState())
+	// The restart path keys off these two predicates to decide what to re-enforce, and they
+	// must not be conflated: only the terminal state also refuses segment lifecycle ops.
+	assert.False(t, m2.IsDecommissioning(), "decommissioned is not decommissioning")
+	assert.True(t, m2.IsDecommissioned())
+}
+
+func TestNodeLifecycleManager_IsDecommissionedOnlyInTerminalState(t *testing.T) {
+	m := NewNodeLifecycleManager()
+	assert.False(t, m.IsDecommissioned(), "active")
+
+	m.StartDecommission()
+	assert.True(t, m.IsDecommissioning())
+	assert.False(t, m.IsDecommissioned(), "draining is not yet retired")
+
+	require.NoError(t, m.MarkDecommissioned())
+	assert.False(t, m.IsDecommissioning())
+	assert.True(t, m.IsDecommissioned())
 }
 
 func TestNodeLifecycleManager_Persistence_ClearState(t *testing.T) {

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -73,6 +73,7 @@ type LogStore interface {
 	GetActiveProcessorCount() int
 	RejectNewWrites()
 	AllowNewWrites()
+	MarkRetired()
 	HasLocalSegmentData() bool
 	EvictLog(ctx context.Context, bucketName string, rootPath string, logId int64) error
 	EvictInstance(ctx context.Context, bucketName string, rootPath string) error
@@ -110,8 +111,11 @@ type logStore struct {
 	maintenance      *NodeMaintenanceManager
 	compactedCleanup *compactedFileCleanupTask // event queue fed by NotifySegmentCompacted; drop path for compacted data.log
 	stopped          atomic.Bool
-	rejectWrites     atomic.Bool  // separate from stopped: only blocks new writes during decommission, not reads
-	diskRejectBps    atomic.Int32 // rejection probability in basis points (0..10000), set by diskWatermarkTask; gates new appends only
+	rejectWrites     atomic.Bool // separate from stopped: only blocks new writes during decommission, not reads
+	retired          atomic.Bool // set on reaching the terminal decommissioned state; additionally refuses
+	// segment-lifecycle participation (fence/complete/compact/LAC). One-way latch:
+	// decommissioned is terminal, CancelDecommission refuses it.
+	diskRejectBps atomic.Int32 // rejection probability in basis points (0..10000), set by diskWatermarkTask; gates new appends only
 }
 
 // admitAppend returns false when the disk-watermark policy rejects this append.
@@ -483,6 +487,9 @@ func (l *logStore) CompleteSegment(ctx context.Context, bucketName string, rootP
 	if l.stopped.Load() {
 		return -1, werr.ErrLogStoreShutdown
 	}
+	if l.retired.Load() {
+		return -1, werr.ErrLogStoreRetired
+	}
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, LogStoreScopeName, "CompleteSegment")
 	defer sp.End()
 	logIdStr := strconv.FormatInt(logId, 10)
@@ -508,6 +515,9 @@ func (l *logStore) CompleteSegment(ctx context.Context, bucketName string, rootP
 func (l *logStore) FenceSegment(ctx context.Context, bucketName string, rootPath string, logId int64, segmentId int64) (int64, error) {
 	if l.stopped.Load() {
 		return -1, werr.ErrLogStoreShutdown
+	}
+	if l.retired.Load() {
+		return -1, werr.ErrLogStoreRetired
 	}
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, LogStoreScopeName, "FenceSegment")
 	defer sp.End()
@@ -608,6 +618,9 @@ func (l *logStore) GetSegmentBlockCount(ctx context.Context, bucketName string, 
 func (l *logStore) CompactSegment(ctx context.Context, bucketName string, rootPath string, logId int64, segmentId int64, expectedLastEntryId int64) (*proto.SegmentMetadata, error) {
 	if l.stopped.Load() {
 		return nil, werr.ErrLogStoreShutdown
+	}
+	if l.retired.Load() {
+		return nil, werr.ErrLogStoreRetired
 	}
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, LogStoreScopeName, "CompactSegment")
 	defer sp.End()
@@ -743,6 +756,9 @@ func (l *logStore) UpdateLastAddConfirmed(ctx context.Context, bucketName string
 	if l.stopped.Load() {
 		return werr.ErrLogStoreShutdown
 	}
+	if l.retired.Load() {
+		return werr.ErrLogStoreRetired
+	}
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, LogStoreScopeName, "UpdateLastAddConfirmed")
 	defer sp.End()
 	logIdStr := strconv.FormatInt(logId, 10)
@@ -791,6 +807,31 @@ func (l *logStore) RejectNewWrites() {
 func (l *logStore) AllowNewWrites() {
 	if l.rejectWrites.Swap(false) {
 		logger.Ctx(context.Background()).Info("log store accepting new writes again (decommission cancelled)",
+			zap.String("nodeID", metrics.NodeID))
+	}
+}
+
+// MarkRetired refuses segment-lifecycle participation on top of RejectNewWrites, for a node
+// that has reached the terminal decommissioned state.
+//
+// During decommissioning fence/complete/compact must stay open — that is how the node's own
+// segments get closed, uploaded and cleaned so it can drain at all. Once drained there is
+// nothing left to close, and continuing to serve them is actively harmful: a peer whose gossip
+// view is still stale can place a brand-new segment on this node, and fence/complete then
+// materialise a staged file for a segment it holds no data for. HasLocalSegmentData sees that
+// file, has_local_data flips back to true and safe_to_terminate to false — permanently, because
+// the decommission monitor has already exited and never re-checks (#257).
+//
+// Gossip is eventually consistent, so peers can always be told stale information; the node's
+// own view of its state is the only thing that cannot be. Hence the gate lives here.
+//
+// Cleanup (CleanSegment / EvictLog / EvictInstance / NotifySegmentCompacted) and reads stay
+// open: they remove data or create nothing, and blocking them would strand whatever the node
+// still holds.
+func (l *logStore) MarkRetired() {
+	l.rejectWrites.Store(true)
+	if !l.retired.Swap(true) {
+		logger.Ctx(context.Background()).Info("log store now retired, refusing segment lifecycle operations (decommissioned)",
 			zap.String("nodeID", metrics.NodeID))
 	}
 }

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -804,7 +804,15 @@ func (l *logStore) RejectNewWrites() {
 
 // AllowNewWrites clears the write-rejection flag set by RejectNewWrites,
 // restoring normal write acceptance after a cancelled decommission.
+//
+// No-op once retired: MarkRetired establishes retired => rejectWrites, and clearing the flag
+// here would break that invariant and let a retired node admit appends again. Unreachable in
+// production today (CancelDecommission refuses the terminal state, ClearState has no production
+// caller) — the latch enforces it rather than relying on every caller to.
 func (l *logStore) AllowNewWrites() {
+	if l.retired.Load() {
+		return
+	}
 	if l.rejectWrites.Swap(false) {
 		logger.Ctx(context.Background()).Info("log store accepting new writes again (decommission cancelled)",
 			zap.String("nodeID", metrics.NodeID))

--- a/server/logstore_retired_test.go
+++ b/server/logstore_retired_test.go
@@ -132,8 +132,12 @@ func TestLogStore_Decommissioning_StillServesSegmentLifecycleOps(t *testing.T) {
 }
 
 // Retirement is a one-way latch: decommissioned is terminal and CancelDecommission refuses it,
-// so AllowNewWrites (the cancel path) must not resurrect a retired node.
+// so AllowNewWrites (the cancel path) must not resurrect a retired node. Both halves of the
+// invariant are checked — segment ops stay refused *and* writes stay refused. The write half is
+// the one that was actually breakable: AllowNewWrites used to clear rejectWrites unconditionally,
+// so a retired store would admit AddEntry again and could materialise a fresh data.log.
 func TestLogStore_Retired_NotClearedByAllowNewWrites(t *testing.T) {
+	ctx := context.Background()
 	store := createTestLogStore()
 	store.stopped.Store(false)
 	store.MarkRetired()
@@ -141,8 +145,13 @@ func TestLogStore_Retired_NotClearedByAllowNewWrites(t *testing.T) {
 	store.AllowNewWrites()
 
 	assert.True(t, store.retired.Load(), "retirement must survive AllowNewWrites")
-	_, err := store.FenceSegment(context.Background(), testBucketName, testRootPath, testLogId, 29)
-	require.ErrorIs(t, err, werr.ErrLogStoreRetired)
+	assert.True(t, store.rejectWrites.Load(), "retired => rejectWrites must survive AllowNewWrites")
+
+	_, addErr := store.AddEntry(ctx, testBucketName, testRootPath, testLogId, nil, nil)
+	require.ErrorIs(t, addErr, werr.ErrLogStoreShutdown, "a retired store must not admit appends again")
+
+	_, fenceErr := store.FenceSegment(ctx, testBucketName, testRootPath, testLogId, 29)
+	require.ErrorIs(t, fenceErr, werr.ErrLogStoreRetired)
 }
 
 // ErrLogStoreRetired must be non-retryable: retrying against a terminally retired node can never

--- a/server/logstore_retired_test.go
+++ b/server/logstore_retired_test.go
@@ -1,0 +1,152 @@
+// Copyright (C) 2025 Zilliz. All rights reserved.
+//
+// This file is part of the Woodpecker project.
+//
+// Woodpecker is dual-licensed under the GNU Affero General Public License v3.0
+// (AGPLv3) and the Server Side Public License v1 (SSPLv1). You may use this
+// file under either license, at your option.
+//
+// AGPLv3 License: https://www.gnu.org/licenses/agpl-3.0.html
+// SSPLv1 License: https://www.mongodb.com/licensing/server-side-public-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under these licenses is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the license texts for specific language governing permissions and
+// limitations under the licenses.
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/woodpecker/common/werr"
+	"github.com/zilliztech/woodpecker/mocks/mocks_server/mocks_segment"
+	"github.com/zilliztech/woodpecker/server/processor"
+)
+
+// A retired node must refuse to participate in segment lifecycle. Without this, a peer whose
+// gossip view is still stale places a new segment here and fence/complete materialise a staged
+// file for a segment this node holds no data for, flipping has_local_data back to true forever
+// (#257).
+func TestLogStore_Retired_RefusesSegmentLifecycleOps(t *testing.T) {
+	store := createTestLogStore()
+	store.stopped.Store(false)
+	store.MarkRetired()
+
+	ctx := context.Background()
+	const segId = int64(29)
+
+	t.Run("FenceSegment", func(t *testing.T) {
+		_, err := store.FenceSegment(ctx, testBucketName, testRootPath, testLogId, segId)
+		require.ErrorIs(t, err, werr.ErrLogStoreRetired)
+	})
+	t.Run("CompleteSegment", func(t *testing.T) {
+		_, err := store.CompleteSegment(ctx, testBucketName, testRootPath, testLogId, segId, 0)
+		require.ErrorIs(t, err, werr.ErrLogStoreRetired)
+	})
+	t.Run("CompactSegment", func(t *testing.T) {
+		_, err := store.CompactSegment(ctx, testBucketName, testRootPath, testLogId, segId, 0)
+		require.ErrorIs(t, err, werr.ErrLogStoreRetired)
+	})
+	t.Run("UpdateLastAddConfirmed", func(t *testing.T) {
+		err := store.UpdateLastAddConfirmed(ctx, testBucketName, testRootPath, testLogId, segId, 0)
+		require.ErrorIs(t, err, werr.ErrLogStoreRetired)
+	})
+}
+
+// Retiring implies write rejection: the terminal state is strictly stricter than decommissioning.
+func TestLogStore_Retired_AlsoRejectsWrites(t *testing.T) {
+	store := createTestLogStore()
+	store.stopped.Store(false)
+	require.False(t, store.rejectWrites.Load(), "precondition: writes accepted before retiring")
+
+	store.MarkRetired()
+
+	assert.True(t, store.rejectWrites.Load())
+	_, err := store.AddEntry(context.Background(), testBucketName, testRootPath, testLogId, nil, nil)
+	require.ErrorIs(t, err, werr.ErrLogStoreShutdown)
+}
+
+// Cleanup and reads stay open on a retired node: they remove data or create nothing, and
+// blocking them would strand whatever the node still holds locally. A mock processor is
+// pre-seeded so these reach the processor instead of building one against absent storage.
+func TestLogStore_Retired_AllowsCleanupAndReads(t *testing.T) {
+	ctx := context.Background()
+	const segId = int64(29)
+
+	newStoreWithProcessor := func(t *testing.T) (*logStore, *mocks_segment.SegmentProcessor) {
+		store := createTestLogStore()
+		store.stopped.Store(false)
+		store.MarkRetired()
+		mp := mocks_segment.NewSegmentProcessor(t)
+		store.segmentProcessors[GetLogKey(testBucketName, testRootPath, testLogId)] = map[int64]processor.SegmentProcessor{segId: mp}
+		return store, mp
+	}
+
+	t.Run("CleanSegment reaches the processor", func(t *testing.T) {
+		store, mp := newStoreWithProcessor(t)
+		mp.EXPECT().Clean(mock.Anything, 0).Return(nil).Once()
+		require.NoError(t, store.CleanSegment(ctx, testBucketName, testRootPath, testLogId, segId, 0))
+	})
+
+	t.Run("reads reach the processor", func(t *testing.T) {
+		store, mp := newStoreWithProcessor(t)
+		mp.EXPECT().GetSegmentLastAddConfirmed(mock.Anything).Return(int64(7), nil).Once()
+		lac, err := store.GetSegmentLastAddConfirmed(ctx, testBucketName, testRootPath, testLogId, segId)
+		require.NoError(t, err)
+		assert.Equal(t, int64(7), lac)
+	})
+}
+
+// A node still draining must keep serving fence/complete/compact — that is how its own segments
+// get closed and uploaded so it can reach the terminal state at all.
+func TestLogStore_Decommissioning_StillServesSegmentLifecycleOps(t *testing.T) {
+	ctx := context.Background()
+	const segId = int64(29)
+
+	store := createTestLogStore()
+	store.stopped.Store(false)
+	store.RejectNewWrites() // decommissioning, not retired
+
+	mp := mocks_segment.NewSegmentProcessor(t)
+	mp.EXPECT().Fence(mock.Anything).Return(int64(4), nil).Once()
+	mp.EXPECT().Complete(mock.Anything, int64(4)).Return(int64(4), nil).Once()
+	store.segmentProcessors[GetLogKey(testBucketName, testRootPath, testLogId)] = map[int64]processor.SegmentProcessor{segId: mp}
+
+	lastEntryId, err := store.FenceSegment(ctx, testBucketName, testRootPath, testLogId, segId)
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), lastEntryId)
+
+	_, err = store.CompleteSegment(ctx, testBucketName, testRootPath, testLogId, segId, 4)
+	require.NoError(t, err)
+
+	// ...while appends are already refused.
+	_, addErr := store.AddEntry(ctx, testBucketName, testRootPath, testLogId, nil, nil)
+	require.ErrorIs(t, addErr, werr.ErrLogStoreShutdown)
+}
+
+// Retirement is a one-way latch: decommissioned is terminal and CancelDecommission refuses it,
+// so AllowNewWrites (the cancel path) must not resurrect a retired node.
+func TestLogStore_Retired_NotClearedByAllowNewWrites(t *testing.T) {
+	store := createTestLogStore()
+	store.stopped.Store(false)
+	store.MarkRetired()
+
+	store.AllowNewWrites()
+
+	assert.True(t, store.retired.Load(), "retirement must survive AllowNewWrites")
+	_, err := store.FenceSegment(context.Background(), testBucketName, testRootPath, testLogId, 29)
+	require.ErrorIs(t, err, werr.ErrLogStoreRetired)
+}
+
+// ErrLogStoreRetired must be non-retryable: retrying against a terminally retired node can never
+// succeed, so the caller should drop it from the quorum and re-discover instead of backing off.
+func TestErrLogStoreRetired_NotRetryable(t *testing.T) {
+	assert.False(t, werr.IsRetryableErr(werr.ErrLogStoreRetired))
+}

--- a/server/service.go
+++ b/server/service.go
@@ -815,23 +815,12 @@ func (s *Server) CancelDecommission() error {
 	// Resume accepting new writes
 	s.logStore.AllowNewWrites()
 	s.updateDecommissionMetrics()
-	// Broadcast active status via gossip so other nodes stop filtering this node out
-	s.serverNodeMu.RLock()
-	node := s.serverNode
-	s.serverNodeMu.RUnlock()
-	if node != nil {
-		currentMeta := node.GetMeta()
-		updatedTags := make(map[string]string)
-		for k, v := range currentMeta.Tags {
-			updatedTags[k] = v
-		}
-		updatedTags["status"] = "active"
-		node.UpdateMeta(map[string]interface{}{
-			"tags": updatedTags,
-		})
-		logger.Ctx(s.ctx).Info("broadcast node status via gossip",
-			zap.String("nodeID", s.serverConfig.NodeID),
-			zap.String("status", "active"))
+	// Broadcast active status via gossip so other nodes stop filtering this node out.
+	// Best-effort: if gossip is not up yet this is skipped, and the node stays excluded from
+	// quorum selection until something else republishes. Callers get the boolean to act on.
+	if !s.broadcastNodeStatus(string(NodeStateActive)) {
+		logger.Ctx(s.ctx).Warn("cancel decommission: gossip not ready, active status not advertised yet",
+			zap.String("nodeID", s.serverConfig.NodeID))
 	}
 	return nil
 }

--- a/server/service.go
+++ b/server/service.go
@@ -256,39 +256,44 @@ func (s *Server) start() error {
 	s.updateDecommissionMetrics()
 	logger.Ctx(s.ctx).Info("log store started", zap.String("nodeID", s.serverConfig.NodeID), zap.String("address", s.logStore.GetAddress()))
 
-	// If the node was decommissioning before restart, re-apply write rejection and resume monitoring
-	if s.lifecycle.IsDecommissioning() {
-		s.logStore.RejectNewWrites()
-		s.startDecommissionMonitor()
-		// Broadcast decommission state once gossip is ready
-		go func() {
-			for {
-				s.serverNodeMu.RLock()
-				node := s.serverNode
-				s.serverNodeMu.RUnlock()
-				if node != nil {
-					currentMeta := node.GetMeta()
-					updatedTags := make(map[string]string)
-					for k, v := range currentMeta.Tags {
-						updatedTags[k] = v
-					}
-					updatedTags["status"] = "decommissioning"
-					node.UpdateMeta(map[string]interface{}{
-						"tags": updatedTags,
-					})
-					break
-				}
-				select {
-				case <-s.ctx.Done():
-					return
-				case <-time.After(500 * time.Millisecond):
-				}
-			}
-		}()
-		logger.Ctx(s.ctx).Info("node was decommissioning before restart, rejecting new writes and resuming monitor",
-			zap.String("nodeID", s.serverConfig.NodeID))
-	}
+	s.restoreLifecycleEnforcement()
 	return nil
+}
+
+// restoreLifecycleEnforcement re-applies the persisted lifecycle state after a restart.
+//
+// Both non-active states refuse writes; only the terminal one also refuses segment-lifecycle
+// operations, and it has nothing left to monitor. This previously keyed off IsDecommissioning()
+// alone — which matches only the draining state — so a node persisted as decommissioned came
+// back indistinguishable from an active one: accepting appends and advertising no status tag at
+// all (#257).
+func (s *Server) restoreLifecycleEnforcement() {
+	state := s.lifecycle.GetState()
+	if state == NodeStateActive {
+		return
+	}
+	s.logStore.RejectNewWrites()
+	if state == NodeStateDecommissioned {
+		s.logStore.MarkRetired()
+	} else {
+		s.startDecommissionMonitor()
+	}
+	// Gossip is not up yet at this point; keep trying until the tag is published.
+	go func() {
+		for {
+			if s.broadcastNodeStatus(string(state)) {
+				return
+			}
+			select {
+			case <-s.ctx.Done():
+				return
+			case <-time.After(500 * time.Millisecond):
+			}
+		}
+	}()
+	logger.Ctx(s.ctx).Info("restored node lifecycle enforcement after restart",
+		zap.String("nodeID", s.serverConfig.NodeID),
+		zap.String("state", string(state)))
 }
 
 func (s *Server) Stop() error {
@@ -842,26 +847,40 @@ func (s *Server) Decommission() error {
 	s.logStore.RejectNewWrites()
 	s.updateDecommissionMetrics()
 	// Broadcast decommission state via gossip so other nodes filter this node from quorum
-	s.serverNodeMu.RLock()
-	node := s.serverNode
-	s.serverNodeMu.RUnlock()
-	if node != nil {
-		currentMeta := node.GetMeta()
-		updatedTags := make(map[string]string)
-		for k, v := range currentMeta.Tags {
-			updatedTags[k] = v
-		}
-		updatedTags["status"] = "decommissioning"
-		node.UpdateMeta(map[string]interface{}{
-			"tags": updatedTags,
-		})
-		logger.Ctx(s.ctx).Info("broadcast node status via gossip",
-			zap.String("nodeID", s.serverConfig.NodeID),
-			zap.String("status", "decommissioning"))
-	}
+	s.broadcastNodeStatus(string(NodeStateDecommissioning))
 	// Start background monitor to auto-mark decommissioned when drained
 	s.startDecommissionMonitor()
 	return nil
+}
+
+// broadcastNodeStatus publishes the node's lifecycle status as a gossip tag so peers exclude it
+// from quorum selection (ServiceDiscovery.excludeDecommissioning). Reports false when gossip is
+// not up yet, so callers on the restart path can retry.
+//
+// Note this is best-effort and eventually consistent: in the run that motivated #257 four peers
+// applied the tag within a second while a fifth took seven, and the client happened to ask that
+// straggler for a quorum. Exclusion shortens the window; it cannot close it. The authoritative
+// enforcement is node-side (RejectNewWrites / MarkRetired).
+func (s *Server) broadcastNodeStatus(status string) bool {
+	s.serverNodeMu.RLock()
+	node := s.serverNode
+	s.serverNodeMu.RUnlock()
+	if node == nil {
+		return false
+	}
+	currentMeta := node.GetMeta()
+	updatedTags := make(map[string]string, len(currentMeta.Tags)+1)
+	for k, v := range currentMeta.Tags {
+		updatedTags[k] = v
+	}
+	updatedTags["status"] = status
+	node.UpdateMeta(map[string]interface{}{
+		"tags": updatedTags,
+	})
+	logger.Ctx(s.ctx).Info("broadcast node status via gossip",
+		zap.String("nodeID", s.serverConfig.NodeID),
+		zap.String("status", status))
+	return true
 }
 
 // GetWriterRegistry returns the logStore as a WriterRegistry for admin inspection.
@@ -952,6 +971,12 @@ func (s *Server) decommissionMonitorLoop(checkInterval time.Duration) {
 						zap.Error(err))
 					continue
 				}
+				// Drained: stop participating in segment lifecycle too. The monitor exits here
+				// and never re-checks, so a fence/complete arriving afterwards (from a peer whose
+				// gossip view is still stale) would re-materialise a staged file and flip
+				// has_local_data back to true for good (#257).
+				s.logStore.MarkRetired()
+				s.broadcastNodeStatus(string(NodeStateDecommissioned))
 				metrics.SetNodeDecommissionProgress(metrics.NodeID, string(s.lifecycle.GetState()), s.logStore.GetActiveProcessorCount(), hasData)
 				logger.Ctx(s.ctx).Info("node decommission complete — no local segment data remaining",
 					zap.String("nodeID", s.serverConfig.NodeID))

--- a/server/service_restart_lifecycle_test.go
+++ b/server/service_restart_lifecycle_test.go
@@ -1,0 +1,116 @@
+// Copyright (C) 2025 Zilliz. All rights reserved.
+//
+// This file is part of the Woodpecker project.
+//
+// Woodpecker is dual-licensed under the GNU Affero General Public License v3.0
+// (AGPLv3) and the Server Side Public License v1 (SSPLv1). You may use this
+// file under either license, at your option.
+//
+// AGPLv3 License: https://www.gnu.org/licenses/agpl-3.0.html
+// SSPLv1 License: https://www.mongodb.com/licensing/server-side-public-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under these licenses is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the license texts for specific language governing permissions and
+// limitations under the licenses.
+
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The monitor is the only place the live decommissioning -> decommissioned transition happens,
+// and it returns immediately afterwards. If it does not retire the log store on the way out,
+// nothing ever will: a later fence/complete from a peer with a stale gossip view re-creates a
+// staged file and flips has_local_data back to true permanently (#257).
+func TestServer_DecommissionMonitor_RetiresLogStoreOnTransition(t *testing.T) {
+	setShortDecommissionInterval(t, 10*time.Millisecond)
+
+	fake := &fakeLogStore{} // HasLocalSegmentData() is false: already drained
+	s := createTestServerWithFakeLogStore(fake)
+	defer s.cancel()
+	s.lifecycle.StartDecommission()
+
+	s.startDecommissionMonitor()
+	s.decommWG.Wait() // the monitor returns once it has marked the node decommissioned
+
+	assert.True(t, s.lifecycle.IsDecommissioned(), "monitor should have completed the transition")
+	assert.True(t, fake.retired, "monitor must retire the log store before exiting")
+}
+
+// Restart must re-apply whatever the persisted lifecycle state implies. The previous code keyed
+// off IsDecommissioning() alone, which matches only the draining state, so a node persisted as
+// decommissioned restarted with no write rejection, no retirement and no gossip tag — back in
+// the cluster indistinguishable from an active node (#257).
+func TestServer_RestoreLifecycleEnforcement(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		setup             func(m *NodeLifecycleManager)
+		wantWritesReject  bool
+		wantRetired       bool
+		wantMonitorResume bool
+	}{
+		{
+			name:  "active restarts unconstrained",
+			setup: func(m *NodeLifecycleManager) {},
+		},
+		{
+			// Still draining: writes stay refused, but fence/complete/compact must keep working
+			// so its own segments can close, and the monitor resumes to finish the transition.
+			name:              "decommissioning re-applies write rejection and resumes monitor",
+			setup:             func(m *NodeLifecycleManager) { m.StartDecommission() },
+			wantWritesReject:  true,
+			wantMonitorResume: true,
+		},
+		{
+			// Terminal: nothing left to drain or monitor, so it also stops participating.
+			name: "decommissioned also retires",
+			setup: func(m *NodeLifecycleManager) {
+				m.StartDecommission()
+				require.NoError(t, m.MarkDecommissioned())
+			},
+			wantWritesReject: true,
+			wantRetired:      true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeLogStore{}
+			s := createTestServerWithFakeLogStore(fake)
+			defer s.cancel()
+			tc.setup(s.lifecycle)
+
+			s.restoreLifecycleEnforcement()
+
+			assert.Equal(t, tc.wantWritesReject, fake.writesRejected, "writes rejected")
+			assert.Equal(t, tc.wantRetired, fake.retired, "retired")
+
+			s.decommMu.Lock()
+			running := s.decommRunning
+			s.decommMu.Unlock()
+			assert.Equal(t, tc.wantMonitorResume, running, "decommission monitor running")
+		})
+	}
+}
+
+// The monitor must not be resumed for a terminally decommissioned node: there is nothing left to
+// drain, and it would be the only thing that could later clear the gate.
+func TestServer_RestoreLifecycleEnforcement_DecommissionedDoesNotResumeMonitor(t *testing.T) {
+	fake := &fakeLogStore{}
+	s := createTestServerWithFakeLogStore(fake)
+	defer s.cancel()
+	s.lifecycle.StartDecommission()
+	require.NoError(t, s.lifecycle.MarkDecommissioned())
+
+	s.restoreLifecycleEnforcement()
+
+	s.decommMu.Lock()
+	defer s.decommMu.Unlock()
+	assert.False(t, s.decommRunning)
+	assert.True(t, fake.retired)
+}

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -448,6 +448,9 @@ type fakeLogStore struct {
 	evictInstanceFn   func(ctx context.Context, bucketName, rootPath string) error
 	notifyCompactedFn func(ctx context.Context, bucketName, rootPath string, logId int64, segmentId int64) error
 	evictReaderFn     func(ctx context.Context, bucketName, rootPath string, logId int64, segId int64) error
+
+	retired        bool // set by MarkRetired
+	writesRejected bool // set by RejectNewWrites, cleared by AllowNewWrites
 }
 
 func (f *fakeLogStore) Start() error       { return nil }
@@ -510,8 +513,9 @@ func (f *fakeLogStore) NotifySegmentCompacted(ctx context.Context, bucketName, r
 }
 
 func (f *fakeLogStore) GetActiveProcessorCount() int { return 0 }
-func (f *fakeLogStore) RejectNewWrites()             {}
-func (f *fakeLogStore) AllowNewWrites()              {}
+func (f *fakeLogStore) RejectNewWrites()             { f.writesRejected = true }
+func (f *fakeLogStore) AllowNewWrites()              { f.writesRejected = false }
+func (f *fakeLogStore) MarkRetired()                 { f.retired = true }
 func (f *fakeLogStore) HasLocalSegmentData() bool    { return false }
 func (f *fakeLogStore) EvictLog(ctx context.Context, bucketName, rootPath string, logId int64) error {
 	if f.evictLogFn != nil {


### PR DESCRIPTION
Fixes #257.

## The defect

A node that had already reached the terminal `decommissioned` state could still be handed a **brand-new** segment and would serve its fence/complete, creating a staged `data.log` for a segment it holds no data for. `HasLocalSegmentData` counted that file, so `has_local_data` flipped back to `true` and `safe_to_terminate` to `false` — **permanently**, because the decommission monitor exits on transition and never re-checks.

Operationally: `wp node drain-status` reports `decommissioned` / `safe_to_terminate: true`, then flips back to `false` and stays stuck forever.

## What actually happened

From nightly run [30765806633](https://github.com/zilliztech/woodpecker/actions/runs/30765806633):

```
20:44:21.399  start decommission, rejectWrites on
20:44:21.579  gossip broadcast status=decommissioning
20:44:26.580  hasLocalSegmentData=false -> marked decommissioned, monitor returns
20:44:28.422  client asks seed 127.0.0.1:36637 for a 3-node quorum
              -> endpoints=[127.0.0.1:36637, 127.0.0.1:37033, 127.0.0.1:38583]   (:38583 = node3)
20:44:28.425  segment 29 created with node3 in its ensemble
20:44:28.434  node3 creates data.log for seg29   (fence -> getOrCreateSegmentWriter(recovery))
20:44:28.466  complete -> Finalize writes header+footer = 78 bytes
```

**node3 never took a single entry for segment 29.** `rejectWrites` did its job: the fence answered `lastEntryId=-1`, `allResults="[-1,0,0]"`, and the completion quorum excluded it —

```
"Replica finalized but does not cover target LAC; excluding it from completion quorum"
  node=127.0.0.1:38583  localLastEntryId=-1
  finalizedCount=3  qualifiedCount=2  ackQuorum=2
```

It contributed nothing to the quorum and still left the file behind. The file was pure side effect.

### Why it was selected at all

Gossip is eventually consistent. There are exactly five `Server updated: node3 (Version: 2)` events in that run: **four at 20:44:21, and a fifth at 20:44:28** — one peer lagged seven seconds, and the client happened to ask that straggler for a quorum. `excludeDecommissioning` is correct and is applied on every selection path including the gRPC seed handler; it simply cannot see what has not arrived yet.

Exclusion shortens that window but can never close it, so the authoritative enforcement has to live on the node itself.

## The fix

Split enforcement by state, matching what each state means:

| | `decommissioning` | `decommissioned` |
|---|---|---|
| AddEntry / AddEntryBatch | refused | refused |
| Fence / Complete / Compact / UpdateLAC | **served** | **refused** |
| Clean / Evict / compacted-mark | served | served |
| reads | served | served |

Keeping fence/complete/compact open while draining is deliberate and load-bearing: that is exactly how the node's own segments get closed, uploaded and cleaned so it can reach the terminal state at all. Once retired there is nothing left to close, and continuing to serve them is what causes the bug.

Refusals return the new **non-retryable** `ErrLogStoreRetired`, so a caller drops the node from the quorum and re-discovers rather than backing off and retrying against a node that will never accept it again.

Cleanup and reads stay open on purpose: they remove data or create nothing, and blocking them would strand whatever the node still holds locally (it can retire with compacted-but-not-yet-GC'd files, which `HasLocalSegmentData` deliberately skips).

Quorum impact is nil for the observed case — fence `successCount` 3→2 with `ackQuorum=2`, and `qualifiedCount` was already 2 because node3 had been excluded anyway.

### Second, independent hole: the restart path

`Start()` keyed off `IsDecommissioning()`, which matches **only** the draining state. A node persisted as `decommissioned` therefore restarted with no write rejection, no retirement, and no status tag broadcast at all — back in the cluster indistinguishable from an active node, accepting appends. That is now driven off the actual persisted state.

The three duplicated gossip-tag blocks are folded into one `broadcastNodeStatus` helper, and the restart branch is extracted to `restoreLifecycleEnforcement()` so it is directly testable.

## Verification

`go test ./server/... ./common/werr/...` passes. `golangci-lint run --config .golangci.yml` reports **0 issues** (run with v2.11.4, the same version CI installs). The `LogStore` mock was regenerated with mockery, adding only the new method (+32 lines, nothing else touched).

New tests, each pinned to a specific claim above:

- `TestLogStore_Retired_RefusesSegmentLifecycleOps` — fence / complete / compact / updateLAC all return `ErrLogStoreRetired`
- `TestLogStore_Decommissioning_StillServesSegmentLifecycleOps` — the draining node still serves fence and complete (against a mock processor) while appends are already refused; this is the property that must not regress
- `TestLogStore_Retired_AllowsCleanupAndReads` — clean and reads reach the processor
- `TestLogStore_Retired_AlsoRejectsWrites` — retiring implies write rejection
- `TestLogStore_Retired_NotClearedByAllowNewWrites` — one-way latch
- `TestErrLogStoreRetired_NotRetryable`
- `TestServer_RestoreLifecycleEnforcement` — table over active / decommissioning / decommissioned, asserting write rejection, retirement and whether the monitor resumes
- `TestServer_DecommissionMonitor_RetiresLogStoreOnTransition` — the monitor retires the store before exiting, which is the only chance it gets
- `TestNodeLifecycleManager_IsDecommissionedOnlyInTerminalState` and an extension of the existing persistence test asserting `IsDecommissioning()` and `IsDecommissioned()` are not conflated

## Not done, deliberately

`HasLocalSegmentData` still counts a zero-entry finalized file as local data. That was considered as a belt-and-braces second layer and rejected: the `decommissioning` window is self-healing (the monitor keeps polling and truncation drives `CleanSegment`, which removes the file), so only the terminal state — where the monitor has already exited — needs a gate.

An earlier idea of not writing the file at all was also rejected: an empty footer is not equivalent to no footer. The footer is how a replica self-describes "this segment is closed here and holds zero entries", and it is read back for idempotent re-finalize and compact safety checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
