### PR TITLE
test(disk): stop the flush-error tests from racing the writer's own goroutine

### DIFF
--- a/server/storage/disk/writer_impl_test.go
+++ b/server/storage/disk/writer_impl_test.go
@@ -1205,67 +1205,46 @@ func TestLocalFileWriter_ProcessFlushTask_BlockHeaderWriteError(t *testing.T) {
 	assert.False(t, writer.storageWritable.Load())
 }
 
-func TestLocalFileWriter_ProcessFlushTask_WriteError_ReadOnlyFd(t *testing.T) {
+// A write that fails while a flush task is being processed must mark the segment
+// unwritable.
+//
+// The failure is arranged by closing the descriptor the writer already holds,
+// never by assigning to writer.file. That field is owned by the writer's flush
+// goroutine (run -> processFlushTask -> writeRecord reads it on every record),
+// so writing it from the test goroutine is a data race — the one this test used
+// to lose about one run in three under -race. Calling Close on the *os.File is
+// safe by contrast: os.File synchronises Close against a concurrent Write, which
+// then fails with os.ErrClosed, which is exactly the condition under test.
+//
+// This replaces a pair of tests (_ReadOnlyFd and _ClosedFd) that swapped the
+// descriptor for a read-only and a closed one respectively. They asserted the
+// same thing and reached the same error branch — writeRecord's w.file.Write
+// returning an error — so a read-only descriptor bought no extra coverage, and
+// installing one cannot be done without the racy assignment. Issue #274.
+func TestLocalFileWriter_ProcessFlushTask_WriteError(t *testing.T) {
 	dir := getTempDir(t)
 	cfg, _ := config.NewConfiguration()
 	writer, err := NewLocalFileWriter(context.Background(), dir, 1, 0, cfg)
 	require.NoError(t, err)
 	defer writer.Close(context.Background())
 
-	// Write and flush first entry to write header
+	// Write and flush the first entry so the header is written normally.
 	_, err = writer.WriteDataAsync(context.Background(), 0, []byte("first"), nil)
 	require.NoError(t, err)
 	writer.Sync(context.Background())
-	time.Sleep(300 * time.Millisecond)
+	require.Eventually(t, func() bool {
+		return writer.headerWritten.Load()
+	}, 10*time.Second, 10*time.Millisecond, "header was never flushed")
 
-	// Now write more data
+	// Queue more data, then break the descriptor under it.
 	_, err = writer.WriteDataAsync(context.Background(), 1, []byte("second data block"), nil)
 	require.NoError(t, err)
-
-	// Replace the fd with a read-only one so the block header write fails
-	filePath := getSegmentFilePath(dir, 1, 0)
-	writer.file.Close()
-	// Reopen as read-only to cause write failure
-	f, err := os.OpenFile(filePath, os.O_RDONLY, 0o644)
-	require.NoError(t, err)
-	writer.file = f
+	require.NoError(t, writer.file.Close())
 
 	writer.Sync(context.Background())
-	time.Sleep(300 * time.Millisecond)
-
-	assert.False(t, writer.storageWritable.Load())
-}
-
-func TestLocalFileWriter_ProcessFlushTask_WriteError_ClosedFd(t *testing.T) {
-	dir := getTempDir(t)
-	cfg, _ := config.NewConfiguration()
-	writer, err := NewLocalFileWriter(context.Background(), dir, 1, 0, cfg)
-	require.NoError(t, err)
-
-	// Write and flush first entry to write header normally
-	_, err = writer.WriteDataAsync(context.Background(), 0, []byte("data"), nil)
-	require.NoError(t, err)
-	writer.Sync(context.Background())
-	time.Sleep(300 * time.Millisecond)
-
-	// Write second entry
-	_, err = writer.WriteDataAsync(context.Background(), 1, []byte("more data"), nil)
-	require.NoError(t, err)
-
-	// Replace the fd with a closed one so writes fail
-	filePath := getSegmentFilePath(dir, 1, 0)
-	writer.file.Close()
-	closedFd, err := os.OpenFile(filePath, os.O_WRONLY|os.O_APPEND, 0o644)
-	require.NoError(t, err)
-	writer.file = closedFd
-	// Close it right away so file.Write() fails on the closed fd
-	closedFd.Close()
-
-	writer.Sync(context.Background())
-	time.Sleep(300 * time.Millisecond)
-
-	assert.False(t, writer.storageWritable.Load())
-	writer.Close(context.Background())
+	assert.Eventually(t, func() bool {
+		return !writer.storageWritable.Load()
+	}, 10*time.Second, 10*time.Millisecond, "a failed flush write must mark the segment unwritable")
 }
 
 // === rollBufferAndSubmitFlushTaskUnsafe context cancellation paths ===


### PR DESCRIPTION
Fixes #274.

## The race

`TestLocalFileWriter_ProcessFlushTask_WriteError_ReadOnlyFd` and `..._ClosedFd` forced a write failure by assigning `writer.file`:

```go
writer.file.Close()
f, err := os.OpenFile(filePath, os.O_RDONLY, 0o644)
require.NoError(t, err)
writer.file = f              // no lock held
```

That field is owned by the writer's flush goroutine — `run` → `processFlushTask` → `writeRecord` reads it on every record — so the assignment races it. Under `-race` the package failed roughly one run in three.

```
Write at 0x... by goroutine N:
  disk.TestLocalFileWriter_ProcessFlushTask_WriteError_ReadOnlyFd()   writer_impl_test.go:1231
Previous read at 0x... by goroutine N+1:
  disk.(*LocalFileWriter).writeRecord()                               writer_impl.go:851
  disk.(*LocalFileWriter).processFlushTask()                          writer_impl.go:545
  disk.(*LocalFileWriter).run()                                       writer_impl.go:321
```

The `Sync` + `time.Sleep(300ms)` before the swap was meant to leave the flush goroutine idle, but a sleep orders nothing — the run loop's ticker re-enters `Sync` on its own schedule, so the two overlap whenever the machine is loaded or the flush is slower than the guess.

The intent of both tests is good: make a write fail, assert `storageWritable` flips to false. Only the mechanism was wrong.

## The fix

Close the descriptor the writer already holds, instead of swapping in another one:

```go
require.NoError(t, writer.file.Close())
```

Reading `writer.file` concurrently is fine — only the assignment was a write. `os.File` synchronises `Close` against a concurrent `Write`, which then fails with `os.ErrClosed`: exactly the condition under test, reached without touching the writer's state.

Worth noting the `_ClosedFd` variant already called `writer.file.Close()` as its first step. Reopening and reassigning after that was redundant as well as racy.

**No production code changes.** The writer is not at fault here — `w.file` is set at construction and used only by its own goroutine.

## Why the two tests become one

They asserted the same thing (`assert.False(t, writer.storageWritable.Load())`) and reached the same branch — `writeRecord`'s `w.file.Write` returning an error. A read-only descriptor bought no coverage that a closed one does not, and installing one cannot be done without the racy assignment. Keeping two names that test one path would only imply coverage that isn't there.

## Sleeps become conditions

`time.Sleep(300ms)` is replaced by `require.Eventually` / `assert.Eventually` on `headerWritten` and `storageWritable`. Stricter and faster — and a slow machine no longer fails a 300ms guess, which was a second, quieter source of flakiness in the same tests.

## Verification

| | Races | Result |
|---|---|---|
| `master`, old tests, `-race -count=20` | **8** | 2 tests failing |
| this branch, `-race -count=20` | **0** | pass, ~3s (was ~24s) |

Full package `go test ./server/storage/disk/ -race` run 3× — clean each time. `golangci-lint` reports 0 issues.

The replacement still fails if the induced failure is removed (commenting out the `Close` gives `a failed flush write must mark the segment unwritable`), so it is testing what it claims to.

## Not in scope

`reader_impl_test.go:723` assigns `reader.file` in the same style, but `LocalFileReader` has no background goroutine, so those are sequential operations in one goroutine and not a race. Left alone.
