### PR TITLE
enhance(metrics): make per-replica and cross-AZ client traffic observable

### DIFF
--- a/common/metrics/active_segment_node_test.go
+++ b/common/metrics/active_segment_node_test.go
@@ -31,7 +31,11 @@ func TestActiveSegmentNodes_SetAndClear(t *testing.T) {
 	reg.MustRegister(WpActiveSegmentNode)
 
 	ns, logId, segId := "bucket/root", "42", "7"
-	nodes := []string{"10.0.0.1:8000", "10.0.0.2:8000", "10.0.0.3:8000"}
+	nodes := []ActiveSegmentNode{
+		{Node: "10.0.0.1:8000", AZ: "us-west-2a"},
+		{Node: "10.0.0.2:8000", AZ: "us-west-2b"},
+		{Node: "10.0.0.3:8000", AZ: ""}, // placement unknown for this replica
+	}
 
 	SetActiveSegmentNodes(ns, logId, segId, nodes)
 
@@ -39,12 +43,34 @@ func TestActiveSegmentNodes_SetAndClear(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(nodes), count, "one series per node after set")
 	for _, n := range nodes {
-		v := testutil.ToFloat64(WpActiveSegmentNode.WithLabelValues(ns, logId, segId, n))
+		v := testutil.ToFloat64(WpActiveSegmentNode.WithLabelValues(ns, logId, segId, n.Node, n.AZ))
 		assert.Equal(t, float64(1), v)
 	}
 
-	ClearActiveSegmentNodes(ns, logId, segId, nodes)
+	ClearActiveSegmentNodes(ns, logId, segId)
 	count, err = testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
 	assert.NoError(t, err)
 	assert.Equal(t, 0, count, "series removed after clear")
+}
+
+// A quorum whose placement changed since it was published must still be
+// removed in full: the clear matches on the segment, not on the exact labels.
+func TestActiveSegmentNodes_ClearAfterPlacementChange(t *testing.T) {
+	WpActiveSegmentNode.Reset()
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(WpActiveSegmentNode)
+
+	ns, logId, segId := "bucket/root", "42", "7"
+	SetActiveSegmentNodes(ns, logId, segId, []ActiveSegmentNode{{Node: "10.0.0.1:8000", AZ: "us-west-2a"}})
+	SetActiveSegmentNodes(ns, logId, segId, []ActiveSegmentNode{{Node: "10.0.0.1:8000", AZ: "us-west-2c"}})
+
+	count, err := testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	ClearActiveSegmentNodes(ns, logId, segId)
+	count, err = testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, 0, count, "all series for the segment removed")
 }

--- a/common/metrics/client_metrics.go
+++ b/common/metrics/client_metrics.go
@@ -229,7 +229,7 @@ var (
 		Subsystem: clientRole,
 		Name:      "active_segment_node",
 		Help:      "Quorum node membership of each log's current active (writable) segment (value always 1, one series per node)",
-	}, []string{"log_ns", "log_id", "segment_id", "node"})
+	}, []string{"log_ns", "log_id", "segment_id", "node", "az"})
 
 	// Direct read metrics (client reads sealed segments directly from object storage)
 	WpClientDirectReadRequestsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -245,6 +245,45 @@ var (
 		Help:      "Latency of direct read operations from object storage for sealed segments",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
 	}, []string{"log_ns", "log_id"})
+
+	// Replica placement metrics. az_scope is where the peer sits relative to
+	// this client — local / cross_az / cross_region, or unknown when either
+	// side's topology is unset. The node endpoint is deliberately NOT a label:
+	// it would multiply by log_id and explode cardinality, while az_scope stays
+	// at four values and answers the question that costs money.
+	WpClientReplicaAppendTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "replica_append_total",
+		Help:      "Total per-replica append outcomes, by how far the replica sits from this client",
+	}, []string{"log_ns", "log_id", "az_scope", "status"})
+	WpClientReplicaAppendBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "replica_append_bytes_total",
+		Help:      "Total bytes acknowledged per replica, by how far the replica sits from this client",
+	}, []string{"log_ns", "log_id", "az_scope"})
+	// Quorum reads of an active segment. A caught-up tail reader polls
+	// continuously and gets "no entry yet" every time, so that outcome is not
+	// counted here at all — only reads that moved data or genuinely failed.
+	WpClientQuorumReadTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "quorum_read_total",
+		Help:      "Total quorum read outcomes, by how far the serving replica sits from this client",
+	}, []string{"log_ns", "log_id", "az_scope", "status"})
+	WpClientQuorumReadBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "quorum_read_bytes_total",
+		Help:      "Total bytes read from quorum replicas, by how far the serving replica sits from this client",
+	}, []string{"log_ns", "log_id", "az_scope"})
+	WpClientReadFailoverTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: woodpeckerNamespace,
+		Subsystem: clientRole,
+		Name:      "read_failover_total",
+		Help:      "Total quorum reads served by a replica in a different scope than the preferred one",
+	}, []string{"log_ns", "log_id", "from_scope", "to_scope"})
 
 	// Etcd Meta metrics
 	WpEtcdMetaOperationsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -312,6 +351,12 @@ func RegisterClientMetricsWithRegisterer(registerer prometheus.Registerer) {
 		// Direct read metrics
 		registerer.MustRegister(WpClientDirectReadRequestsTotal)
 		registerer.MustRegister(WpClientDirectReadLatency)
+		// Replica placement metrics
+		registerer.MustRegister(WpClientReplicaAppendTotal)
+		registerer.MustRegister(WpClientReplicaAppendBytesTotal)
+		registerer.MustRegister(WpClientQuorumReadTotal)
+		registerer.MustRegister(WpClientQuorumReadBytesTotal)
+		registerer.MustRegister(WpClientReadFailoverTotal)
 		// etcd meta metrics
 		registerer.MustRegister(WpEtcdMetaOperationsTotal)
 		registerer.MustRegister(WpEtcdMetaOperationLatency)
@@ -351,18 +396,30 @@ func setMonotonicFrontier(frontiers map[string]progressFrontier, segmentGauge, e
 	frontierMu.Unlock()
 }
 
+// ActiveSegmentNode is one replica of a log's current writable segment: the
+// node's endpoint and the availability zone it sits in (empty when the quorum
+// metadata carries no placement for it).
+type ActiveSegmentNode struct {
+	Node string
+	AZ   string
+}
+
 // SetActiveSegmentNodes marks each node of an active (writable) segment's quorum
 // with a value of 1 (one series per node). Call when a segment becomes writable.
-func SetActiveSegmentNodes(logNs, logId, segmentId string, nodes []string) {
+func SetActiveSegmentNodes(logNs, logId, segmentId string, nodes []ActiveSegmentNode) {
 	for _, node := range nodes {
-		WpActiveSegmentNode.WithLabelValues(logNs, logId, segmentId, node).Set(1)
+		WpActiveSegmentNode.WithLabelValues(logNs, logId, segmentId, node.Node, node.AZ).Set(1)
 	}
 }
 
 // ClearActiveSegmentNodes deletes the per-node series for an active segment.
 // Call when the segment leaves the writable state (completed / rolling / closed).
-func ClearActiveSegmentNodes(logNs, logId, segmentId string, nodes []string) {
-	for _, node := range nodes {
-		WpActiveSegmentNode.DeleteLabelValues(logNs, logId, segmentId, node)
-	}
+// It matches on the segment alone, so a quorum whose membership or placement
+// changed since it was published is still removed in full.
+func ClearActiveSegmentNodes(logNs, logId, segmentId string) {
+	WpActiveSegmentNode.DeletePartialMatch(prometheus.Labels{
+		"log_ns":     logNs,
+		"log_id":     logId,
+		"segment_id": segmentId,
+	})
 }

--- a/common/metrics/metrics_registration_test.go
+++ b/common/metrics/metrics_registration_test.go
@@ -289,3 +289,22 @@ func TestMetrics_UseLogNsLabel(t *testing.T) {
 		check(t, reg, "woodpecker_client_append_requests_total")
 	})
 }
+
+func TestRegisterReplicaPlacementMetrics(t *testing.T) {
+	WpClientRegisterOnce = sync.Once{}
+	registry := prometheus.NewRegistry()
+	RegisterClientMetricsWithRegisterer(registry)
+
+	WpClientReplicaAppendTotal.WithLabelValues("bucket/root", "1", "cross_az", "success").Inc()
+	WpClientReplicaAppendBytesTotal.WithLabelValues("bucket/root", "1", "cross_az").Add(64)
+	WpClientQuorumReadTotal.WithLabelValues("bucket/root", "1", "local", "success").Inc()
+	WpClientQuorumReadBytesTotal.WithLabelValues("bucket/root", "1", "local").Add(128)
+	WpClientReadFailoverTotal.WithLabelValues("bucket/root", "1", "local", "cross_az").Inc()
+
+	names := gatheredMetricNames(t, registry)
+	assert.True(t, names["woodpecker_client_replica_append_total"])
+	assert.True(t, names["woodpecker_client_replica_append_bytes_total"])
+	assert.True(t, names["woodpecker_client_quorum_read_total"])
+	assert.True(t, names["woodpecker_client_quorum_read_bytes_total"])
+	assert.True(t, names["woodpecker_client_read_failover_total"])
+}

--- a/common/topology/topology_utils.go
+++ b/common/topology/topology_utils.go
@@ -9,6 +9,33 @@ const (
 	DefaultClusterNameValue = "default"
 )
 
+// Placement scopes describe how far a peer sits from this process. They are
+// used as a metric label, so the value set is deliberately tiny — the peer's
+// identity is intentionally not part of it.
+const (
+	ScopeLocal       = "local"
+	ScopeCrossAZ     = "cross_az"
+	ScopeCrossRegion = "cross_region"
+	ScopeUnknown     = "unknown"
+)
+
+// Scope classifies a peer's placement relative to a local placement. Either
+// side may be unset — REGION/AVAILABILITY_ZONE are optional, and a process
+// without them cannot tell local from remote at all — which yields
+// ScopeUnknown rather than a guess.
+func Scope(localRegion, localAZ, peerRegion, peerAZ string) string {
+	if localRegion == "" || localAZ == "" || peerRegion == "" || peerAZ == "" {
+		return ScopeUnknown
+	}
+	if localRegion != peerRegion {
+		return ScopeCrossRegion
+	}
+	if localAZ != peerAZ {
+		return ScopeCrossAZ
+	}
+	return ScopeLocal
+}
+
 func envOrDefault(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
 		return v

--- a/common/topology/topology_utils_test.go
+++ b/common/topology/topology_utils_test.go
@@ -25,3 +25,26 @@ func TestCurrentTopologyFromEnv(t *testing.T) {
 	assert.Equal(t, "region-a", GetCurrentRegion())
 	assert.Equal(t, "az-a", GetCurrentAvailabilityZone())
 }
+
+func TestScope(t *testing.T) {
+	cases := []struct {
+		name                 string
+		localRegion, localAZ string
+		peerRegion, peerAZ   string
+		want                 string
+	}{
+		{"same region and az", "r1", "a1", "r1", "a1", ScopeLocal},
+		{"same region other az", "r1", "a1", "r1", "a2", ScopeCrossAZ},
+		{"other region", "r1", "a1", "r2", "a1", ScopeCrossRegion},
+		{"other region and az", "r1", "a1", "r2", "a2", ScopeCrossRegion},
+		{"local placement unset", "", "", "r1", "a1", ScopeUnknown},
+		{"local az unset", "r1", "", "r1", "a1", ScopeUnknown},
+		{"peer placement unset", "r1", "a1", "", "", ScopeUnknown},
+		{"peer az unset", "r1", "a1", "r1", "", ScopeUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, Scope(tc.localRegion, tc.localAZ, tc.peerRegion, tc.peerAZ))
+		})
+	}
+}

--- a/tests/docker/monitor/README.md
+++ b/tests/docker/monitor/README.md
@@ -123,6 +123,25 @@ tests/monitor/
 | `woodpecker_client_segment_handle_pending_append_ops` | Gauge | log_id | Pending append operations | Write backpressure observation |
 | `woodpecker_client_writer_bytes_written` | Counter | log_id | Writer bytes written | Per-writer throughput |
 
+### Client Replica Placement Module
+
+`az_scope` is where the peer replica sits relative to the client: `local`,
+`cross_az`, `cross_region`, or `unknown` when either side's placement is not
+configured. The client learns its own placement from the `REGION` /
+`AVAILABILITY_ZONE` environment variables and each replica's from the quorum
+metadata — **without them every sample is `unknown`, and the read path's
+local-replica preference is inert as well.** The replica endpoint is
+deliberately not a label: it would multiply by `log_id`.
+
+| Metric Name | Type | Labels | Description | Key Design Metric |
+|---|---|---|---|---|
+| `woodpecker_client_replica_append_total` | Counter | log_id, az_scope, status | Per-replica append outcomes | Which replicas a write actually reached |
+| `woodpecker_client_replica_append_bytes_total` | Counter | log_id, az_scope | Bytes acknowledged per replica | Cross-AZ write traffic |
+| `woodpecker_client_quorum_read_total` | Counter | log_id, az_scope, status | Quorum read outcomes (a caught-up tail reader's "no entry yet" is not counted) | Which replica serves reads |
+| `woodpecker_client_quorum_read_bytes_total` | Counter | log_id, az_scope | Bytes read from quorum replicas | Cross-AZ read traffic |
+| `woodpecker_client_read_failover_total` | Counter | log_id, from_scope, to_scope | Reads served by a different scope than the preferred one | Local-replica preference effectiveness |
+| `woodpecker_client_active_segment_node` | Gauge | log_id, segment_id, node, az | Quorum membership of the current writable segment | AZ spread of the write quorum |
+
 ### Client Etcd Meta Module
 
 | Metric Name | Type | Labels | Description | Key Design Metric |

--- a/tests/docker/monitor/grafana/templates/dashboard_client.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_client.json
@@ -479,7 +479,7 @@
           "refId": "A"
         }
       ],
-      "title": "Log Name \u2192 Log ID Mapping",
+      "title": "Log Name → Log ID Mapping",
       "transformations": [
         {
           "id": "organize",
@@ -845,12 +845,334 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 58
+      },
+      "id": 105,
+      "title": "Cross-AZ / Replica Traffic",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 59
+      },
+      "id": 106,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_replica_append_bytes_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (az_scope)",
+          "legendFormat": "{{az_scope}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replica Write Bytes by Scope",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 59
+      },
+      "id": 107,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_replica_append_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (az_scope, status)",
+          "legendFormat": "{{az_scope}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replica Write Rate by Scope",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 59
+      },
+      "id": 108,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_quorum_read_bytes_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (az_scope)",
+          "legendFormat": "{{az_scope}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Quorum Read Bytes by Scope",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 67
+      },
+      "id": 109,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_quorum_read_bytes_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", az_scope!=\"local\"}[5m])) / clamp_min(sum(rate(woodpecker_client_quorum_read_bytes_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[5m])), 1)",
+          "legendFormat": "read",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(woodpecker_client_replica_append_bytes_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", az_scope!=\"local\"}[5m])) / clamp_min(sum(rate(woodpecker_client_replica_append_bytes_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[5m])), 1)",
+          "legendFormat": "write",
+          "refId": "B"
+        }
+      ],
+      "title": "Cross-Zone Traffic Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 67
+      },
+      "id": 110,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_read_failover_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (from_scope, to_scope)",
+          "legendFormat": "{{from_scope}} → {{to_scope}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Read Failover Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "__DATASOURCE_UID__"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 67
+      },
+      "id": 111,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count by (az) (woodpecker_client_active_segment_node{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"})",
+          "legendFormat": "az={{az}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Segment Replicas by AZ",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 75
       },
       "id": 8,
       "panels": [

--- a/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
@@ -479,7 +479,7 @@
           "refId": "A"
         }
       ],
-      "title": "Log Name \u2192 Log ID Mapping",
+      "title": "Log Name → Log ID Mapping",
       "transformations": [
         {
           "id": "organize",
@@ -845,12 +845,334 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 58
+      },
+      "id": 105,
+      "title": "Cross-AZ / Replica Traffic",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 59
+      },
+      "id": 106,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_replica_append_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (az_scope)",
+          "legendFormat": "{{az_scope}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replica Write Bytes by Scope",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 59
+      },
+      "id": 107,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_replica_append_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (az_scope, status)",
+          "legendFormat": "{{az_scope}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Replica Write Rate by Scope",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 59
+      },
+      "id": 108,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_quorum_read_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (az_scope)",
+          "legendFormat": "{{az_scope}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Quorum Read Bytes by Scope",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 67
+      },
+      "id": 109,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_quorum_read_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", az_scope!=\"local\"}[5m])) / clamp_min(sum(rate(woodpecker_client_quorum_read_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[5m])), 1)",
+          "legendFormat": "read",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(woodpecker_client_replica_append_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", az_scope!=\"local\"}[5m])) / clamp_min(sum(rate(woodpecker_client_replica_append_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[5m])), 1)",
+          "legendFormat": "write",
+          "refId": "B"
+        }
+      ],
+      "title": "Cross-Zone Traffic Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 67
+      },
+      "id": 110,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_read_failover_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (from_scope, to_scope)",
+          "legendFormat": "{{from_scope}} → {{to_scope}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Read Failover Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 67
+      },
+      "id": 111,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "count by (az) (woodpecker_client_active_segment_node{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"})",
+          "legendFormat": "az={{az}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Segment Replicas by AZ",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 75
       },
       "id": 8,
       "panels": [

--- a/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
+++ b/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
@@ -3948,7 +3948,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Log Name \u2192 Log ID Mapping",
+          "title": "Log Name → Log ID Mapping",
           "transformations": [
             {
               "id": "organize",
@@ -4314,12 +4314,334 @@ data:
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
             "y": 58
+          },
+          "id": 105,
+          "title": "Cross-AZ / Replica Traffic",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 59
+          },
+          "id": 106,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_replica_append_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (az_scope)",
+              "legendFormat": "{{az_scope}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Replica Write Bytes by Scope",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 59
+          },
+          "id": 107,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_replica_append_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (az_scope, status)",
+              "legendFormat": "{{az_scope}} {{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Replica Write Rate by Scope",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "Bps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 59
+          },
+          "id": 108,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_quorum_read_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (az_scope)",
+              "legendFormat": "{{az_scope}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Quorum Read Bytes by Scope",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 67
+          },
+          "id": 109,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_quorum_read_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", az_scope!=\"local\"}[5m])) / clamp_min(sum(rate(woodpecker_client_quorum_read_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[5m])), 1)",
+              "legendFormat": "read",
+              "refId": "A"
+            },
+            {
+              "expr": "sum(rate(woodpecker_client_replica_append_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\", az_scope!=\"local\"}[5m])) / clamp_min(sum(rate(woodpecker_client_replica_append_bytes_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[5m])), 1)",
+              "legendFormat": "write",
+              "refId": "B"
+            }
+          ],
+          "title": "Cross-Zone Traffic Ratio",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 67
+          },
+          "id": 110,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_read_failover_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (from_scope, to_scope)",
+              "legendFormat": "{{from_scope}} → {{to_scope}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Read Failover Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 67
+          },
+          "id": 111,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "count by (az) (woodpecker_client_active_segment_node{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"})",
+              "legendFormat": "az={{az}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Active Segment Replicas by AZ",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 75
           },
           "id": 8,
           "panels": [

--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -33,6 +33,7 @@ import (
 	"github.com/zilliztech/woodpecker/common/channel"
 	"github.com/zilliztech/woodpecker/common/logger"
 	"github.com/zilliztech/woodpecker/common/metrics"
+	"github.com/zilliztech/woodpecker/common/topology"
 	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/proto"
 	"github.com/zilliztech/woodpecker/woodpecker/client"
@@ -67,6 +68,7 @@ type AppendOp struct {
 	handle          SegmentHandle
 	ackSet          *bitset.BitSet
 	quorumInfo      *proto.QuorumInfo
+	nodeScopes      []string // per node index: how far that replica sits from this client
 	resultChannels  []channel.ResultChannel
 	channelAttempts []int
 	channelErrors   []error // Each channel has its own error
@@ -77,7 +79,7 @@ type AppendOp struct {
 }
 
 func NewAppendOp(bucketName string, rootPath string, logId int64, segmentId int64, entryId int64, value []byte, callback func(segmentId int64, entryId int64, err error),
-	clientPool client.LogStoreClientPool, handle SegmentHandle, quorumInfo *proto.QuorumInfo,
+	clientPool client.LogStoreClientPool, handle SegmentHandle, quorumInfo *proto.QuorumInfo, nodeScopes []string,
 ) *AppendOp {
 	op := &AppendOp{
 		bucketName: bucketName,
@@ -93,6 +95,7 @@ func NewAppendOp(bucketName string, rootPath string, logId int64, segmentId int6
 		handle:          handle,
 		ackSet:          &bitset.BitSet{},
 		quorumInfo:      quorumInfo,
+		nodeScopes:      nodeScopes,
 		resultChannels:  make([]channel.ResultChannel, 0),
 		channelAttempts: make([]int, len(quorumInfo.Nodes)),
 		channelErrors:   make([]error, len(quorumInfo.Nodes)),
@@ -104,6 +107,21 @@ func NewAppendOp(bucketName string, rootPath string, logId int64, segmentId int6
 
 func (op *AppendOp) Identifier() string {
 	return fmt.Sprintf("%d/%d/%d", op.logId, op.segmentId, op.entryId)
+}
+
+// recordReplicaResult counts one replica's outcome for this entry, labelled by
+// how far that replica sits from this client. A quorum append writes to every
+// replica, so this is where cross-AZ write traffic becomes visible.
+func (op *AppendOp) recordReplicaResult(serverIndex int, status string) {
+	scope := topology.ScopeUnknown
+	if serverIndex >= 0 && serverIndex < len(op.nodeScopes) {
+		scope = op.nodeScopes[serverIndex]
+	}
+	logIdStr := strconv.FormatInt(op.logId, 10)
+	metrics.WpClientReplicaAppendTotal.WithLabelValues(op.logNs, logIdStr, scope, status).Inc()
+	if status == "success" {
+		metrics.WpClientReplicaAppendBytesTotal.WithLabelValues(op.logNs, logIdStr, scope).Add(float64(len(op.value)))
+	}
 }
 
 func (op *AppendOp) Execute() {
@@ -159,6 +177,7 @@ func (op *AppendOp) sendWriteRequestRetry(ctx context.Context, serverIndex int) 
 	cli, clientErr := op.clientPool.GetLogStoreClient(ctx, serverAddr)
 	if clientErr != nil {
 		op.channelErrors[serverIndex] = clientErr
+		op.recordReplicaResult(serverIndex, "error")
 		// segHandle failure async
 		go op.handle.HandleAppendRequestFailure(ctx, op.entryId, clientErr, serverIndex, serverAddr)
 		return
@@ -207,6 +226,7 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 			return
 		}
 		op.channelErrors[serverIndex] = err
+		op.recordReplicaResult(serverIndex, "error")
 		op.handle.HandleAppendRequestFailure(ctx, op.entryId, err, serverIndex, serverAddr)
 		return
 	}
@@ -236,18 +256,21 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 		}
 		// read chan error, retry if necessary
 		op.channelErrors[serverIndex] = readChanErr
+		op.recordReplicaResult(serverIndex, "error")
 		op.handle.HandleAppendRequestFailure(ctx, op.entryId, readChanErr, serverIndex, serverAddr)
 		return
 	}
 
 	if syncedResult.SyncedId == -1 || syncedResult.Err != nil {
 		op.channelErrors[serverIndex] = syncedResult.Err
+		op.recordReplicaResult(serverIndex, "error")
 		op.handle.HandleAppendRequestFailure(ctx, op.entryId, syncedResult.Err, serverIndex, serverAddr)
 		return
 	}
 
 	// set and count if ack >= aq
 	if syncedResult.SyncedId != -1 && syncedResult.SyncedId >= op.entryId {
+		op.recordReplicaResult(serverIndex, "success")
 		ackCount := op.ackSet.SetAndCount(serverIndex)
 		if ackCount >= int(op.quorumInfo.Aq) {
 			// Use atomic operation to ensure SendAppendSuccessCallbacks is called only once
@@ -278,15 +301,18 @@ func (op *AppendOp) applyNodeAck(ctx context.Context, startRequestTime time.Time
 	}
 	if readErr != nil {
 		op.channelErrors[serverIndex] = readErr
+		op.recordReplicaResult(serverIndex, "error")
 		op.handle.HandleAppendRequestFailure(ctx, op.entryId, readErr, serverIndex, serverAddr)
 		return
 	}
 	if result.SyncedId == -1 || result.Err != nil {
 		op.channelErrors[serverIndex] = result.Err
+		op.recordReplicaResult(serverIndex, "error")
 		op.handle.HandleAppendRequestFailure(ctx, op.entryId, result.Err, serverIndex, serverAddr)
 		return
 	}
 	if result.SyncedId >= op.entryId {
+		op.recordReplicaResult(serverIndex, "success")
 		if op.ackSet.SetAndCount(serverIndex) >= int(op.quorumInfo.Aq) {
 			if op.completed.CompareAndSwap(false, true) {
 				op.handle.SendAppendSuccessCallbacks(ctx, op.entryId)

--- a/woodpecker/segment/append_op_test.go
+++ b/woodpecker/segment/append_op_test.go
@@ -66,7 +66,7 @@ func TestAppendOp_Retry_RebuildsResultChannelForRemoteClient(t *testing.T) {
 		Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"},
 	}
 	op := NewAppendOp("bucket", "root", 1, 2, 10, []byte("v"),
-		func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo)
+		func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo, nil)
 
 	// Simulate the batch path having installed a LocalResultChannel in the slot.
 	op.resultChannels = make([]channel.ResultChannel, 1)
@@ -111,7 +111,7 @@ func newApplyNodeAckOp(t *testing.T, quorumInfo *proto.QuorumInfo) (*AppendOp, *
 	t.Helper()
 	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
 	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("v"),
-		func(int64, int64, error) {}, nil, mockHandle, quorumInfo)
+		func(int64, int64, error) {}, nil, mockHandle, quorumInfo, nil)
 	return op, mockHandle
 }
 
@@ -200,7 +200,7 @@ func TestAppendOp_RetryChannelRebuild_RacesWithFastFail(t *testing.T) {
 		quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}}
 
 		op := NewAppendOp("bucket", "root", 1, 2, 10, []byte("v"),
-			func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo)
+			func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo, nil)
 		// As installed by a prior batched send: a LocalResultChannel in the slot,
 		// which the retry against a remote client must rebuild (type mismatch).
 		op.resultChannels = make([]channel.ResultChannel, 1)
@@ -251,7 +251,7 @@ func TestNewAppendOp(t *testing.T) {
 		Nodes: []string{"node1"},
 	}
 
-	op := NewAppendOp("a-bucket", "files", logId, segmentId, entryId, value, callback, clientPool, handle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", logId, segmentId, entryId, value, callback, clientPool, handle, quorumInfo, nil)
 
 	assert.NotNil(t, op)
 	assert.Equal(t, logId, op.logId)
@@ -301,7 +301,7 @@ func TestAppendOp_Execute_Success(t *testing.T) {
 		close(done)
 	}).Return()
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo, nil)
 
 	// Execute
 	op.Execute()
@@ -342,7 +342,7 @@ func TestAppendOp_Execute_GetClientError(t *testing.T) {
 	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, "node1").Return(nil, expectedErr)
 	mockHandle.EXPECT().HandleAppendRequestFailure(mock.Anything, int64(3), mock.Anything, mock.Anything, mock.Anything).Return()
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo, nil)
 
 	op.Execute()
 	// Wait for async handleAppendRequestFailure to be processed
@@ -361,7 +361,7 @@ func TestAppendOp_receivedAckCallback_Success(t *testing.T) {
 		Nodes: []string{"node1"},
 	}
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, mockHandle, quorumInfo, nil)
 
 	// Create a channel and send success signal
 	rc := channel.NewLocalResultChannel(fmt.Sprintf("1/0/%d", 0))
@@ -385,7 +385,7 @@ func TestAppendOp_receivedAckCallback_SyncError(t *testing.T) {
 	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
 	expectedErr := errors.New("sync error")
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, mockHandle, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}})
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, mockHandle, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}}, nil)
 
 	mockHandle.EXPECT().HandleAppendRequestFailure(mock.Anything, int64(3), mock.Anything, mock.Anything, mock.Anything).Return()
 
@@ -398,7 +398,7 @@ func TestAppendOp_receivedAckCallback_SyncError(t *testing.T) {
 
 func TestAppendOp_receivedAckCallback_FailureSignal(t *testing.T) {
 	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, mockHandle, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}})
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, mockHandle, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}}, nil)
 
 	// Create a channel and send failure signal
 	rc := channel.NewLocalResultChannel(fmt.Sprintf("1/0/%d", 0))
@@ -417,7 +417,7 @@ func TestAppendOp_receivedAckCallback_FailureSignal(t *testing.T) {
 
 func TestAppendOp_receivedAckCallback_ChannelClosed(t *testing.T) {
 	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, mockHandle, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}})
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, mockHandle, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}}, nil)
 
 	// Create a channel and close it
 	rc := channel.NewLocalResultChannel(fmt.Sprintf("1/0/%d", 0))
@@ -432,7 +432,7 @@ func TestAppendOp_receivedAckCallback_ChannelClosed(t *testing.T) {
 }
 
 func TestAppendOp_FastFail(t *testing.T) {
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}})
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}}, nil)
 
 	// Add some result channels
 	rc1 := channel.NewLocalResultChannel("1/2/3-1")
@@ -464,7 +464,7 @@ func TestAppendOp_FastFail(t *testing.T) {
 }
 
 func TestAppendOp_FastFail_Idempotent(t *testing.T) {
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}})
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}}, nil)
 
 	rc := channel.NewLocalResultChannel("1/2/3")
 	op.resultChannels = []channel.ResultChannel{rc}
@@ -485,7 +485,7 @@ func TestAppendOp_FastFail_Idempotent(t *testing.T) {
 }
 
 func TestAppendOp_FastSuccess(t *testing.T) {
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}})
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}}, nil)
 
 	// Add some result channels
 	rc1 := channel.NewLocalResultChannel("1/2/3-1")
@@ -517,7 +517,7 @@ func TestAppendOp_FastSuccess(t *testing.T) {
 }
 
 func TestAppendOp_FastSuccess_Idempotent(t *testing.T) {
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}})
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}}, nil)
 
 	rc := channel.NewLocalResultChannel("1/2/3")
 	op.resultChannels = []channel.ResultChannel{rc}
@@ -538,7 +538,7 @@ func TestAppendOp_FastSuccess_Idempotent(t *testing.T) {
 }
 
 func TestAppendOp_FastFail_WithClosedChannel(t *testing.T) {
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}})
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}}, nil)
 
 	// Add a closed channel
 	rc := channel.NewLocalResultChannel("1/2/3")
@@ -555,7 +555,7 @@ func TestAppendOp_FastFail_WithClosedChannel(t *testing.T) {
 }
 
 func TestAppendOp_FastSuccess_WithClosedChannel(t *testing.T) {
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}})
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}}, nil)
 
 	// Add a closed channel
 	rc := channel.NewLocalResultChannel("1/2/3")
@@ -572,7 +572,7 @@ func TestAppendOp_FastSuccess_WithClosedChannel(t *testing.T) {
 }
 
 func TestAppendOp_ConcurrentFastCalls(t *testing.T) {
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}})
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, nil, nil, &proto.QuorumInfo{Nodes: []string{"127.0.0.1"}}, nil)
 
 	rc := channel.NewLocalResultChannel("1/2/3")
 	op.resultChannels = []channel.ResultChannel{rc}
@@ -674,7 +674,7 @@ func TestAppendOp_Execute_RetryIdempotency(t *testing.T) {
 	mockClient.EXPECT().AppendEntry(mock.Anything, mock.Anything, mock.Anything, int64(1), mock.Anything, mock.Anything).Return(int64(3), nil)
 	mockClient.EXPECT().IsRemoteClient().Return(true)
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo, nil)
 	t.Cleanup(func() { cleanupAppendOp(t, op) })
 
 	// First execution
@@ -729,7 +729,7 @@ func TestAppendOp_Execute_RetryIdempotency_WithSameQuorumSize(t *testing.T) {
 	mockClient.EXPECT().AppendEntry(mock.Anything, mock.Anything, mock.Anything, int64(1), mock.Anything, mock.Anything).Return(int64(3), nil)
 	mockClient.EXPECT().IsRemoteClient().Return(true)
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, initialQuorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, initialQuorumInfo, nil)
 	t.Cleanup(func() { cleanupAppendOp(t, op) })
 
 	// First execution with 2 nodes
@@ -771,7 +771,7 @@ func TestAppendOp_sendWriteRequest_ChannelReuse(t *testing.T) {
 	mockClient.EXPECT().AppendEntry(mock.Anything, mock.Anything, mock.Anything, int64(1), mock.Anything, mock.Anything).Return(int64(3), nil)
 	mockClient.EXPECT().IsRemoteClient().Return(true)
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, nil, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, nil, quorumInfo, nil)
 	t.Cleanup(func() { cleanupAppendOp(t, op) })
 
 	// Initialize result channels slice
@@ -813,7 +813,7 @@ func TestAppendOp_Execute_RetryIdempotency_WithNilChannels(t *testing.T) {
 	mockClient.EXPECT().AppendEntry(mock.Anything, mock.Anything, mock.Anything, int64(1), mock.Anything, mock.Anything).Return(int64(3), nil)
 	mockClient.EXPECT().IsRemoteClient().Return(true)
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo, nil)
 	t.Cleanup(func() { cleanupAppendOp(t, op) })
 
 	// Manually set up result channels with one nil channel (simulating partial failure).
@@ -856,7 +856,7 @@ func TestAppendOp_Execute_RetryIdempotency_ChannelIdentifier(t *testing.T) {
 	mockClient.EXPECT().AppendEntry(mock.Anything, mock.Anything, mock.Anything, int64(1), mock.Anything, mock.Anything).Return(int64(3), nil)
 	mockClient.EXPECT().IsRemoteClient().Return(true)
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo, nil)
 	t.Cleanup(func() { cleanupAppendOp(t, op) })
 
 	// First execution
@@ -929,7 +929,7 @@ func TestAppendOp_QuorumWrite_Case1_AllNodesSuccess(t *testing.T) {
 		callback(2, entryId, nil)
 	}).Return()
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), callback, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), callback, mockClientPool, mockHandle, quorumInfo, nil)
 
 	// Execute
 	op.Execute()
@@ -1019,7 +1019,7 @@ func TestAppendOp_QuorumWrite_Case2_TwoSuccessOneFail(t *testing.T) {
 	// Expect HandleAppendRequestFailure for the failing node
 	mockHandle.EXPECT().HandleAppendRequestFailure(mock.Anything, int64(3), mock.Anything, 2, "node3").Return()
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), callback, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), callback, mockClientPool, mockHandle, quorumInfo, nil)
 
 	// Execute
 	op.Execute()
@@ -1111,7 +1111,7 @@ func TestAppendOp_QuorumWrite_Case3_SingleNodeSuccess(t *testing.T) {
 		callback(2, entryId, nil)
 	}).Return()
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), callback, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), callback, mockClientPool, mockHandle, quorumInfo, nil)
 
 	// Execute
 	op.Execute()
@@ -1176,7 +1176,7 @@ func TestAppendOp_QuorumWrite_Case4_SingleNodeFailure(t *testing.T) {
 	// Expect HandleAppendRequestFailure for the failing node
 	mockHandle.EXPECT().HandleAppendRequestFailure(mock.Anything, int64(3), mock.Anything, 0, "node1").Return()
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), callback, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), callback, mockClientPool, mockHandle, quorumInfo, nil)
 
 	// Execute
 	op.Execute()
@@ -1304,7 +1304,7 @@ func testSimpleQuorum(t *testing.T, nodeCount, ackQuorum, successCount int, expe
 		}).Return()
 	}
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), callback, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), callback, mockClientPool, mockHandle, quorumInfo, nil)
 
 	// Execute
 	op.Execute()
@@ -1377,7 +1377,7 @@ func TestAppendOp_Execute_ParallelFanout(t *testing.T) {
 		}).
 		Return(int64(3), nil)
 
-	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo, nil)
 
 	start := time.Now()
 	op.Execute()

--- a/woodpecker/segment/append_request_retry_op_test.go
+++ b/woodpecker/segment/append_request_retry_op_test.go
@@ -50,6 +50,7 @@ func TestNewAppendRequestRetryOp(t *testing.T) {
 		mockClientPool,
 		mockSegHandle,
 		quorumInfo,
+		nil,
 	)
 
 	retryOp := NewAppendRequestRetryOp(ctx, 0, innerOp)
@@ -81,6 +82,7 @@ func TestAppendRequestRetryOp_Identifier(t *testing.T) {
 		mockClientPool,
 		mockSegHandle,
 		quorumInfo,
+		nil,
 	)
 
 	retryOp := NewAppendRequestRetryOp(ctx, 0, innerOp)
@@ -113,6 +115,7 @@ func TestAppendRequestRetryOp_IdentifierDelegatesToInnerOp(t *testing.T) {
 		mockClientPool,
 		mockSegHandle,
 		quorumInfo,
+		nil,
 	)
 
 	retryOp := NewAppendRequestRetryOp(ctx, 0, innerOp)
@@ -144,6 +147,7 @@ func TestAppendRequestRetryOp_ImplementsOperationInterface(t *testing.T) {
 		mockClientPool,
 		mockSegHandle,
 		quorumInfo,
+		nil,
 	)
 
 	var op Operation = NewAppendRequestRetryOp(ctx, 0, innerOp)
@@ -174,6 +178,7 @@ func TestAppendRequestRetryOp_DifferentServerIndices(t *testing.T) {
 		mockClientPool,
 		mockSegHandle,
 		quorumInfo,
+		nil,
 	)
 
 	// Create retry ops for different server indices

--- a/woodpecker/segment/batch_append_op.go
+++ b/woodpecker/segment/batch_append_op.go
@@ -170,6 +170,7 @@ func (b *BatchAppendOp) sendBatchToNode(ctx context.Context, entries []*proto.Lo
 func (b *BatchAppendOp) failNode(ctx context.Context, nodeIdx int, serverAddr string, err error) {
 	for _, op := range b.ops {
 		op.channelErrors[nodeIdx] = err
+		op.recordReplicaResult(nodeIdx, "error")
 		go op.handle.HandleAppendRequestFailure(ctx, op.entryId, err, nodeIdx, serverAddr)
 	}
 }

--- a/woodpecker/segment/batch_append_op_test.go
+++ b/woodpecker/segment/batch_append_op_test.go
@@ -55,7 +55,7 @@ func TestBatchAppendOp_Execute_QuorumAck(t *testing.T) {
 	ops := make([]*AppendOp, batchN)
 	for i := 0; i < batchN; i++ {
 		ops[i] = NewAppendOp("a-bucket", "files", 1, 2, firstEntryId+int64(i), []byte("val"),
-			func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo)
+			func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo, nil)
 	}
 
 	mockPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil)
@@ -127,7 +127,7 @@ func TestSequentialExecutor_CoalescesAppendOps(t *testing.T) {
 	ops := make([]*AppendOp, batchN)
 	for i := 0; i < batchN; i++ {
 		ops[i] = NewAppendOp("a-bucket", "files", 1, 2, firstEntryId+int64(i), []byte("v"),
-			func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo)
+			func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo, nil)
 	}
 
 	mockPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil)
@@ -196,7 +196,7 @@ func newBatchOps(t *testing.T, n int, pool *mocks_logstore_client.LogStoreClient
 	ops := make([]*AppendOp, n)
 	for i := 0; i < n; i++ {
 		ops[i] = NewAppendOp("a-bucket", "files", 1, 2, int64(10+i), []byte("v"),
-			func(int64, int64, error) {}, pool, handle, quorumInfo)
+			func(int64, int64, error) {}, pool, handle, quorumInfo, nil)
 	}
 	return ops
 }

--- a/woodpecker/segment/group_commit_bench_test.go
+++ b/woodpecker/segment/group_commit_bench_test.go
@@ -92,7 +92,7 @@ func benchGroupCommit(b *testing.B, maxBatchEntries int, rtt time.Duration) {
 	ops := make([]*AppendOp, b.N)
 	for i := range ops {
 		ops[i] = NewAppendOp("bk", "fp", 1, 2, int64(i), []byte("v"),
-			func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo)
+			func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo, nil)
 	}
 	exec := NewBatchingSequentialExecutor(b.N+1, maxBatchEntries, 0)
 	wg.Add(b.N)

--- a/woodpecker/segment/quorum_scope_test.go
+++ b/woodpecker/segment/quorum_scope_test.go
@@ -1,0 +1,223 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/metrics"
+	"github.com/zilliztech/woodpecker/common/topology"
+	"github.com/zilliztech/woodpecker/meta"
+	"github.com/zilliztech/woodpecker/mocks/mocks_meta"
+	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_logstore_client"
+	"github.com/zilliztech/woodpecker/proto"
+)
+
+func scopeTestQuorum() *proto.QuorumInfo {
+	return &proto.QuorumInfo{
+		Id:    1,
+		Aq:    2,
+		Es:    3,
+		Wq:    3,
+		Nodes: []string{"node-remote-a", "node-local", "node-unmapped"},
+		Replicas: []*proto.QuorumNode{
+			{Endpoint: "node-remote-a", Region: "region-remote", Az: "az-remote-a"},
+			{Endpoint: "node-local", Region: "region-local", Az: "az-local"},
+			// node-unmapped has no replica entry: quorum metadata written
+			// before placement was recorded.
+		},
+	}
+}
+
+func TestQuorumNodeScopes(t *testing.T) {
+	t.Run("with local placement", func(t *testing.T) {
+		t.Setenv("REGION", "region-local")
+		t.Setenv("AVAILABILITY_ZONE", "az-local")
+
+		assert.Equal(t,
+			[]string{topology.ScopeCrossRegion, topology.ScopeLocal, topology.ScopeUnknown},
+			quorumNodeScopes(scopeTestQuorum()))
+	})
+
+	t.Run("same region other az", func(t *testing.T) {
+		t.Setenv("REGION", "region-remote")
+		t.Setenv("AVAILABILITY_ZONE", "az-remote-b")
+
+		assert.Equal(t,
+			[]string{topology.ScopeCrossAZ, topology.ScopeCrossRegion, topology.ScopeUnknown},
+			quorumNodeScopes(scopeTestQuorum()))
+	})
+
+	t.Run("client without placement knows nothing", func(t *testing.T) {
+		t.Setenv("REGION", "")
+		t.Setenv("AVAILABILITY_ZONE", "")
+
+		assert.Equal(t,
+			[]string{topology.ScopeUnknown, topology.ScopeUnknown, topology.ScopeUnknown},
+			quorumNodeScopes(scopeTestQuorum()))
+	})
+}
+
+func TestActiveSegmentNodes(t *testing.T) {
+	assert.Equal(t, []metrics.ActiveSegmentNode{
+		{Node: "node-remote-a", AZ: "az-remote-a"},
+		{Node: "node-local", AZ: "az-local"},
+		{Node: "node-unmapped", AZ: ""},
+	}, activeSegmentNodes(scopeTestQuorum()))
+}
+
+func TestOrderedQuorumReadCandidates_CarriesScope(t *testing.T) {
+	t.Setenv("REGION", "region-local")
+	t.Setenv("AVAILABILITY_ZONE", "az-local")
+
+	candidates := orderedQuorumReadCandidates(scopeTestQuorum(), nil)
+
+	// Local first, and every candidate knows its own distance.
+	assert.Equal(t, "node-local", candidates[0].node)
+	assert.Equal(t, topology.ScopeLocal, candidates[0].azScope)
+	assert.Equal(t, topology.ScopeCrossRegion, candidates[1].azScope)
+	assert.Equal(t, topology.ScopeUnknown, candidates[2].azScope)
+}
+
+// A read that falls off the local replica onto a remote one is the case that
+// costs money, so it must show up as both cross-scope read traffic and a
+// failover.
+func TestReadBatchAdv_RecordsCrossScopeReadAndFailover(t *testing.T) {
+	t.Setenv("REGION", "region-local")
+	t.Setenv("AVAILABILITY_ZONE", "az-local")
+
+	metrics.WpClientQuorumReadTotal.Reset()
+	metrics.WpClientQuorumReadBytesTotal.Reset()
+	metrics.WpClientReadFailoverTotal.Reset()
+
+	mockMetadata := mocks_meta.NewMetadataProvider(t)
+	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	localClient := mocks_logstore_client.NewLogStoreClient(t)
+	remoteClient := mocks_logstore_client.NewLogStoreClient(t)
+
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, "node-local").Return(localClient, nil).Once()
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, "node-remote-a").Return(remoteClient, nil).Once()
+
+	localClient.EXPECT().
+		ReadEntriesBatchAdv(mock.Anything, mock.Anything, mock.Anything, int64(1), int64(1), int64(0), int64(10), (*proto.LastReadState)(nil)).
+		Return(nil, errors.New("replica unavailable")).Once()
+	remoteClient.EXPECT().
+		ReadEntriesBatchAdv(mock.Anything, mock.Anything, mock.Anything, int64(1), int64(1), int64(0), int64(10), (*proto.LastReadState)(nil)).
+		Return(&proto.BatchReadResult{
+			Entries: []*proto.LogEntry{
+				{SegId: 1, EntryId: 0, Values: []byte("0123456789")},
+			},
+			LastReadState: &proto.LastReadState{},
+		}, nil).Once()
+
+	cfg := &config.Configuration{
+		Woodpecker: config.WoodpeckerConfig{
+			Client: config.ClientConfig{
+				SegmentAppend: config.SegmentAppendConfig{QueueSize: 10, MaxRetries: 2},
+			},
+		},
+	}
+	cfg.Minio.BucketName = "a-bucket"
+	cfg.Minio.RootPath = "files"
+
+	segmentMeta := &meta.SegmentMeta{
+		Metadata: &proto.SegmentMetadata{
+			SegNo:       1,
+			State:       proto.SegmentState_Active,
+			LastEntryId: -1,
+			Quorum:      scopeTestQuorum(),
+		},
+		Revision: 1,
+	}
+
+	segmentHandle := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, false, nil)
+	result, err := segmentHandle.ReadBatchAdv(context.Background(), 0, 10, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "node-remote-a", result.LastReadState.Node)
+
+	logNs := metrics.BuildLogNs("a-bucket", "files")
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		metrics.WpClientQuorumReadTotal.WithLabelValues(logNs, "1", topology.ScopeLocal, "error"),
+	))
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		metrics.WpClientQuorumReadTotal.WithLabelValues(logNs, "1", topology.ScopeCrossRegion, "success"),
+	))
+	assert.Equal(t, float64(10), testutil.ToFloat64(
+		metrics.WpClientQuorumReadBytesTotal.WithLabelValues(logNs, "1", topology.ScopeCrossRegion),
+	))
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		metrics.WpClientReadFailoverTotal.WithLabelValues(logNs, "1", topology.ScopeLocal, topology.ScopeCrossRegion),
+	))
+}
+
+// Serving from the preferred replica is not a failover.
+func TestReadBatchAdv_LocalReadIsNotAFailover(t *testing.T) {
+	t.Setenv("REGION", "region-local")
+	t.Setenv("AVAILABILITY_ZONE", "az-local")
+
+	metrics.WpClientQuorumReadTotal.Reset()
+	metrics.WpClientReadFailoverTotal.Reset()
+
+	mockMetadata := mocks_meta.NewMetadataProvider(t)
+	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	localClient := mocks_logstore_client.NewLogStoreClient(t)
+
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, "node-local").Return(localClient, nil).Once()
+	localClient.EXPECT().
+		ReadEntriesBatchAdv(mock.Anything, mock.Anything, mock.Anything, int64(1), int64(1), int64(0), int64(10), (*proto.LastReadState)(nil)).
+		Return(&proto.BatchReadResult{
+			Entries:       []*proto.LogEntry{{SegId: 1, EntryId: 0, Values: []byte("abc")}},
+			LastReadState: &proto.LastReadState{},
+		}, nil).Once()
+
+	cfg := &config.Configuration{
+		Woodpecker: config.WoodpeckerConfig{
+			Client: config.ClientConfig{
+				SegmentAppend: config.SegmentAppendConfig{QueueSize: 10, MaxRetries: 2},
+			},
+		},
+	}
+	cfg.Minio.BucketName = "a-bucket"
+	cfg.Minio.RootPath = "files"
+
+	segmentMeta := &meta.SegmentMeta{
+		Metadata: &proto.SegmentMetadata{
+			SegNo:       1,
+			State:       proto.SegmentState_Active,
+			LastEntryId: -1,
+			Quorum:      scopeTestQuorum(),
+		},
+		Revision: 1,
+	}
+
+	segmentHandle := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, false, nil)
+	_, err := segmentHandle.ReadBatchAdv(context.Background(), 0, 10, nil)
+	assert.NoError(t, err)
+
+	logNs := metrics.BuildLogNs("a-bucket", "files")
+	assert.Equal(t, float64(1), testutil.ToFloat64(
+		metrics.WpClientQuorumReadTotal.WithLabelValues(logNs, "1", topology.ScopeLocal, "success"),
+	))
+	assert.Equal(t, 0, testutil.CollectAndCount(metrics.WpClientReadFailoverTotal))
+}

--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -120,6 +120,7 @@ func NewSegmentHandle(ctx context.Context, logId int64, logName string, segmentM
 		lacSyncNotify:       make(chan struct{}, 1),
 		lacSyncStop:         make(chan struct{}),
 	}
+	segmentHandle.nodeScopes = quorumNodeScopes(segmentHandle.quorumInfo)
 	segmentHandle.lacSyncLatest.Store(segmentMeta.Metadata.LastEntryId)
 	segmentHandle.lastPushed.Store(segmentMeta.Metadata.LastEntryId)
 	segmentHandle.lastAddConfirmed.Store(segmentMeta.Metadata.LastEntryId)
@@ -141,7 +142,7 @@ func NewSegmentHandle(ctx context.Context, logId int64, logName string, segmentM
 			segmentHandle.logNs,
 			strconv.FormatInt(segmentHandle.logId, 10),
 			strconv.FormatInt(segmentHandle.segmentId, 10),
-			segmentHandle.quorumInfo.GetNodes(),
+			activeSegmentNodes(segmentHandle.quorumInfo),
 		)
 		segmentHandle.executor.Start(ctx)
 		segmentHandle.completionMgr = newCompletionManager(segmentHandle)
@@ -184,6 +185,7 @@ func NewSegmentHandleWithAppendOpsQueueWithWritable(ctx context.Context, logId i
 		lacSyncNotify: make(chan struct{}, 1),
 		lacSyncStop:   make(chan struct{}),
 	}
+	segmentHandle.nodeScopes = quorumNodeScopes(segmentHandle.quorumInfo)
 	segmentHandle.lacSyncLatest.Store(segmentMeta.Metadata.LastEntryId)
 	segmentHandle.lastPushed.Store(segmentMeta.Metadata.LastEntryId)
 	segmentHandle.lastAddConfirmed.Store(segmentMeta.Metadata.LastEntryId)
@@ -215,8 +217,12 @@ type segmentHandleImpl struct {
 	metadata         meta.MetadataProvider
 	ClientPool       client.LogStoreClientPool
 	quorumInfo       *proto.QuorumInfo
-	cfg              *config.Configuration
-	logNs            string
+	// nodeScopes says, per quorum node index, how far that replica sits from
+	// this client. A segment's quorum is fixed, so it is resolved once here
+	// instead of on every append.
+	nodeScopes []string
+	cfg        *config.Configuration
+	logNs      string
 
 	sync.RWMutex
 	lastPushed       atomic.Int64
@@ -327,7 +333,8 @@ func (s *segmentHandleImpl) createPendingAppendOp(ctx context.Context, bytes []b
 		callback,
 		s.ClientPool,
 		s,
-		s.quorumInfo)
+		s.quorumInfo,
+		s.nodeScopes)
 	return pendingAppendOp
 }
 
@@ -594,6 +601,69 @@ func (s *segmentHandleImpl) directReadBatch(ctx context.Context, from int64, max
 type quorumReadCandidate struct {
 	node          string
 	originalIndex int
+	azScope       string
+}
+
+// quorumPlacements maps each quorum endpoint to the replica metadata that says
+// where it sits. Endpoints absent from the replica list — quorum metadata
+// written before placement was recorded — are simply missing from the map.
+func quorumPlacements(quorumInfo *proto.QuorumInfo) map[string]*proto.QuorumNode {
+	replicas := quorumInfo.GetReplicas()
+	placements := make(map[string]*proto.QuorumNode, len(replicas))
+	for _, replica := range replicas {
+		if replica != nil && replica.Endpoint != "" {
+			placements[replica.Endpoint] = replica
+		}
+	}
+	return placements
+}
+
+func scopeOfReplica(localRegion, localAZ string, replica *proto.QuorumNode) string {
+	if replica == nil {
+		return topology.ScopeUnknown
+	}
+	return topology.Scope(localRegion, localAZ, replica.Region, replica.Az)
+}
+
+// quorumNodeScopes returns, per quorum node index, how far that replica sits
+// from this client, for the per-replica traffic metrics.
+func quorumNodeScopes(quorumInfo *proto.QuorumInfo) []string {
+	nodes := quorumInfo.GetNodes()
+	placements := quorumPlacements(quorumInfo)
+	localRegion := topology.GetCurrentRegion()
+	localAZ := topology.GetCurrentAvailabilityZone()
+
+	scopes := make([]string, len(nodes))
+	for i, node := range nodes {
+		scopes[i] = scopeOfReplica(localRegion, localAZ, placements[node])
+	}
+	return scopes
+}
+
+// activeSegmentNodes pairs each quorum endpoint with its availability zone for
+// the active-segment membership gauge.
+func activeSegmentNodes(quorumInfo *proto.QuorumInfo) []metrics.ActiveSegmentNode {
+	nodes := quorumInfo.GetNodes()
+	placements := quorumPlacements(quorumInfo)
+
+	members := make([]metrics.ActiveSegmentNode, 0, len(nodes))
+	for _, node := range nodes {
+		member := metrics.ActiveSegmentNode{Node: node}
+		if placement := placements[node]; placement != nil {
+			member.AZ = placement.Az
+		}
+		members = append(members, member)
+	}
+	return members
+}
+
+// batchReadBytes is the payload size a quorum read actually moved.
+func batchReadBytes(result *proto.BatchReadResult) int {
+	total := 0
+	for _, entry := range result.GetEntries() {
+		total += len(entry.GetValues())
+	}
+	return total
 }
 
 func orderedQuorumReadCandidates(quorumInfo *proto.QuorumInfo, lastReadState *proto.LastReadState) []quorumReadCandidate {
@@ -612,33 +682,28 @@ func orderedQuorumReadCandidates(quorumInfo *proto.QuorumInfo, lastReadState *pr
 		}
 	}
 
+	placements := quorumPlacements(quorumInfo)
+	localRegion := topology.GetCurrentRegion()
+	localAZ := topology.GetCurrentAvailabilityZone()
+
 	ordered := make([]quorumReadCandidate, 0, len(nodes))
 	for i := 0; i < len(nodes); i++ {
 		nodeIndex := (startNodeIndex + i) % len(nodes)
+		node := nodes[nodeIndex]
 		ordered = append(ordered, quorumReadCandidate{
-			node:          nodes[nodeIndex],
+			node:          node,
 			originalIndex: nodeIndex,
+			azScope:       scopeOfReplica(localRegion, localAZ, placements[node]),
 		})
 	}
 
-	localRegion := topology.GetCurrentRegion()
-	localAZ := topology.GetCurrentAvailabilityZone()
-	if localRegion == "" || localAZ == "" || len(quorumInfo.GetReplicas()) == 0 {
-		return ordered
-	}
-
-	replicasByEndpoint := make(map[string]*proto.QuorumNode, len(quorumInfo.GetReplicas()))
-	for _, replica := range quorumInfo.GetReplicas() {
-		if replica != nil && replica.Endpoint != "" {
-			replicasByEndpoint[replica.Endpoint] = replica
-		}
-	}
-
+	// Prefer a replica in this client's own zone. A replica only counts as
+	// local when both sides know their placement, so a client without
+	// REGION / AVAILABILITY_ZONE keeps the original order.
 	localCandidates := make([]quorumReadCandidate, 0, len(ordered))
 	remainingCandidates := make([]quorumReadCandidate, 0, len(ordered))
 	for _, candidate := range ordered {
-		replica := replicasByEndpoint[candidate.node]
-		if replica != nil && replica.Region == localRegion && replica.Az == localAZ {
+		if candidate.azScope == topology.ScopeLocal {
 			localCandidates = append(localCandidates, candidate)
 			continue
 		}
@@ -663,6 +728,15 @@ func (s *segmentHandleImpl) quorumReadBatch(ctx context.Context, from int64, max
 	nodeCount := len(candidates)
 	var lastError error
 
+	logIdStr := strconv.FormatInt(s.logId, 10)
+	// The scope we would have preferred: candidates are ordered local-first, so
+	// being served by a different scope means we crossed a zone boundary we
+	// did not want to cross.
+	preferredScope := topology.ScopeUnknown
+	if len(candidates) > 0 {
+		preferredScope = candidates[0].azScope
+	}
+
 	// Cycle through nodes starting from the preferred index
 	for i, candidate := range candidates {
 		node := candidate.node
@@ -674,6 +748,7 @@ func (s *segmentHandleImpl) quorumReadBatch(ctx context.Context, from int64, max
 				zap.Int64("segId", s.segmentId),
 				zap.String("node", node),
 				zap.Error(err))
+			metrics.WpClientQuorumReadTotal.WithLabelValues(s.logNs, logIdStr, candidate.azScope, "error").Inc()
 			lastError = err
 			continue
 		}
@@ -697,12 +772,25 @@ func (s *segmentHandleImpl) quorumReadBatch(ctx context.Context, from int64, max
 				// encounter EOF, stop reading immediately
 				break
 			}
+			// Count genuine failures only: a caught-up tail reader gets
+			// ErrEntryNotFound on every poll, and EOF (handled above) ends the
+			// segment — neither is traffic that failed to move.
+			if !werr.ErrEntryNotFound.Is(err) {
+				metrics.WpClientQuorumReadTotal.WithLabelValues(s.logNs, logIdStr, candidate.azScope, "error").Inc()
+			}
 			continue
 		}
 
 		// Success! Update the LastReadState with current node and return the result
 		if batchResult.LastReadState != nil {
 			batchResult.LastReadState.Node = node
+		}
+
+		metrics.WpClientQuorumReadTotal.WithLabelValues(s.logNs, logIdStr, candidate.azScope, "success").Inc()
+		metrics.WpClientQuorumReadBytesTotal.WithLabelValues(s.logNs, logIdStr, candidate.azScope).
+			Add(float64(batchReadBytes(batchResult)))
+		if candidate.azScope != preferredScope {
+			metrics.WpClientReadFailoverTotal.WithLabelValues(s.logNs, logIdStr, preferredScope, candidate.azScope).Inc()
 		}
 
 		logger.Ctx(ctx).Debug("finish read batch successfully",
@@ -962,7 +1050,6 @@ func (s *segmentHandleImpl) stopWritingUnsafe(ctx context.Context, lastFlushedEn
 		s.logNs,
 		strconv.FormatInt(s.logId, 10),
 		strconv.FormatInt(s.segmentId, 10),
-		s.quorumInfo.GetNodes(),
 	)
 
 	// fast fail all pending append operations

--- a/woodpecker/segment/segment_handle_test.go
+++ b/woodpecker/segment/segment_handle_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/zilliztech/woodpecker/common/config"
 	"github.com/zilliztech/woodpecker/common/logger"
 	"github.com/zilliztech/woodpecker/common/metrics"
+	"github.com/zilliztech/woodpecker/common/topology"
 	"github.com/zilliztech/woodpecker/common/tracer"
 	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/meta"
@@ -970,7 +971,7 @@ func TestSendAppendSuccessCallbacks(t *testing.T) {
 			callback,
 			mockClientPool,
 			segmentHandle,
-			segmentMeta.Metadata.Quorum)
+			segmentMeta.Metadata.Quorum, nil)
 		ops = append(ops, op)
 		testQueue.PushBack(op)
 	}
@@ -1053,7 +1054,7 @@ func TestSendAppendErrorCallbacks(t *testing.T) {
 			callback,
 			mockClientPool,
 			segmentHandle,
-			segmentMeta.Metadata.Quorum)
+			segmentMeta.Metadata.Quorum, nil)
 		ops = append(ops, op)
 		testQueue.PushBack(op)
 	}
@@ -1146,7 +1147,7 @@ func TestFence_WithPendingAppendOps_PartialSuccess(t *testing.T) {
 			callback,
 			mockClientPool,
 			segmentHandle,
-			segmentMeta.Metadata.Quorum)
+			segmentMeta.Metadata.Quorum, nil)
 		ops[i] = op
 		testQueue.PushBack(op)
 	}
@@ -1251,7 +1252,7 @@ func TestFence_AlreadyFencedError_WithPendingAppendOps(t *testing.T) {
 			callback,
 			mockClientPool,
 			segmentHandle,
-			segmentMeta.Metadata.Quorum)
+			segmentMeta.Metadata.Quorum, nil)
 		testQueue.PushBack(op)
 	}
 
@@ -1407,7 +1408,7 @@ func TestSegmentHandle_Rolling_AutoCompleteAndClose(t *testing.T) {
 			callback,
 			mockClientPool,
 			segmentHandle,
-			segmentMeta.Metadata.Quorum)
+			segmentMeta.Metadata.Quorum, nil)
 		testQueue.PushBack(op)
 	}
 
@@ -1516,7 +1517,7 @@ func TestSegmentHandle_Rolling_CompleteFlow(t *testing.T) {
 			callback,
 			mockClientPool,
 			segmentHandle,
-			segmentMeta.Metadata.Quorum)
+			segmentMeta.Metadata.Quorum, nil)
 		testQueue.PushBack(op)
 	}
 
@@ -1625,7 +1626,7 @@ func TestSegmentHandle_Rolling_ErrorTriggersRolling(t *testing.T) {
 			callback,
 			mockClientPool,
 			segmentHandle,
-			segmentMeta.Metadata.Quorum)
+			segmentMeta.Metadata.Quorum, nil)
 		attempt := 1
 		if i == 1 {
 			attempt = 2 // This will be >= MaxRetries (2), so it will be removed
@@ -3126,7 +3127,7 @@ func TestSegmentHandle_HandleAppendRequestFailure_RetrySubmitFailed(t *testing.T
 		"a-bucket", "files", 1, 1, 0,
 		[]byte("test_data"), callback,
 		mockClientPool, segmentHandle,
-		segmentMeta.Metadata.Quorum)
+		segmentMeta.Metadata.Quorum, nil)
 	retryableOp.channelAttempts[0] = 0 // first attempt, retryable
 	testQueue.PushBack(retryableOp)
 
@@ -4825,9 +4826,10 @@ func TestOrderedQuorumReadCandidates_MissingLocalTopologyKeepsOriginalOrder(t *t
 		},
 	}, nil)
 
+	// A client that does not know its own zone cannot classify any replica.
 	assert.Equal(t, []quorumReadCandidate{
-		{node: "node-first", originalIndex: 0},
-		{node: "node-local", originalIndex: 1},
+		{node: "node-first", originalIndex: 0, azScope: topology.ScopeUnknown},
+		{node: "node-local", originalIndex: 1, azScope: topology.ScopeUnknown},
 	}, candidates)
 }
 
@@ -5992,7 +5994,7 @@ func TestSendAppendSuccessCallbacks_EntryIdBelowLAC(t *testing.T) {
 			mu.Lock()
 			successIds = append(successIds, eid)
 			mu.Unlock()
-		}, mockClientPool, sh, segmentMeta.Metadata.Quorum)
+		}, mockClientPool, sh, segmentMeta.Metadata.Quorum, nil)
 		op.completed.Store(true)
 		testQueue.PushBack(op)
 	}
@@ -6031,7 +6033,7 @@ func TestSendAppendSuccessCallbacks_NotCompleted_Break(t *testing.T) {
 	sh := NewSegmentHandleWithAppendOpsQueue(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, testQueue)
 
 	// Add op that is NOT completed — should trigger the "not completed" break
-	op := NewAppendOp("b", "r", 1, 1, 0, []byte("data"), func(segmentId int64, eid int64, err error) {}, mockClientPool, sh, segmentMeta.Metadata.Quorum)
+	op := NewAppendOp("b", "r", 1, 1, 0, []byte("data"), func(segmentId int64, eid int64, err error) {}, mockClientPool, sh, segmentMeta.Metadata.Quorum, nil)
 	op.completed.Store(false)
 	testQueue.PushBack(op)
 
@@ -6524,7 +6526,7 @@ func TestHandleAppendRequestFailure_OpAlreadyRemovedFromQueue(t *testing.T) {
 		callbackCount++
 	}
 	appendOp := NewAppendOp("bucket", "root", 1, 1, 0, []byte("data"), callback,
-		mockClientPool, sh, segmentMeta.Metadata.Quorum)
+		mockClientPool, sh, segmentMeta.Metadata.Quorum, nil)
 
 	// Mark the op as completed (2 ack quorum nodes succeeded)
 	appendOp.completed.Store(true)


### PR DESCRIPTION
Fixes #269

## What

Client metrics were all aggregated by log, so nothing could say *which replica* served a request or *how far the traffic travelled*. This adds an `az_scope` dimension — where the peer sits relative to the client — to the write and read paths, and surfaces it on both client dashboards.

The placement data was already available: `proto.QuorumNode` carries each replica's region/AZ, and `orderedQuorumReadCandidates` already uses it to prefer a local replica. This PR records what that machinery was already deciding.

## New metrics

| Metric | Labels |
|---|---|
| `woodpecker_client_replica_append_total` | log_ns, log_id, az_scope, status |
| `woodpecker_client_replica_append_bytes_total` | log_ns, log_id, az_scope |
| `woodpecker_client_quorum_read_total` | log_ns, log_id, az_scope, status |
| `woodpecker_client_quorum_read_bytes_total` | log_ns, log_id, az_scope |
| `woodpecker_client_read_failover_total` | log_ns, log_id, from_scope, to_scope |

`az_scope` ∈ `local` / `cross_az` / `cross_region` / `unknown`. The replica endpoint is deliberately **not** a label — it would multiply by `log_id`, while `az_scope` stays at four values and answers the question that costs money.

`woodpecker_client_active_segment_node` gains an `az` label, so the AZ spread of the current write quorum is visible from the membership gauge. Its clear path now matches on the segment rather than the exact label set, so a quorum whose placement changed since it was published is still removed in full (covered by a new test).

## Instrumentation points

- **Write** — every point where a replica resolves: the single-append ack callback, the group-commit drain (`applyNodeAck`), and the send-failure path (`failNode`, client-unavailable). `FastFail`-completed ops are skipped, so a fast-failed entry is not double counted.
- **Read** — the candidate loop in `quorumReadBatch`. `ErrEntryNotFound` and end-of-file are **not** counted: a caught-up tail reader hits `ErrEntryNotFound` on every poll, so counting it would swamp the error rate and add per-poll counter churn for traffic that never moved. Logging behaviour is unchanged.
- **Scope resolution** — a segment's quorum is fixed, so scopes are resolved once per segment handle and passed to each `AppendOp`, rather than rebuilding an endpoint map per append.

`topology.Scope` returns `unknown` unless *both* sides know their placement, which keeps the existing read-preference semantics exactly: a client without `REGION` / `AVAILABILITY_ZONE` sees no local replica and keeps the original candidate order.

## Dashboards

A `Cross-AZ / Replica Traffic` row on both client dashboards (k8s + docker): replica write bytes by scope, replica write rate by scope/status, quorum read bytes by scope, cross-zone traffic ratio (read and write), read failover rate, and active segment replicas by AZ. `dashboard-configmaps.yaml` regenerated via the sync test added in #268.

## Verification

- `go test ./woodpecker/segment/ ./common/metrics/ ./common/topology/ ./tests/k8s/monitor/` — all pass (segment suite 159s).
- New tests: `topology.Scope` truth table; `quorumNodeScopes` / `activeSegmentNodes` incl. a replica missing from the quorum's replica list; candidates carrying their scope; a read that fails over from local to a remote replica asserting the exact counter values (error on local, success + bytes on cross_region, one failover local→cross_region); and a local read asserting **no** failover is recorded.
- `golangci-lint run --config .golangci.yml` on the touched packages — 0 issues; `gofmt` clean.
- All 14 new dashboard expressions executed against a live Prometheus with variables substituted — 0 parse/eval errors.

## Notes / not done

- **No live multi-AZ validation.** Verification is unit-level. The prerequisite from #269 — faking a per-pod `AVAILABILITY_ZONE` in the k8s monitor suite so the `cross_*` branches are exercised end to end — is **not** in this PR: a StatefulSet shares one pod template, so per-pod placement needs an init container or downward-API wiring, which is its own change.
- Whatever embeds the client still has to inject `REGION` / `AVAILABILITY_ZONE`; without them every sample is `unknown` — and note the read path's local-replica preference is already inert in that case today. This is documented alongside the new metrics table in `tests/docker/monitor/README.md`.
