### PR TITLE
enhance(monitor): scope dashboards by a woodpecker_id instance label

### DIFF
--- a/tests/docker/monitor/grafana/templates/dashboard_client.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_client.json
@@ -55,7 +55,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_append_requests_total{log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_append_requests_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -106,12 +106,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append latency P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append latency P99",
           "refId": "B"
         }
@@ -162,12 +162,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append bytes P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append bytes P99",
           "refId": "B"
         }
@@ -218,7 +218,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_read_requests_total{log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_read_requests_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -269,12 +269,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Read latency P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Read latency P99",
           "refId": "B"
         }
@@ -325,12 +325,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_reader_bytes_read{log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_reader_bytes_read{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}} read bytes",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(woodpecker_client_writer_bytes_written{log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_writer_bytes_written{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}} write bytes",
           "refId": "B"
         }
@@ -381,7 +381,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
+          "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
           "legendFormat": "op={{operation}} status={{status}}",
           "refId": "A"
         }
@@ -432,7 +432,7 @@
       },
       "targets": [
         {
-          "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{log_ns=~\"$log_ns\"}) by (log_id)",
+          "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_log_name_id_mapping{log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_log_name_id_mapping{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -541,7 +541,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_segment_state{log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_segment_state{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} {{state}}",
           "refId": "A"
         }
@@ -581,7 +581,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_active_segment_node{log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_active_segment_node{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -652,7 +652,7 @@
       },
       "targets": [
         {
-          "expr": "count by (node) (woodpecker_client_active_segment_node{log_ns=~\"$log_ns\"})",
+          "expr": "count by (node) (woodpecker_client_active_segment_node{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"})",
           "legendFormat": "{{node}}",
           "refId": "A"
         }
@@ -714,17 +714,17 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_write_frontier_segment{log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_write_frontier_segment{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} write",
           "refId": "A"
         },
         {
-          "expr": "woodpecker_client_compaction_frontier_segment{log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_compaction_frontier_segment{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} compacted",
           "refId": "B"
         },
         {
-          "expr": "woodpecker_client_truncation_frontier_segment{log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_truncation_frontier_segment{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} truncated",
           "refId": "C"
         }
@@ -775,17 +775,17 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_write_frontier_entry{log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_write_frontier_entry{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} write",
           "refId": "A"
         },
         {
-          "expr": "woodpecker_client_compaction_frontier_entry{log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_compaction_frontier_entry{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} compacted",
           "refId": "B"
         },
         {
-          "expr": "woodpecker_client_truncation_frontier_entry{log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_truncation_frontier_entry{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} truncated",
           "refId": "C"
         }
@@ -836,7 +836,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_segment_compaction_failures_total{log_ns=~\"$log_ns\"}[1m])) by (log_id, reason)",
+          "expr": "sum(rate(woodpecker_client_segment_compaction_failures_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, reason)",
           "legendFormat": "logID={{log_id}} reason={{reason}}",
           "refId": "A"
         }
@@ -897,7 +897,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(grpc_server_started_total[1m])) by (grpc_method)",
+              "expr": "sum(rate(grpc_server_started_total{woodpecker_id=~\"$woodpecker_id\"}[1m])) by (grpc_method)",
               "legendFormat": "method={{grpc_method}}",
               "refId": "A"
             }
@@ -948,7 +948,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(grpc_server_handled_total{grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
+              "expr": "sum(rate(grpc_server_handled_total{woodpecker_id=~\"$woodpecker_id\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
               "legendFormat": "method={{grpc_method}} code={{grpc_code}}",
               "refId": "A"
             }
@@ -999,12 +999,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket[1m])) by (grpc_method, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{woodpecker_id=~\"$woodpecker_id\"}[1m])) by (grpc_method, le))",
               "legendFormat": "method={{grpc_method}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket[1m])) by (grpc_method, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{woodpecker_id=~\"$woodpecker_id\"}[1m])) by (grpc_method, le))",
               "legendFormat": "method={{grpc_method}} P99",
               "refId": "B"
             }
@@ -1037,8 +1037,25 @@
         },
         "includeAll": true,
         "multi": true,
+        "name": "woodpecker_id",
+        "query": "label_values(woodpecker_client_append_requests_total, woodpecker_id)",
+        "refresh": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "__DATASOURCE_UID__"
+        },
+        "includeAll": true,
+        "multi": true,
         "name": "log_ns",
-        "query": "label_values(woodpecker_client_append_requests_total, log_ns)",
+        "query": "label_values(woodpecker_client_append_requests_total{woodpecker_id=~\"$woodpecker_id\"}, log_ns)",
         "refresh": 2,
         "type": "query"
       }

--- a/tests/docker/monitor/grafana/templates/dashboard_server.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_server.json
@@ -54,12 +54,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_active_logs{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_active_logs{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} logs",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_logstore_active_segments{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_active_segments{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} segments",
               "refId": "B"
             }
@@ -110,7 +110,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_instances_total{log_ns=~\"$log_ns\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_instances_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -161,7 +161,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_logstore_operations_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
+              "expr": "sum(rate(woodpecker_server_logstore_operations_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
               "legendFormat": "op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -212,12 +212,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
               "legendFormat": "op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
               "legendFormat": "op={{operation}} P99",
               "refId": "B"
             }
@@ -268,7 +268,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_active_segment_processors{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_logstore_active_segment_processors{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -333,12 +333,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Buffer P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Buffer P99",
               "refId": "B"
             }
@@ -389,7 +389,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_file_operations_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+              "expr": "sum(rate(woodpecker_server_file_operations_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
               "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -440,12 +440,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -496,12 +496,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_writer{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+              "expr": "sum(woodpecker_server_file_writer{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
               "legendFormat": "{{node_id}} logID={{log_id}} writer",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_file_reader{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+              "expr": "sum(woodpecker_server_file_reader{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
               "legendFormat": "{{node_id}} logID={{log_id}} reader",
               "refId": "B"
             }
@@ -552,12 +552,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Flush P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Flush P99",
               "refId": "B"
             }
@@ -608,12 +608,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} ReadBatch P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} ReadBatch P99",
               "refId": "B"
             }
@@ -664,12 +664,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Compact P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Compact P99",
               "refId": "B"
             }
@@ -720,12 +720,12 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_flush_bytes_written{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+              "expr": "sum(rate(woodpecker_server_flush_bytes_written{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
               "legendFormat": "{{node_id}} flush",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(woodpecker_server_compact_bytes_written{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+              "expr": "sum(rate(woodpecker_server_compact_bytes_written{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
               "legendFormat": "{{node_id}} compact",
               "refId": "B"
             }
@@ -790,7 +790,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_object_storage_operations_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+              "expr": "sum(rate(woodpecker_server_object_storage_operations_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
               "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -841,12 +841,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -897,12 +897,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -953,7 +953,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
+              "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
               "legendFormat": "{{node_id}} op={{operation}}",
               "refId": "A"
             }
@@ -1018,7 +1018,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_cpu_usage) by (node_id)",
+              "expr": "sum(woodpecker_server_system_cpu_usage{woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -1069,12 +1069,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_memory_used_bytes) by (node_id)",
+              "expr": "sum(woodpecker_server_system_memory_used_bytes{woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} used",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_system_memory_usage_ratio) by (node_id)",
+              "expr": "sum(woodpecker_server_system_memory_usage_ratio{woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} ratio",
               "refId": "B"
             }
@@ -1125,12 +1125,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_disk_used_bytes) by (node_id)",
+              "expr": "sum(woodpecker_server_system_disk_used_bytes{woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} used",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_system_disk_total_bytes) by (node_id)",
+              "expr": "sum(woodpecker_server_system_disk_total_bytes{woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} total",
               "refId": "B"
             }
@@ -1181,7 +1181,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_io_wait) by (node_id)",
+              "expr": "sum(woodpecker_server_system_io_wait{woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -1232,7 +1232,7 @@
           },
           "targets": [
             {
-              "expr": "process_open_fds{job=~\"$server_job\"}",
+              "expr": "process_open_fds{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} open",
               "refId": "A"
             }
@@ -1283,12 +1283,12 @@
           },
           "targets": [
             {
-              "expr": "rate(process_network_receive_bytes_total{job=~\"$server_job\"}[1m])",
+              "expr": "rate(process_network_receive_bytes_total{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])",
               "legendFormat": "{{pod}} {{instance}} rx",
               "refId": "A"
             },
             {
-              "expr": "rate(process_network_transmit_bytes_total{job=~\"$server_job\"}[1m])",
+              "expr": "rate(process_network_transmit_bytes_total{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])",
               "legendFormat": "{{pod}} {{instance}} tx",
               "refId": "B"
             }
@@ -1339,7 +1339,7 @@
           },
           "targets": [
             {
-              "expr": "process_open_fds{job=~\"$server_job\"} / process_max_fds{job=~\"$server_job\"}",
+              "expr": "process_open_fds{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"} / process_max_fds{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1390,7 +1390,7 @@
           },
           "targets": [
             {
-              "expr": "time() - process_start_time_seconds{job=~\"$server_job\"}",
+              "expr": "time() - process_start_time_seconds{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1441,7 +1441,7 @@
           },
           "targets": [
             {
-              "expr": "process_virtual_memory_bytes{job=~\"$server_job\"}",
+              "expr": "process_virtual_memory_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1528,7 +1528,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_disk_usage_ratio) by (node_id, path)",
+              "expr": "sum(woodpecker_server_logstore_disk_usage_ratio{woodpecker_id=~\"$woodpecker_id\"}) by (node_id, path)",
               "legendFormat": "nodeID={{node_id}} path={{path}}",
               "refId": "A"
             }
@@ -1579,7 +1579,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_disk_free_bytes) by (node_id, path)",
+              "expr": "sum(woodpecker_server_logstore_disk_free_bytes{woodpecker_id=~\"$woodpecker_id\"}) by (node_id, path)",
               "legendFormat": "nodeID={{node_id}} path={{path}}",
               "refId": "A"
             }
@@ -1633,7 +1633,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_write_backpressure_state) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_write_backpressure_state{woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} (0=normal 1=warn 2=blocked)",
               "refId": "A"
             }
@@ -1686,7 +1686,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_write_reject_probability) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_write_reject_probability{woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -1737,7 +1737,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_logstore_write_rejected_total[1m])) by (node_id, reason)",
+              "expr": "sum(rate(woodpecker_server_logstore_write_rejected_total{woodpecker_id=~\"$woodpecker_id\"}[1m])) by (node_id, reason)",
               "legendFormat": "nodeID={{node_id}} reason={{reason}}",
               "refId": "A"
             }
@@ -1802,7 +1802,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(process_cpu_seconds_total{job=~\"$server_job\"}[1m])) by (pod, instance)",
+              "expr": "sum(rate(process_cpu_seconds_total{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])) by (pod, instance)",
               "legendFormat": "{{pod}} {{instance}} cpu",
               "refId": "A"
             }
@@ -1853,7 +1853,7 @@
           },
           "targets": [
             {
-              "expr": "sum(process_resident_memory_bytes{job=~\"$server_job\"}) by (pod, instance)",
+              "expr": "sum(process_resident_memory_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}) by (pod, instance)",
               "legendFormat": "{{pod}} {{instance}} memory",
               "refId": "A"
             }
@@ -1904,7 +1904,7 @@
           },
           "targets": [
             {
-              "expr": "sum(go_goroutines{job=~\"$server_job\"}) by (pod, instance)",
+              "expr": "sum(go_goroutines{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}) by (pod, instance)",
               "legendFormat": "{{pod}} {{instance}} goroutines",
               "refId": "A"
             }
@@ -1955,7 +1955,7 @@
           },
           "targets": [
             {
-              "expr": "rate(process_cpu_seconds_total{job=~\"$server_job\"}[1m])",
+              "expr": "rate(process_cpu_seconds_total{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2006,7 +2006,7 @@
           },
           "targets": [
             {
-              "expr": "process_resident_memory_bytes{job=~\"$server_job\"}",
+              "expr": "process_resident_memory_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2057,7 +2057,7 @@
           },
           "targets": [
             {
-              "expr": "go_goroutines{job=~\"$server_job\"}",
+              "expr": "go_goroutines{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2108,7 +2108,7 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_alloc_bytes{job=~\"$server_job\"}",
+              "expr": "go_memstats_alloc_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2159,17 +2159,17 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_heap_inuse_bytes{job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_inuse_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} in-use",
               "refId": "A"
             },
             {
-              "expr": "go_memstats_heap_idle_bytes{job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_idle_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} idle",
               "refId": "B"
             },
             {
-              "expr": "go_memstats_heap_released_bytes{job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_released_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} released",
               "refId": "C"
             }
@@ -2220,7 +2220,7 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_heap_objects{job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_objects{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2271,7 +2271,7 @@
           },
           "targets": [
             {
-              "expr": "go_gc_duration_seconds{job=~\"$server_job\", quantile=\"1\"}",
+              "expr": "go_gc_duration_seconds{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\", quantile=\"1\"}",
               "legendFormat": "{{pod}} {{instance}} max",
               "refId": "A"
             }
@@ -2322,7 +2322,7 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_gc_cpu_fraction{job=~\"$server_job\"}",
+              "expr": "go_memstats_gc_cpu_fraction{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2373,12 +2373,12 @@
           },
           "targets": [
             {
-              "expr": "rate(go_memstats_mallocs_total{job=~\"$server_job\"}[2m])",
+              "expr": "rate(go_memstats_mallocs_total{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[2m])",
               "legendFormat": "{{pod}} {{instance}} mallocs",
               "refId": "A"
             },
             {
-              "expr": "rate(go_memstats_frees_total{job=~\"$server_job\"}[2m])",
+              "expr": "rate(go_memstats_frees_total{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[2m])",
               "legendFormat": "{{pod}} {{instance}} frees",
               "refId": "B"
             }
@@ -2429,7 +2429,7 @@
           },
           "targets": [
             {
-              "expr": "rate(go_memstats_alloc_bytes_total{job=~\"$server_job\"}[5m])",
+              "expr": "rate(go_memstats_alloc_bytes_total{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[5m])",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2480,12 +2480,12 @@
           },
           "targets": [
             {
-              "expr": "go_sched_gomaxprocs_threads{job=~\"$server_job\"}",
+              "expr": "go_sched_gomaxprocs_threads{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} GOMAXPROCS",
               "refId": "A"
             },
             {
-              "expr": "go_threads{job=~\"$server_job\"}",
+              "expr": "go_threads{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} threads",
               "refId": "B"
             }
@@ -2536,7 +2536,7 @@
           },
           "targets": [
             {
-              "expr": "rate(go_gc_duration_seconds_count{job=~\"$server_job\"}[5m])",
+              "expr": "rate(go_gc_duration_seconds_count{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[5m])",
               "legendFormat": "{{pod}} {{instance}} GC/s",
               "refId": "A"
             }
@@ -2587,12 +2587,12 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_sys_bytes{job=~\"$server_job\"}",
+              "expr": "go_memstats_sys_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} sys",
               "refId": "A"
             },
             {
-              "expr": "go_memstats_stack_inuse_bytes{job=~\"$server_job\"}",
+              "expr": "go_memstats_stack_inuse_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} stack",
               "refId": "B"
             }
@@ -2643,12 +2643,12 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_next_gc_bytes{job=~\"$server_job\"}",
+              "expr": "go_memstats_next_gc_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} next GC",
               "refId": "A"
             },
             {
-              "expr": "go_gc_gomemlimit_bytes{job=~\"$server_job\"}",
+              "expr": "go_gc_gomemlimit_bytes{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} memory limit",
               "refId": "B"
             }
@@ -2713,7 +2713,7 @@
           },
           "targets": [
             {
-              "expr": "woodpecker_server_op_registry_pool_usage{job=~\"$server_job\"}",
+              "expr": "woodpecker_server_op_registry_pool_usage{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2764,7 +2764,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{job=~\"$server_job\"}[1m])) by (signal)",
+              "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])) by (signal)",
               "legendFormat": "{{signal}}",
               "refId": "A"
             }
@@ -2815,7 +2815,7 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{job=~\"$server_job\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[5m])) by (le))",
               "legendFormat": "P99",
               "refId": "A"
             }
@@ -2880,7 +2880,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_stored_bytes{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_file_stored_bytes{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2931,7 +2931,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_object_storage_stored_bytes{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_object_storage_stored_bytes{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2982,7 +2982,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_stored_count{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_file_stored_count{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -3033,7 +3033,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_object_storage_stored_objects{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_object_storage_stored_objects{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -3098,7 +3098,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
               "legendFormat": "node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "A"
             }
@@ -3149,12 +3149,12 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
               "legendFormat": "reclaimed node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
               "legendFormat": "marks node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "B"
             }
@@ -3205,7 +3205,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, reason)",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, reason)",
               "legendFormat": "node={{node_id}} logID={{log_id}} reason={{reason}}",
               "refId": "A"
             }
@@ -3256,17 +3256,17 @@
           },
           "targets": [
             {
-              "expr": "woodpecker_server_node_lifecycle_state{job=~\"$server_job\"}",
+              "expr": "woodpecker_server_node_lifecycle_state{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "node={{node_id}} state={{state}}",
               "refId": "A"
             },
             {
-              "expr": "woodpecker_server_node_decommission_has_local_data{job=~\"$server_job\"}",
+              "expr": "woodpecker_server_node_decommission_has_local_data{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "node={{node_id}} has_local_data",
               "refId": "B"
             },
             {
-              "expr": "woodpecker_server_node_decommission_safe_to_terminate{job=~\"$server_job\"}",
+              "expr": "woodpecker_server_node_decommission_safe_to_terminate{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "node={{node_id}} safe_to_terminate",
               "refId": "C"
             }
@@ -3317,7 +3317,7 @@
           },
           "targets": [
             {
-              "expr": "woodpecker_server_node_decommission_remaining_processors{job=~\"$server_job\"}",
+              "expr": "woodpecker_server_node_decommission_remaining_processors{woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "node={{node_id}}",
               "refId": "A"
             }
@@ -3350,8 +3350,25 @@
         },
         "includeAll": true,
         "multi": true,
+        "name": "woodpecker_id",
+        "query": "label_values(woodpecker_server_logstore_instances_total, woodpecker_id)",
+        "refresh": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "__DATASOURCE_UID__"
+        },
+        "includeAll": true,
+        "multi": true,
         "name": "log_ns",
-        "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{log_ns=~\".+\"}))",
+        "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{woodpecker_id=~\"$woodpecker_id\", log_ns=~\".+\"}))",
         "refresh": 2,
         "regex": "/log_ns=\"([^\"]+)\"/",
         "type": "query"
@@ -3369,7 +3386,7 @@
         "includeAll": true,
         "multi": true,
         "name": "log_id",
-        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{log_ns=~\"$log_ns\", log_id=~\".+\"}))",
+        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
         "refresh": 2,
         "regex": "/log_id=\"([^\"]+)\"/",
         "type": "query"
@@ -3388,7 +3405,7 @@
         "includeAll": true,
         "multi": true,
         "name": "server_job",
-        "query": "label_values(woodpecker_server_logstore_instances_total, job)",
+        "query": "label_values(woodpecker_server_logstore_instances_total{woodpecker_id=~\"$woodpecker_id\"}, job)",
         "refresh": 2,
         "type": "query"
       }

--- a/tests/docker/monitor/prometheus.yml
+++ b/tests/docker/monitor/prometheus.yml
@@ -2,20 +2,29 @@ global:
   scrape_interval: 5s
   evaluation_interval: 5s
 
+# woodpecker_id identifies the woodpecker cluster a target belongs to. The k8s
+# suite derives it from the pod's app.kubernetes.io/instance label; here the
+# compose file defines a single cluster, so the value is stamped statically —
+# both suites end up with the same label scheme and the same dashboards work.
 scrape_configs:
   - job_name: woodpecker-node1
     static_configs:
       - targets: ['woodpecker-node1:9091']
+        labels: { woodpecker_id: my-woodpecker }
   - job_name: woodpecker-node2
     static_configs:
       - targets: ['woodpecker-node2:9092']
+        labels: { woodpecker_id: my-woodpecker }
   - job_name: woodpecker-node3
     static_configs:
       - targets: ['woodpecker-node3:9093']
+        labels: { woodpecker_id: my-woodpecker }
   - job_name: woodpecker-node4
     static_configs:
       - targets: ['woodpecker-node4:9094']
+        labels: { woodpecker_id: my-woodpecker }
   # Client metrics exposed by the Go test process on the host machine.
   - job_name: woodpecker-test-client
     static_configs:
       - targets: ['host.docker.internal:29099']
+        labels: { woodpecker_id: my-woodpecker }

--- a/tests/k8s/monitor/README.md
+++ b/tests/k8s/monitor/README.md
@@ -36,19 +36,31 @@ resources before running:
 MK_CPUS=6 MK_MEMORY=8192 ./run_monitor_tests.sh
 ```
 
-## Label Scheme: `namespace` / `log_ns`
+## Label Scheme: `namespace` / `woodpecker_id` / `log_ns`
 
-Woodpecker metrics carry two key labels:
+Woodpecker metrics carry three key labels:
 
 | Label | Value | Source |
 |-------|-------|--------|
 | `namespace` | Kubernetes namespace (e.g. `woodpecker`) | injected by kube-prometheus-stack from the PodMonitor namespace |
+| `woodpecker_id` | Woodpecker cluster instance (e.g. `my-woodpecker`) | relabeled by the PodMonitors from the pod's `app.kubernetes.io/instance` label, with the `wp-` prefix stripped |
 | `log_ns` | Woodpecker logical log namespace (e.g. `my-log`) | emitted by the server/client as a metric label |
+
+`woodpecker_id` exists because a namespace may host several woodpecker
+clusters (a pooled deployment runs one StatefulSet per instance, named
+`wp-<id>`). prometheus-operator derives `job` from the PodMonitor, so every
+instance in the pool shares one `job` value and only the instance label can
+tell them apart. Its `All` option is `.*` rather than the generated value
+list, so targets scraped without the relabel — where the label is absent —
+still match.
 
 Dashboards derive everything else from these: the `namespace` dropdown is
 discovered via `go_info`, and the hidden `server_job` variable resolves the
 PodMonitor-assigned `job` label within the selected namespace (also via
 `go_info`), so no job name or cluster name is hardcoded.
+
+The docker monitor suite stamps the same `woodpecker_id` value statically in
+`tests/docker/monitor/prometheus.yml`, so one dashboard layout serves both.
 
 ### Breaking-change note for production dashboards
 
@@ -78,5 +90,16 @@ The test checks:
 3. **ServerMetrics** — core server metrics are present and non-zero.
 4. **ClientMetrics** — core client metrics are present and non-zero.
 5. **LabelScheme** — every `woodpecker_server_logstore_active_logs` series
-   carries `namespace=woodpecker`, a non-empty `log_ns`, and no
-   `exported_namespace` (which would indicate a relabeling conflict).
+   carries `namespace=woodpecker`, `woodpecker_id=$CR_NAME`, a non-empty
+   `log_ns`, and no `exported_namespace` (which would indicate a relabeling
+   conflict).
+
+`dashboards_test.go` runs without a cluster: it validates the dashboard
+templates and checks that `manifests/dashboard-configmaps.yaml` still matches
+them, since `run_monitor_tests.sh` applies the ConfigMaps and a stale manifest
+would silently deploy an outdated dashboard. Regenerate it after editing a
+template:
+
+```bash
+go test ./tests/k8s/monitor -run TestK8sDashboardConfigMaps_InSync -update
+```

--- a/tests/k8s/monitor/dashboards_test.go
+++ b/tests/k8s/monitor/dashboards_test.go
@@ -17,8 +17,12 @@
 package monitor
 
 import (
+	"bytes"
 	"encoding/json"
+	"flag"
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -50,10 +54,76 @@ func TestK8sDashboards_Valid(t *testing.T) {
 		for _, v := range obj["templating"].(map[string]any)["list"].([]any) {
 			names[v.(map[string]any)["name"].(string)] = true
 		}
-		for _, want := range []string{"prometheus", "namespace", "log_ns"} {
+		for _, want := range []string{"prometheus", "namespace", "woodpecker_id", "log_ns"} {
 			if !names[want] {
 				t.Errorf("%s: missing template var %q", f, want)
 			}
 		}
+	}
+}
+
+var updateConfigMaps = flag.Bool("update", false,
+	"regenerate manifests/dashboard-configmaps.yaml from the dashboard templates")
+
+const dashboardConfigMapPath = "manifests/dashboard-configmaps.yaml"
+
+var dashboardConfigMaps = []struct {
+	name string
+	file string
+}{
+	{"woodpecker-server-k8s-dashboard", "dashboard_server_k8s.json"},
+	{"woodpecker-client-k8s-dashboard", "dashboard_client_k8s.json"},
+}
+
+// renderDashboardConfigMaps embeds the dashboard templates verbatim into the
+// ConfigMap manifest the Grafana sidecar imports.
+func renderDashboardConfigMaps() ([]byte, error) {
+	var b strings.Builder
+	b.WriteString("# Generated from grafana/templates/*.json — Grafana sidecar imports these.\n")
+	for _, cm := range dashboardConfigMaps {
+		raw, err := os.ReadFile(filepath.Join("grafana", "templates", cm.file))
+		if err != nil {
+			return nil, err
+		}
+		b.WriteString("---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n")
+		fmt.Fprintf(&b, "  name: %s\n", cm.name)
+		b.WriteString("  namespace: monitoring\n")
+		b.WriteString("  labels: { grafana_dashboard: \"1\" }\n")
+		b.WriteString("data:\n")
+		fmt.Fprintf(&b, "  %s: |\n", cm.file)
+		for line := range strings.SplitSeq(strings.TrimRight(string(raw), "\n"), "\n") {
+			if line == "" {
+				b.WriteString("\n")
+				continue
+			}
+			b.WriteString("    " + line + "\n")
+		}
+	}
+	return []byte(b.String()), nil
+}
+
+// TestK8sDashboardConfigMaps_InSync guards the generated manifest against
+// drifting from the templates: run_monitor_tests.sh applies the ConfigMaps, so
+// a stale manifest silently deploys an outdated dashboard.
+func TestK8sDashboardConfigMaps_InSync(t *testing.T) {
+	want, err := renderDashboardConfigMaps()
+	if err != nil {
+		t.Fatalf("render config maps: %v", err)
+	}
+	if *updateConfigMaps {
+		if err := os.WriteFile(dashboardConfigMapPath, want, 0o644); err != nil {
+			t.Fatalf("write %s: %v", dashboardConfigMapPath, err)
+		}
+		t.Logf("regenerated %s", dashboardConfigMapPath)
+		return
+	}
+	got, err := os.ReadFile(dashboardConfigMapPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", dashboardConfigMapPath, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("%s is out of sync with grafana/templates/*.json; regenerate with:\n"+
+			"\tgo test ./tests/k8s/monitor -run TestK8sDashboardConfigMaps_InSync -update",
+			dashboardConfigMapPath)
 	}
 }

--- a/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
@@ -55,7 +55,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_append_requests_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_append_requests_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -106,12 +106,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append latency P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append latency P99",
           "refId": "B"
         }
@@ -162,12 +162,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append bytes P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Append bytes P99",
           "refId": "B"
         }
@@ -218,7 +218,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_read_requests_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_read_requests_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -269,12 +269,12 @@
       },
       "targets": [
         {
-          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Read latency P50",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
           "legendFormat": "logID={{log_id}} Read latency P99",
           "refId": "B"
         }
@@ -325,12 +325,12 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_reader_bytes_read{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_reader_bytes_read{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}} read bytes",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(woodpecker_client_writer_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+          "expr": "sum(rate(woodpecker_client_writer_bytes_written{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
           "legendFormat": "logID={{log_id}} write bytes",
           "refId": "B"
         }
@@ -381,7 +381,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
+          "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
           "legendFormat": "op={{operation}} status={{status}}",
           "refId": "A"
         }
@@ -432,7 +432,7 @@
       },
       "targets": [
         {
-          "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (log_id)",
+          "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}) by (log_id)",
           "legendFormat": "logID={{log_id}}",
           "refId": "A"
         }
@@ -472,7 +472,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_log_name_id_mapping{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_log_name_id_mapping{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -541,7 +541,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_segment_state{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_segment_state{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} {{state}}",
           "refId": "A"
         }
@@ -581,7 +581,7 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_active_segment_node{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_active_segment_node{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "",
@@ -652,7 +652,7 @@
       },
       "targets": [
         {
-          "expr": "count by (node) (woodpecker_client_active_segment_node{namespace=~\"$namespace\", log_ns=~\"$log_ns\"})",
+          "expr": "count by (node) (woodpecker_client_active_segment_node{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"})",
           "legendFormat": "{{node}}",
           "refId": "A"
         }
@@ -714,17 +714,17 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_write_frontier_segment{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_write_frontier_segment{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} write",
           "refId": "A"
         },
         {
-          "expr": "woodpecker_client_compaction_frontier_segment{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_compaction_frontier_segment{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} compacted",
           "refId": "B"
         },
         {
-          "expr": "woodpecker_client_truncation_frontier_segment{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_truncation_frontier_segment{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} truncated",
           "refId": "C"
         }
@@ -775,17 +775,17 @@
       },
       "targets": [
         {
-          "expr": "woodpecker_client_write_frontier_entry{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_write_frontier_entry{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} write",
           "refId": "A"
         },
         {
-          "expr": "woodpecker_client_compaction_frontier_entry{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_compaction_frontier_entry{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} compacted",
           "refId": "B"
         },
         {
-          "expr": "woodpecker_client_truncation_frontier_entry{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+          "expr": "woodpecker_client_truncation_frontier_entry{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
           "legendFormat": "logID={{log_id}} truncated",
           "refId": "C"
         }
@@ -836,7 +836,7 @@
       },
       "targets": [
         {
-          "expr": "sum(rate(woodpecker_client_segment_compaction_failures_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, reason)",
+          "expr": "sum(rate(woodpecker_client_segment_compaction_failures_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, reason)",
           "legendFormat": "logID={{log_id}} reason={{reason}}",
           "refId": "A"
         }
@@ -897,7 +897,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(grpc_server_started_total{namespace=~\"$namespace\"}[1m])) by (grpc_method)",
+              "expr": "sum(rate(grpc_server_started_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}[1m])) by (grpc_method)",
               "legendFormat": "method={{grpc_method}}",
               "refId": "A"
             }
@@ -948,7 +948,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(grpc_server_handled_total{namespace=~\"$namespace\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
+              "expr": "sum(rate(grpc_server_handled_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
               "legendFormat": "method={{grpc_method}} code={{grpc_code}}",
               "refId": "A"
             }
@@ -999,12 +999,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}[1m])) by (grpc_method, le))",
               "legendFormat": "method={{grpc_method}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}[1m])) by (grpc_method, le))",
               "legendFormat": "method={{grpc_method}} P99",
               "refId": "B"
             }
@@ -1055,6 +1055,23 @@
         }
       },
       {
+        "name": "woodpecker_id",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "query": "label_values(go_info{namespace=~\"$namespace\"}, woodpecker_id)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
         "allValue": ".*",
         "current": {
           "text": "All",
@@ -1067,7 +1084,7 @@
         "includeAll": true,
         "multi": true,
         "name": "log_ns",
-        "query": "label_values(woodpecker_client_append_requests_total{namespace=~\"$namespace\"}, log_ns)",
+        "query": "label_values(woodpecker_client_append_requests_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}, log_ns)",
         "refresh": 2,
         "type": "query"
       }

--- a/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_server_k8s.json
@@ -54,12 +54,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} logs",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} segments",
               "refId": "B"
             }
@@ -110,7 +110,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_instances_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_instances_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -161,7 +161,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_logstore_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
+              "expr": "sum(rate(woodpecker_server_logstore_operations_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
               "legendFormat": "op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -212,12 +212,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
               "legendFormat": "op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
               "legendFormat": "op={{operation}} P99",
               "refId": "B"
             }
@@ -268,7 +268,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_active_segment_processors{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_logstore_active_segment_processors{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -333,12 +333,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Buffer P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Buffer P99",
               "refId": "B"
             }
@@ -389,7 +389,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_file_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+              "expr": "sum(rate(woodpecker_server_file_operations_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
               "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -440,12 +440,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -496,12 +496,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_writer{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+              "expr": "sum(woodpecker_server_file_writer{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
               "legendFormat": "{{node_id}} logID={{log_id}} writer",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_file_reader{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+              "expr": "sum(woodpecker_server_file_reader{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
               "legendFormat": "{{node_id}} logID={{log_id}} reader",
               "refId": "B"
             }
@@ -552,12 +552,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Flush P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Flush P99",
               "refId": "B"
             }
@@ -608,12 +608,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} ReadBatch P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} ReadBatch P99",
               "refId": "B"
             }
@@ -664,12 +664,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Compact P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
               "legendFormat": "{{node_id}} Compact P99",
               "refId": "B"
             }
@@ -720,12 +720,12 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_flush_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+              "expr": "sum(rate(woodpecker_server_flush_bytes_written{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
               "legendFormat": "{{node_id}} flush",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(woodpecker_server_compact_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+              "expr": "sum(rate(woodpecker_server_compact_bytes_written{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
               "legendFormat": "{{node_id}} compact",
               "refId": "B"
             }
@@ -790,7 +790,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_object_storage_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+              "expr": "sum(rate(woodpecker_server_object_storage_operations_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
               "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -841,12 +841,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -897,12 +897,12 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
               "legendFormat": "{{node_id}} op={{operation}} P99",
               "refId": "B"
             }
@@ -953,7 +953,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
+              "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
               "legendFormat": "{{node_id}} op={{operation}}",
               "refId": "A"
             }
@@ -1018,7 +1018,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_cpu_usage{namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_cpu_usage{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -1069,12 +1069,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_memory_used_bytes{namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_memory_used_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} used",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_system_memory_usage_ratio{namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_memory_usage_ratio{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} ratio",
               "refId": "B"
             }
@@ -1125,12 +1125,12 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_disk_used_bytes{namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_disk_used_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} used",
               "refId": "A"
             },
             {
-              "expr": "sum(woodpecker_server_system_disk_total_bytes{namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_disk_total_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} total",
               "refId": "B"
             }
@@ -1181,7 +1181,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_system_io_wait{namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_system_io_wait{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -1232,7 +1232,7 @@
           },
           "targets": [
             {
-              "expr": "process_open_fds{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "process_open_fds{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} open",
               "refId": "A"
             }
@@ -1283,12 +1283,12 @@
           },
           "targets": [
             {
-              "expr": "rate(process_network_receive_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+              "expr": "rate(process_network_receive_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])",
               "legendFormat": "{{pod}} {{instance}} rx",
               "refId": "A"
             },
             {
-              "expr": "rate(process_network_transmit_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+              "expr": "rate(process_network_transmit_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])",
               "legendFormat": "{{pod}} {{instance}} tx",
               "refId": "B"
             }
@@ -1339,7 +1339,7 @@
           },
           "targets": [
             {
-              "expr": "process_open_fds{namespace=~\"$namespace\", job=~\"$server_job\"} / process_max_fds{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "process_open_fds{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"} / process_max_fds{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1390,7 +1390,7 @@
           },
           "targets": [
             {
-              "expr": "time() - process_start_time_seconds{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "time() - process_start_time_seconds{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1441,7 +1441,7 @@
           },
           "targets": [
             {
-              "expr": "process_virtual_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "process_virtual_memory_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -1528,7 +1528,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_disk_usage_ratio{namespace=~\"$namespace\"}) by (node_id, path)",
+              "expr": "sum(woodpecker_server_logstore_disk_usage_ratio{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id, path)",
               "legendFormat": "nodeID={{node_id}} path={{path}}",
               "refId": "A"
             }
@@ -1579,7 +1579,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_disk_free_bytes{namespace=~\"$namespace\"}) by (node_id, path)",
+              "expr": "sum(woodpecker_server_logstore_disk_free_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id, path)",
               "legendFormat": "nodeID={{node_id}} path={{path}}",
               "refId": "A"
             }
@@ -1633,7 +1633,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_write_backpressure_state{namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_write_backpressure_state{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}} (0=normal 1=warn 2=blocked)",
               "refId": "A"
             }
@@ -1686,7 +1686,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_logstore_write_reject_probability{namespace=~\"$namespace\"}) by (node_id)",
+              "expr": "sum(woodpecker_server_logstore_write_reject_probability{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
               "legendFormat": "nodeID={{node_id}}",
               "refId": "A"
             }
@@ -1737,7 +1737,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_logstore_write_rejected_total{namespace=~\"$namespace\"}[1m])) by (node_id, reason)",
+              "expr": "sum(rate(woodpecker_server_logstore_write_rejected_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}[1m])) by (node_id, reason)",
               "legendFormat": "nodeID={{node_id}} reason={{reason}}",
               "refId": "A"
             }
@@ -1802,7 +1802,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(process_cpu_seconds_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (pod, instance)",
+              "expr": "sum(rate(process_cpu_seconds_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])) by (pod, instance)",
               "legendFormat": "{{pod}} {{instance}} cpu",
               "refId": "A"
             }
@@ -1853,7 +1853,7 @@
           },
           "targets": [
             {
-              "expr": "sum(process_resident_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+              "expr": "sum(process_resident_memory_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}) by (pod, instance)",
               "legendFormat": "{{pod}} {{instance}} memory",
               "refId": "A"
             }
@@ -1904,7 +1904,7 @@
           },
           "targets": [
             {
-              "expr": "sum(go_goroutines{namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+              "expr": "sum(go_goroutines{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}) by (pod, instance)",
               "legendFormat": "{{pod}} {{instance}} goroutines",
               "refId": "A"
             }
@@ -1955,7 +1955,7 @@
           },
           "targets": [
             {
-              "expr": "rate(process_cpu_seconds_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+              "expr": "rate(process_cpu_seconds_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2006,7 +2006,7 @@
           },
           "targets": [
             {
-              "expr": "process_resident_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "process_resident_memory_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2057,7 +2057,7 @@
           },
           "targets": [
             {
-              "expr": "go_goroutines{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_goroutines{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2108,7 +2108,7 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_alloc_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_alloc_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2159,17 +2159,17 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} in-use",
               "refId": "A"
             },
             {
-              "expr": "go_memstats_heap_idle_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_idle_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} idle",
               "refId": "B"
             },
             {
-              "expr": "go_memstats_heap_released_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_released_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} released",
               "refId": "C"
             }
@@ -2220,7 +2220,7 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_heap_objects{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_heap_objects{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2271,7 +2271,7 @@
           },
           "targets": [
             {
-              "expr": "go_gc_duration_seconds{namespace=~\"$namespace\", job=~\"$server_job\", quantile=\"1\"}",
+              "expr": "go_gc_duration_seconds{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\", quantile=\"1\"}",
               "legendFormat": "{{pod}} {{instance}} max",
               "refId": "A"
             }
@@ -2322,7 +2322,7 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_gc_cpu_fraction{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_gc_cpu_fraction{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2373,12 +2373,12 @@
           },
           "targets": [
             {
-              "expr": "rate(go_memstats_mallocs_total{namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+              "expr": "rate(go_memstats_mallocs_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[2m])",
               "legendFormat": "{{pod}} {{instance}} mallocs",
               "refId": "A"
             },
             {
-              "expr": "rate(go_memstats_frees_total{namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+              "expr": "rate(go_memstats_frees_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[2m])",
               "legendFormat": "{{pod}} {{instance}} frees",
               "refId": "B"
             }
@@ -2429,7 +2429,7 @@
           },
           "targets": [
             {
-              "expr": "rate(go_memstats_alloc_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+              "expr": "rate(go_memstats_alloc_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[5m])",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2480,12 +2480,12 @@
           },
           "targets": [
             {
-              "expr": "go_sched_gomaxprocs_threads{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_sched_gomaxprocs_threads{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} GOMAXPROCS",
               "refId": "A"
             },
             {
-              "expr": "go_threads{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_threads{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} threads",
               "refId": "B"
             }
@@ -2536,7 +2536,7 @@
           },
           "targets": [
             {
-              "expr": "rate(go_gc_duration_seconds_count{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+              "expr": "rate(go_gc_duration_seconds_count{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[5m])",
               "legendFormat": "{{pod}} {{instance}} GC/s",
               "refId": "A"
             }
@@ -2587,12 +2587,12 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_sys_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_sys_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} sys",
               "refId": "A"
             },
             {
-              "expr": "go_memstats_stack_inuse_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_stack_inuse_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} stack",
               "refId": "B"
             }
@@ -2643,12 +2643,12 @@
           },
           "targets": [
             {
-              "expr": "go_memstats_next_gc_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_memstats_next_gc_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} next GC",
               "refId": "A"
             },
             {
-              "expr": "go_gc_gomemlimit_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "go_gc_gomemlimit_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}} memory limit",
               "refId": "B"
             }
@@ -2713,7 +2713,7 @@
           },
           "targets": [
             {
-              "expr": "woodpecker_server_op_registry_pool_usage{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "woodpecker_server_op_registry_pool_usage{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "{{pod}} {{instance}}",
               "refId": "A"
             }
@@ -2764,7 +2764,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (signal)",
+              "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])) by (signal)",
               "legendFormat": "{{signal}}",
               "refId": "A"
             }
@@ -2815,7 +2815,7 @@
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[5m])) by (le))",
               "legendFormat": "P99",
               "refId": "A"
             }
@@ -2880,7 +2880,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_stored_bytes{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_file_stored_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2931,7 +2931,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_object_storage_stored_bytes{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_object_storage_stored_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2982,7 +2982,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_file_stored_count{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_file_stored_count{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -3033,7 +3033,7 @@
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_server_object_storage_stored_objects{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+              "expr": "sum(woodpecker_server_object_storage_stored_objects{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -3098,7 +3098,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
               "legendFormat": "node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "A"
             }
@@ -3149,12 +3149,12 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
               "legendFormat": "reclaimed node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
               "legendFormat": "marks node={{node_id}} logID={{log_id}} source={{source}}",
               "refId": "B"
             }
@@ -3205,7 +3205,7 @@
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, reason)",
+              "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, reason)",
               "legendFormat": "node={{node_id}} logID={{log_id}} reason={{reason}}",
               "refId": "A"
             }
@@ -3256,17 +3256,17 @@
           },
           "targets": [
             {
-              "expr": "woodpecker_server_node_lifecycle_state{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "woodpecker_server_node_lifecycle_state{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "node={{node_id}} state={{state}}",
               "refId": "A"
             },
             {
-              "expr": "woodpecker_server_node_decommission_has_local_data{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "woodpecker_server_node_decommission_has_local_data{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "node={{node_id}} has_local_data",
               "refId": "B"
             },
             {
-              "expr": "woodpecker_server_node_decommission_safe_to_terminate{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "woodpecker_server_node_decommission_safe_to_terminate{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "node={{node_id}} safe_to_terminate",
               "refId": "C"
             }
@@ -3317,7 +3317,7 @@
           },
           "targets": [
             {
-              "expr": "woodpecker_server_node_decommission_remaining_processors{namespace=~\"$namespace\", job=~\"$server_job\"}",
+              "expr": "woodpecker_server_node_decommission_remaining_processors{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
               "legendFormat": "node={{node_id}}",
               "refId": "A"
             }
@@ -3368,6 +3368,23 @@
         }
       },
       {
+        "name": "woodpecker_id",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "query": "label_values(go_info{namespace=~\"$namespace\"}, woodpecker_id)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        }
+      },
+      {
         "allValue": ".*",
         "current": {
           "text": "All",
@@ -3380,7 +3397,7 @@
         "includeAll": true,
         "multi": true,
         "name": "log_ns",
-        "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", log_ns=~\".+\"}))",
+        "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\".+\"}))",
         "refresh": 2,
         "regex": "/log_ns=\"([^\"]+)\"/",
         "type": "query"
@@ -3398,7 +3415,7 @@
         "includeAll": true,
         "multi": true,
         "name": "log_id",
-        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
+        "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
         "refresh": 2,
         "regex": "/log_id=\"([^\"]+)\"/",
         "type": "query"
@@ -3417,7 +3434,7 @@
         "includeAll": true,
         "multi": true,
         "name": "server_job",
-        "query": "label_values(go_info{namespace=~\"$namespace\"}, job)",
+        "query": "label_values(go_info{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}, job)",
         "refresh": 2,
         "type": "query"
       }

--- a/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
+++ b/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
@@ -64,12 +64,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} logs",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} segments",
                   "refId": "B"
                 }
@@ -120,7 +120,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_logstore_instances_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_logstore_instances_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}}",
                   "refId": "A"
                 }
@@ -171,7 +171,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_logstore_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
+                  "expr": "sum(rate(woodpecker_server_logstore_operations_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, status)",
                   "legendFormat": "op={{operation}} status={{status}}",
                   "refId": "A"
                 }
@@ -222,12 +222,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
                   "legendFormat": "op={{operation}} P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_logstore_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (operation, le))",
                   "legendFormat": "op={{operation}} P99",
                   "refId": "B"
                 }
@@ -278,7 +278,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_logstore_active_segment_processors{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "expr": "sum(woodpecker_server_logstore_active_segment_processors{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
                   "legendFormat": "logID={{log_id}}",
                   "refId": "A"
                 }
@@ -287,7 +287,7 @@ data:
               "type": "timeseries"
             }
           ],
-          "title": "Engine Layer \u2014 LogStore",
+          "title": "Engine Layer — LogStore",
           "type": "row"
         },
         {
@@ -343,12 +343,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Buffer P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_buffer_wait_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Buffer P99",
                   "refId": "B"
                 }
@@ -399,7 +399,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_file_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+                  "expr": "sum(rate(woodpecker_server_file_operations_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
                   "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
                   "refId": "A"
                 }
@@ -450,12 +450,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P99",
                   "refId": "B"
                 }
@@ -506,12 +506,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_file_writer{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+                  "expr": "sum(woodpecker_server_file_writer{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
                   "legendFormat": "{{node_id}} logID={{log_id}} writer",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(woodpecker_server_file_reader{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
+                  "expr": "sum(woodpecker_server_file_reader{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (node_id, log_id)",
                   "legendFormat": "{{node_id}} logID={{log_id}} reader",
                   "refId": "B"
                 }
@@ -562,12 +562,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Flush P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_flush_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Flush P99",
                   "refId": "B"
                 }
@@ -618,12 +618,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} ReadBatch P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_read_batch_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} ReadBatch P99",
                   "refId": "B"
                 }
@@ -674,12 +674,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Compact P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_file_compaction_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, le))",
                   "legendFormat": "{{node_id}} Compact P99",
                   "refId": "B"
                 }
@@ -730,12 +730,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_flush_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+                  "expr": "sum(rate(woodpecker_server_flush_bytes_written{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
                   "legendFormat": "{{node_id}} flush",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(rate(woodpecker_server_compact_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
+                  "expr": "sum(rate(woodpecker_server_compact_bytes_written{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id)",
                   "legendFormat": "{{node_id}} compact",
                   "refId": "B"
                 }
@@ -744,7 +744,7 @@ data:
               "type": "timeseries"
             }
           ],
-          "title": "Storage Layer \u2014 File I/O & Buffer",
+          "title": "Storage Layer — File I/O & Buffer",
           "type": "row"
         },
         {
@@ -800,7 +800,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_object_storage_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
+                  "expr": "sum(rate(woodpecker_server_object_storage_operations_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, status)",
                   "legendFormat": "{{node_id}} op={{operation}} status={{status}}",
                   "refId": "A"
                 }
@@ -851,12 +851,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P99",
                   "refId": "B"
                 }
@@ -907,12 +907,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_object_storage_request_bytes_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation, le))",
                   "legendFormat": "{{node_id}} op={{operation}} P99",
                   "refId": "B"
                 }
@@ -963,7 +963,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
+                  "expr": "sum(rate(woodpecker_server_object_storage_bytes_transferred{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, operation)",
                   "legendFormat": "{{node_id}} op={{operation}}",
                   "refId": "A"
                 }
@@ -1028,7 +1028,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_cpu_usage{namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_cpu_usage{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}}",
                   "refId": "A"
                 }
@@ -1079,12 +1079,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_memory_used_bytes{namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_memory_used_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} used",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(woodpecker_server_system_memory_usage_ratio{namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_memory_usage_ratio{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} ratio",
                   "refId": "B"
                 }
@@ -1135,12 +1135,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_disk_used_bytes{namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_disk_used_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} used",
                   "refId": "A"
                 },
                 {
-                  "expr": "sum(woodpecker_server_system_disk_total_bytes{namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_disk_total_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}} total",
                   "refId": "B"
                 }
@@ -1191,7 +1191,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_system_io_wait{namespace=~\"$namespace\"}) by (node_id)",
+                  "expr": "sum(woodpecker_server_system_io_wait{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
                   "legendFormat": "nodeID={{node_id}}",
                   "refId": "A"
                 }
@@ -1242,7 +1242,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "process_open_fds{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "process_open_fds{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} open",
                   "refId": "A"
                 }
@@ -1293,12 +1293,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "rate(process_network_receive_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+                  "expr": "rate(process_network_receive_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])",
                   "legendFormat": "{{pod}} {{instance}} rx",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(process_network_transmit_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+                  "expr": "rate(process_network_transmit_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])",
                   "legendFormat": "{{pod}} {{instance}} tx",
                   "refId": "B"
                 }
@@ -1349,7 +1349,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "process_open_fds{namespace=~\"$namespace\", job=~\"$server_job\"} / process_max_fds{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "process_open_fds{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"} / process_max_fds{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1400,7 +1400,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "time() - process_start_time_seconds{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "time() - process_start_time_seconds{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1451,7 +1451,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "process_virtual_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "process_virtual_memory_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1470,6 +1470,302 @@ data:
             "w": 24,
             "x": 0,
             "y": 4
+          },
+          "id": 59,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "thresholdsStyle": {
+                      "mode": "dashed"
+                    }
+                  },
+                  "unit": "percentunit",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 0.8
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.9
+                      }
+                    ]
+                  },
+                  "max": 1,
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 5
+              },
+              "id": 60,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_logstore_disk_usage_ratio{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id, path)",
+                  "legendFormat": "nodeID={{node_id}} path={{path}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "WAL Disk Usage Ratio",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 5
+              },
+              "id": 61,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_logstore_disk_free_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id, path)",
+                  "legendFormat": "nodeID={{node_id}} path={{path}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "WAL Disk Free Bytes",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false,
+                    "lineInterpolation": "stepAfter"
+                  },
+                  "unit": "short",
+                  "max": 2,
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 5
+              },
+              "id": 62,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_logstore_write_backpressure_state{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}} (0=normal 1=warn 2=blocked)",
+                  "refId": "A"
+                }
+              ],
+              "title": "Write Backpressure State",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "percentunit",
+                  "max": 1,
+                  "min": 0
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 13
+              },
+              "id": 63,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(woodpecker_server_logstore_write_reject_probability{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}) by (node_id)",
+                  "legendFormat": "nodeID={{node_id}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Write Reject Probability",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 13
+              },
+              "id": 64,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(woodpecker_server_logstore_write_rejected_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}[1m])) by (node_id, reason)",
+                  "legendFormat": "nodeID={{node_id}} reason={{reason}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Write Rejected Rate",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Disk Watermark — Backpressure",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 5
           },
           "id": 32,
           "panels": [
@@ -1516,7 +1812,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(process_cpu_seconds_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (pod, instance)",
+                  "expr": "sum(rate(process_cpu_seconds_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])) by (pod, instance)",
                   "legendFormat": "{{pod}} {{instance}} cpu",
                   "refId": "A"
                 }
@@ -1567,7 +1863,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(process_resident_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+                  "expr": "sum(process_resident_memory_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}) by (pod, instance)",
                   "legendFormat": "{{pod}} {{instance}} memory",
                   "refId": "A"
                 }
@@ -1618,7 +1914,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(go_goroutines{namespace=~\"$namespace\", job=~\"$server_job\"}) by (pod, instance)",
+                  "expr": "sum(go_goroutines{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}) by (pod, instance)",
                   "legendFormat": "{{pod}} {{instance}} goroutines",
                   "refId": "A"
                 }
@@ -1669,7 +1965,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "rate(process_cpu_seconds_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])",
+                  "expr": "rate(process_cpu_seconds_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1720,7 +2016,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "process_resident_memory_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "process_resident_memory_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1771,7 +2067,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_goroutines{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_goroutines{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1822,7 +2118,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_alloc_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_alloc_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1873,17 +2169,17 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_heap_inuse_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} in-use",
                   "refId": "A"
                 },
                 {
-                  "expr": "go_memstats_heap_idle_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_heap_idle_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} idle",
                   "refId": "B"
                 },
                 {
-                  "expr": "go_memstats_heap_released_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_heap_released_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} released",
                   "refId": "C"
                 }
@@ -1934,7 +2230,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_heap_objects{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_heap_objects{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -1985,7 +2281,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_gc_duration_seconds{namespace=~\"$namespace\", job=~\"$server_job\", quantile=\"1\"}",
+                  "expr": "go_gc_duration_seconds{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\", quantile=\"1\"}",
                   "legendFormat": "{{pod}} {{instance}} max",
                   "refId": "A"
                 }
@@ -2036,7 +2332,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_gc_cpu_fraction{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_gc_cpu_fraction{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -2087,12 +2383,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "rate(go_memstats_mallocs_total{namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+                  "expr": "rate(go_memstats_mallocs_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[2m])",
                   "legendFormat": "{{pod}} {{instance}} mallocs",
                   "refId": "A"
                 },
                 {
-                  "expr": "rate(go_memstats_frees_total{namespace=~\"$namespace\", job=~\"$server_job\"}[2m])",
+                  "expr": "rate(go_memstats_frees_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[2m])",
                   "legendFormat": "{{pod}} {{instance}} frees",
                   "refId": "B"
                 }
@@ -2143,7 +2439,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+                  "expr": "rate(go_memstats_alloc_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[5m])",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -2194,12 +2490,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_sched_gomaxprocs_threads{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_sched_gomaxprocs_threads{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} GOMAXPROCS",
                   "refId": "A"
                 },
                 {
-                  "expr": "go_threads{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_threads{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} threads",
                   "refId": "B"
                 }
@@ -2250,7 +2546,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "rate(go_gc_duration_seconds_count{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])",
+                  "expr": "rate(go_gc_duration_seconds_count{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[5m])",
                   "legendFormat": "{{pod}} {{instance}} GC/s",
                   "refId": "A"
                 }
@@ -2301,12 +2597,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_sys_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_sys_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} sys",
                   "refId": "A"
                 },
                 {
-                  "expr": "go_memstats_stack_inuse_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_stack_inuse_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} stack",
                   "refId": "B"
                 }
@@ -2357,12 +2653,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "go_memstats_next_gc_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_memstats_next_gc_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} next GC",
                   "refId": "A"
                 },
                 {
-                  "expr": "go_gc_gomemlimit_bytes{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "go_gc_gomemlimit_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}} memory limit",
                   "refId": "B"
                 }
@@ -2380,7 +2676,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 5
+            "y": 6
           },
           "id": 55,
           "panels": [
@@ -2427,7 +2723,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "woodpecker_server_op_registry_pool_usage{namespace=~\"$namespace\", job=~\"$server_job\"}",
+                  "expr": "woodpecker_server_op_registry_pool_usage{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
                   "legendFormat": "{{pod}} {{instance}}",
                   "refId": "A"
                 }
@@ -2478,7 +2774,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{namespace=~\"$namespace\", job=~\"$server_job\"}[1m])) by (signal)",
+                  "expr": "sum(rate(woodpecker_server_op_registry_evicted_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[1m])) by (signal)",
                   "legendFormat": "{{signal}}",
                   "refId": "A"
                 }
@@ -2529,7 +2825,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{namespace=~\"$namespace\", job=~\"$server_job\"}[5m])) by (le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(woodpecker_server_op_registry_evicted_age_seconds_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}[5m])) by (le))",
                   "legendFormat": "P99",
                   "refId": "A"
                 }
@@ -2547,7 +2843,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 6
+            "y": 7
           },
           "id": 27,
           "panels": [
@@ -2594,7 +2890,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_file_stored_bytes{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "expr": "sum(woodpecker_server_file_stored_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
                   "legendFormat": "logID={{log_id}}",
                   "refId": "A"
                 }
@@ -2645,7 +2941,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_object_storage_stored_bytes{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "expr": "sum(woodpecker_server_object_storage_stored_bytes{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
                   "legendFormat": "logID={{log_id}}",
                   "refId": "A"
                 }
@@ -2696,7 +2992,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_file_stored_count{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "expr": "sum(woodpecker_server_file_stored_count{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
                   "legendFormat": "logID={{log_id}}",
                   "refId": "A"
                 }
@@ -2747,7 +3043,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(woodpecker_server_object_storage_stored_objects{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
+                  "expr": "sum(woodpecker_server_object_storage_stored_objects{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}) by (log_id)",
                   "legendFormat": "logID={{log_id}}",
                   "refId": "A"
                 }
@@ -2757,6 +3053,290 @@ data:
             }
           ],
           "title": "Cost",
+          "type": "row"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 8
+          },
+          "id": 105,
+          "panels": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 0,
+                "y": 9
+              },
+              "id": 106,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+                  "legendFormat": "node={{node_id}} logID={{log_id}} source={{source}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Compacted Cleanup Reclaimed Bytes Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 8,
+                "y": 9
+              },
+              "id": 107,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(woodpecker_server_compacted_cleanup_reclaimed_files_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+                  "legendFormat": "reclaimed node={{node_id}} logID={{log_id}} source={{source}}",
+                  "refId": "A"
+                },
+                {
+                  "expr": "sum(rate(woodpecker_server_compacted_cleanup_marks_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, source)",
+                  "legendFormat": "marks node={{node_id}} logID={{log_id}} source={{source}}",
+                  "refId": "B"
+                }
+              ],
+              "title": "Compacted Cleanup Files & Marks Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "ops"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 8,
+                "x": 16,
+                "y": 9
+              },
+              "id": 108,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "sum(rate(woodpecker_server_compacted_cleanup_footer_failures_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\"$log_id\"}[1m])) by (node_id, log_id, reason)",
+                  "legendFormat": "node={{node_id}} logID={{log_id}} reason={{reason}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Compacted Cleanup Footer Failure Rate",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 0,
+                "y": 17
+              },
+              "id": 109,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "woodpecker_server_node_lifecycle_state{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
+                  "legendFormat": "node={{node_id}} state={{state}}",
+                  "refId": "A"
+                },
+                {
+                  "expr": "woodpecker_server_node_decommission_has_local_data{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
+                  "legendFormat": "node={{node_id}} has_local_data",
+                  "refId": "B"
+                },
+                {
+                  "expr": "woodpecker_server_node_decommission_safe_to_terminate{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
+                  "legendFormat": "node={{node_id}} safe_to_terminate",
+                  "refId": "C"
+                }
+              ],
+              "title": "Node Decommission Progress",
+              "type": "timeseries"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${prometheus}"
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "showPoints": "auto",
+                    "spanNulls": false
+                  },
+                  "unit": "short"
+                },
+                "overrides": []
+              },
+              "gridPos": {
+                "h": 8,
+                "w": 12,
+                "x": 12,
+                "y": 17
+              },
+              "id": 110,
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom"
+                },
+                "tooltip": {
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              },
+              "targets": [
+                {
+                  "expr": "woodpecker_server_node_decommission_remaining_processors{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", job=~\"$server_job\"}",
+                  "legendFormat": "node={{node_id}}",
+                  "refId": "A"
+                }
+              ],
+              "title": "Node Decommission Remaining Processors",
+              "type": "timeseries"
+            }
+          ],
+          "title": "Compacted Cleanup & Decommission",
           "type": "row"
         }
       ],
@@ -2798,6 +3378,23 @@ data:
             }
           },
           {
+            "name": "woodpecker_id",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "query": "label_values(go_info{namespace=~\"$namespace\"}, woodpecker_id)",
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "allValue": ".*",
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          },
+          {
             "allValue": ".*",
             "current": {
               "text": "All",
@@ -2810,7 +3407,7 @@ data:
             "includeAll": true,
             "multi": true,
             "name": "log_ns",
-            "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", log_ns=~\".+\"}))",
+            "query": "query_result(max by (log_ns) (woodpecker_server_logstore_active_logs{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\".+\"}))",
             "refresh": 2,
             "regex": "/log_ns=\"([^\"]+)\"/",
             "type": "query"
@@ -2828,7 +3425,7 @@ data:
             "includeAll": true,
             "multi": true,
             "name": "log_id",
-            "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
+            "query": "query_result(max by (log_id) (woodpecker_server_logstore_active_segments{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", log_id=~\".+\"}))",
             "refresh": 2,
             "regex": "/log_id=\"([^\"]+)\"/",
             "type": "query"
@@ -2847,7 +3444,7 @@ data:
             "includeAll": true,
             "multi": true,
             "name": "server_job",
-            "query": "label_values(go_info{namespace=~\"$namespace\"}, job)",
+            "query": "label_values(go_info{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}, job)",
             "refresh": 2,
             "type": "query"
           }
@@ -2927,7 +3524,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_client_append_requests_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "expr": "sum(rate(woodpecker_client_append_requests_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -2978,12 +3575,12 @@ data:
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Append latency P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Append latency P99",
               "refId": "B"
             }
@@ -3034,12 +3631,12 @@ data:
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Append bytes P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_append_bytes_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Append bytes P99",
               "refId": "B"
             }
@@ -3090,7 +3687,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_client_read_requests_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "expr": "sum(rate(woodpecker_client_read_requests_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -3141,12 +3738,12 @@ data:
           },
           "targets": [
             {
-              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.5, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Read latency P50",
               "refId": "A"
             },
             {
-              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_read_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, le))",
               "legendFormat": "logID={{log_id}} Read latency P99",
               "refId": "B"
             }
@@ -3197,12 +3794,12 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_client_reader_bytes_read{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "expr": "sum(rate(woodpecker_client_reader_bytes_read{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
               "legendFormat": "logID={{log_id}} read bytes",
               "refId": "A"
             },
             {
-              "expr": "sum(rate(woodpecker_client_writer_bytes_written{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
+              "expr": "sum(rate(woodpecker_client_writer_bytes_written{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id)",
               "legendFormat": "logID={{log_id}} write bytes",
               "refId": "B"
             }
@@ -3253,7 +3850,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
+              "expr": "sum(rate(woodpecker_client_etcd_meta_operations_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
               "legendFormat": "op={{operation}} status={{status}}",
               "refId": "A"
             }
@@ -3304,7 +3901,7 @@ data:
           },
           "targets": [
             {
-              "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}) by (log_id)",
+              "expr": "sum(woodpecker_client_segment_handle_pending_append_ops{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}) by (log_id)",
               "legendFormat": "logID={{log_id}}",
               "refId": "A"
             }
@@ -3344,7 +3941,7 @@ data:
           },
           "targets": [
             {
-              "expr": "woodpecker_client_log_name_id_mapping{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+              "expr": "woodpecker_client_log_name_id_mapping{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
               "format": "table",
               "instant": true,
               "legendFormat": "",
@@ -3413,7 +4010,7 @@ data:
           },
           "targets": [
             {
-              "expr": "woodpecker_client_segment_state{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+              "expr": "woodpecker_client_segment_state{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
               "legendFormat": "logID={{log_id}} {{state}}",
               "refId": "A"
             }
@@ -3453,7 +4050,7 @@ data:
           },
           "targets": [
             {
-              "expr": "woodpecker_client_active_segment_node{namespace=~\"$namespace\", log_ns=~\"$log_ns\"}",
+              "expr": "woodpecker_client_active_segment_node{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
               "format": "table",
               "instant": true,
               "legendFormat": "",
@@ -3524,7 +4121,7 @@ data:
           },
           "targets": [
             {
-              "expr": "count by (node) (woodpecker_client_active_segment_node{namespace=~\"$namespace\", log_ns=~\"$log_ns\"})",
+              "expr": "count by (node) (woodpecker_client_active_segment_node{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"})",
               "legendFormat": "{{node}}",
               "refId": "A"
             }
@@ -3533,12 +4130,196 @@ data:
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
             "y": 41
+          },
+          "id": 101,
+          "title": "Progress Frontiers",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 42
+          },
+          "id": 102,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "woodpecker_client_write_frontier_segment{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
+              "legendFormat": "logID={{log_id}} write",
+              "refId": "A"
+            },
+            {
+              "expr": "woodpecker_client_compaction_frontier_segment{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
+              "legendFormat": "logID={{log_id}} compacted",
+              "refId": "B"
+            },
+            {
+              "expr": "woodpecker_client_truncation_frontier_segment{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
+              "legendFormat": "logID={{log_id}} truncated",
+              "refId": "C"
+            }
+          ],
+          "title": "Segment Frontiers",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 42
+          },
+          "id": 103,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "woodpecker_client_write_frontier_entry{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
+              "legendFormat": "logID={{log_id}} write",
+              "refId": "A"
+            },
+            {
+              "expr": "woodpecker_client_compaction_frontier_entry{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
+              "legendFormat": "logID={{log_id}} compacted",
+              "refId": "B"
+            },
+            {
+              "expr": "woodpecker_client_truncation_frontier_entry{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}",
+              "legendFormat": "logID={{log_id}} truncated",
+              "refId": "C"
+            }
+          ],
+          "title": "Entry Frontiers",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 50
+          },
+          "id": 104,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_segment_compaction_failures_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (log_id, reason)",
+              "legendFormat": "logID={{log_id}} reason={{reason}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Compaction Failure Rate by Reason",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 58
           },
           "id": 8,
           "panels": [
@@ -3565,7 +4346,7 @@ data:
                 "h": 8,
                 "w": 8,
                 "x": 0,
-                "y": 42
+                "y": 59
               },
               "id": 9,
               "options": {
@@ -3585,7 +4366,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(grpc_server_started_total{namespace=~\"$namespace\"}[1m])) by (grpc_method)",
+                  "expr": "sum(rate(grpc_server_started_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}[1m])) by (grpc_method)",
                   "legendFormat": "method={{grpc_method}}",
                   "refId": "A"
                 }
@@ -3616,7 +4397,7 @@ data:
                 "h": 8,
                 "w": 8,
                 "x": 8,
-                "y": 42
+                "y": 59
               },
               "id": 10,
               "options": {
@@ -3636,7 +4417,7 @@ data:
               },
               "targets": [
                 {
-                  "expr": "sum(rate(grpc_server_handled_total{namespace=~\"$namespace\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
+                  "expr": "sum(rate(grpc_server_handled_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", grpc_code!=\"OK\"}[1m])) by (grpc_method, grpc_code)",
                   "legendFormat": "method={{grpc_method}} code={{grpc_code}}",
                   "refId": "A"
                 }
@@ -3667,7 +4448,7 @@ data:
                 "h": 8,
                 "w": 8,
                 "x": 16,
-                "y": 42
+                "y": 59
               },
               "id": 11,
               "options": {
@@ -3687,12 +4468,12 @@ data:
               },
               "targets": [
                 {
-                  "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+                  "expr": "histogram_quantile(0.5, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}[1m])) by (grpc_method, le))",
                   "legendFormat": "method={{grpc_method}} P50",
                   "refId": "A"
                 },
                 {
-                  "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\"}[1m])) by (grpc_method, le))",
+                  "expr": "histogram_quantile(0.99, sum(rate(grpc_server_handling_seconds_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}[1m])) by (grpc_method, le))",
                   "legendFormat": "method={{grpc_method}} P99",
                   "refId": "B"
                 }
@@ -3743,6 +4524,23 @@ data:
             }
           },
           {
+            "name": "woodpecker_id",
+            "type": "query",
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "query": "label_values(go_info{namespace=~\"$namespace\"}, woodpecker_id)",
+            "refresh": 2,
+            "includeAll": true,
+            "multi": true,
+            "allValue": ".*",
+            "current": {
+              "text": "All",
+              "value": "$__all"
+            }
+          },
+          {
             "allValue": ".*",
             "current": {
               "text": "All",
@@ -3755,7 +4553,7 @@ data:
             "includeAll": true,
             "multi": true,
             "name": "log_ns",
-            "query": "label_values(woodpecker_client_append_requests_total{namespace=~\"$namespace\"}, log_ns)",
+            "query": "label_values(woodpecker_client_append_requests_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\"}, log_ns)",
             "refresh": 2,
             "type": "query"
           }

--- a/tests/k8s/monitor/manifests/podmonitor-client.yaml
+++ b/tests/k8s/monitor/manifests/podmonitor-client.yaml
@@ -19,3 +19,11 @@ spec:
       path: /metrics
       interval: 15s
       honorLabels: true
+      relabelings:
+        # Same instance identity as the server PodMonitor, so a client and the
+        # cluster it writes to share one woodpecker_id value.
+        - action: replace
+          sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+          regex: (?:wp-)?(.+)
+          replacement: $1
+          targetLabel: woodpecker_id

--- a/tests/k8s/monitor/manifests/podmonitor-server.yaml
+++ b/tests/k8s/monitor/manifests/podmonitor-server.yaml
@@ -19,3 +19,13 @@ spec:
       path: /metrics
       interval: 15s
       honorLabels: true
+      relabelings:
+        # Instance identity: a namespace may host several woodpecker clusters,
+        # and prometheus-operator derives `job` from this PodMonitor, so `job`
+        # is the same for all of them. The helm release name is the only
+        # per-cluster discriminator; production names it wp-<id>.
+        - action: replace
+          sourceLabels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+          regex: (?:wp-)?(.+)
+          replacement: $1
+          targetLabel: woodpecker_id

--- a/tests/k8s/monitor/monitor_test.go
+++ b/tests/k8s/monitor/monitor_test.go
@@ -18,12 +18,14 @@ package monitor
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
 
-// TestK8sMonitor_Metrics verifies scrape targets and the namespace/log_ns
-// label scheme against a Prometheus reachable at $WP_K8S_PROM_URL (a kubectl
+// TestK8sMonitor_Metrics verifies scrape targets and the
+// namespace/woodpecker_id/log_ns label scheme against a Prometheus reachable
+// at $WP_K8S_PROM_URL (a kubectl
 // port-forward set up by run_monitor_tests.sh). Skipped when unset so the package
 // stays `go test ./...`-safe without a live cluster.
 func TestK8sMonitor_Metrics(t *testing.T) {
@@ -70,9 +72,19 @@ func TestK8sMonitor_Metrics(t *testing.T) {
 		if len(series) == 0 {
 			t.Fatal("no logstore_active_logs series")
 		}
+		// The PodMonitor relabels app.kubernetes.io/instance (the helm release
+		// name, wp-<id> in production) into woodpecker_id.
+		wantID := os.Getenv("CR_NAME")
+		if wantID == "" {
+			wantID = "my-woodpecker"
+		}
+		wantID = strings.TrimPrefix(wantID, "wp-")
 		for _, m := range series {
 			if m["namespace"] != "woodpecker" {
 				t.Errorf("namespace=%q, want k8s namespace woodpecker", m["namespace"])
+			}
+			if m["woodpecker_id"] != wantID {
+				t.Errorf("woodpecker_id=%q, want %q", m["woodpecker_id"], wantID)
 			}
 			if m["log_ns"] == "" {
 				t.Errorf("missing log_ns label: %v", m)


### PR DESCRIPTION
Fixes #267

## What

A namespace can host several woodpecker clusters — a pooled deployment runs one StatefulSet per instance, named `wp-<id>`. prometheus-operator derives `job` from the PodMonitor, so every instance in the pool reports the same `job` value, and none of the dashboard dimensions could separate them (`namespace` is shared, `log_ns`/`log_id` are per business log). The only remaining discriminator was a hand-typed pod-name regex, which is also silently wrong when one Prometheus aggregates several k8s clusters that each have the namespace.

This adds a proper instance identity to the scrape config and threads it through the dashboards.

## Changes

- **PodMonitors** — relabel `__meta_kubernetes_pod_label_app_kubernetes_io_instance` into a `woodpecker_id` target label, stripping the `wp-` prefix (`(?:wp-)?(.+)`), so both the test suite's `my-woodpecker` and production's `wp-<id>` produce a clean value.
- **docker suite** — stamp the same `woodpecker_id` on the static targets, so one dashboard layout serves both suites.
- **Dashboards** (4 templates) — new multi-select `woodpecker_id` variable, and `woodpecker_id=~"$woodpecker_id"` added to every panel expression and variable query. Each dashboard discovers the values from the metric its existing variables already use (`go_info` for k8s, `woodpecker_server_logstore_instances_total` / `woodpecker_client_append_requests_total` for docker).
- **`allValue` is `.*`**, not the generated value list: a missing label equals the empty string in PromQL, so `All` keeps matching targets scraped by a deployment that predates the relabel. With the default value list they would vanish from every panel.
- **`dashboard-configmaps.yaml`** — regenerated, and a new test keeps it in sync. It had drifted: the committed manifest was missing the `Disk Watermark — Backpressure` and `Compacted Cleanup & Decommission` rows of the server dashboard and the `Progress Frontiers` / `Segment Frontiers` / `Entry Frontiers` / `Compaction Failure Rate by Reason` panels of the client one, so `run_monitor_tests.sh` was applying an outdated dashboard.
- **Tests** — `dashboards_test.go` requires the `woodpecker_id` variable and asserts the ConfigMap matches the templates (`-update` regenerates); the live `LabelScheme` subtest asserts the relabeled value equals `$CR_NAME`.

## Verification

- `go test ./tests/k8s/monitor/` — pass; the sync test was confirmed to fail against the stale manifest before regenerating, so it does catch drift.
- `golangci-lint run --config .golangci.yml ./tests/k8s/monitor/...` — 0 issues; `gofmt`/`gofumpt` clean.
- All 224 distinct PromQL expressions from the four patched templates were executed against a live Prometheus with the variables substituted — 0 parse or evaluation errors. This caught one real bug during development: the first pass injected the filter into `by (grpc_method)` grouping clauses, since a grouping label looks exactly like a bare metric selector.
- YAML of both PodMonitors, `prometheus.yml` and the regenerated ConfigMaps re-parsed; the embedded dashboards compare equal to the templates.

## Notes

- No metric or label changes inside the woodpecker binaries — scrape configuration plus dashboards only.
- The test suite deploys a single release, so `woodpecker_id` has one value there; the multi-instance case it targets is the pooled production deployment. Widening the suite to two releases would exercise the split, but that is a bigger change to `run_monitor_tests.sh` and is left out.
- Per-replica / cross-AZ traffic visibility (which replica served a read, how much traffic crossed an AZ) is a separate gap that needs new client metrics; it is tracked in #269.
