### PR TITLE
fix(meta): stop reader temp info sessions from outliving provider shutdown

### DIFF
--- a/meta/metadata_etcd.go
+++ b/meta/metadata_etcd.go
@@ -113,6 +113,12 @@ type metadataProviderEtcd struct {
 	// CreateReaderTempInfo handed it to; this is only a registry so provider
 	// Close() can stop every keepalive that would otherwise outlive it.
 	readerTempSessions sync.Map // map[*readerTempSession]struct{}
+
+	// closed is set by Close() under the provider mutex. It is what makes
+	// Close() and CreateReaderTempInfo mutually exclusive: the registry alone
+	// cannot express "this session was created too late to be retired", so
+	// every registration is gated on this flag under the same lock.
+	closed bool
 }
 
 func NewMetadataProvider(ctx context.Context, client *clientv3.Client, cfg *config.Configuration) MetadataProvider {
@@ -1225,10 +1231,33 @@ func (e *metadataProviderEtcd) retireReaderTempSession(ctx context.Context, entr
 	e.readerTempSessions.Delete(entry)
 }
 
+// CreateReaderTempInfo registers one open reader and returns the session that
+// keeps its temp info alive.
+//
+// readerName must be unique among live readers of the same log. Sessions are
+// tracked per session object, not per name, so reopening a name that is still
+// open does NOT swap out the old session: both would keep their own lease
+// alive, and DeleteReaderTempInfo deletes by name, so closing either one would
+// remove the surviving reader's key. Callers satisfy this by making the name
+// unique per open (see OpenLogReader, which appends a nanosecond timestamp).
 func (e *metadataProviderEtcd) CreateReaderTempInfo(ctx context.Context, readerName string, logId int64, fromSegmentId int64, fromEntryId int64) (ReaderTempInfoSession, error) {
 	ctx, sp := otel.Tracer(CurrentScopeName).Start(ctx, "CreateReaderTempInfo")
 	defer sp.End()
 	startTime := time.Now()
+
+	// Fast path: don't grant a lease and write a key we would only have to
+	// revoke again. The authoritative check is at registration time below.
+	e.Lock()
+	alreadyClosed := e.closed
+	e.Unlock()
+	if alreadyClosed {
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		logger.Ctx(ctx).Warn("create reader temp info on a closed metadata provider",
+			zap.String("readerName", readerName), zap.Int64("logId", logId))
+		return nil, werr.ErrMetadataWrite.WithCauseErrMsg("metadata provider is closed")
+	}
+
 	// Create a key path for the reader temporary information
 	readerKey := e.keyBuilder.BuildLogReaderTempInfoKey(logId, readerName)
 
@@ -1287,7 +1316,27 @@ func (e *metadataProviderEtcd) CreateReaderTempInfo(ctx context.Context, readerN
 		openSegmentId: fromSegmentId,
 		openEntryId:   fromEntryId,
 	}
+
+	// Register under the provider mutex, gated on the same closed flag Close()
+	// sets there. Either this Store lands before Close() drains the registry
+	// and Close() retires the session, or Close() got there first and this
+	// create must undo itself - there is no third outcome where a live
+	// keepalive ends up tracked by nothing.
+	e.Lock()
+	if e.closed {
+		e.Unlock()
+		if closeErr := e.closeReaderTempSession(session); closeErr != nil {
+			logger.Ctx(ctx).Warn("close reader temp info session for a closed provider failed",
+				zap.String("readerName", readerName), zap.Int64("logId", logId), zap.Error(closeErr))
+		}
+		metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "create_reader_temp_info", "error").Inc()
+		metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "create_reader_temp_info", "error").Observe(float64(time.Since(startTime).Milliseconds()))
+		logger.Ctx(ctx).Warn("create reader temp info on a closed metadata provider",
+			zap.String("readerName", readerName), zap.Int64("logId", logId))
+		return nil, werr.ErrMetadataWrite.WithCauseErrMsg("metadata provider is closed")
+	}
 	e.readerTempSessions.Store(readerSession, struct{}{})
+	e.Unlock()
 
 	logger.Ctx(ctx).Debug("Created reader temporary information with session lease",
 		zap.String("readerName", readerName),
@@ -1579,57 +1628,108 @@ func (e *metadataProviderEtcd) CheckSessionLockAlive(ctx context.Context, sessio
 	return ttlResp.TTL > 0, nil
 }
 
+// Close shuts the provider down in three stages, deliberately ordered.
+//
+// First, under e.Lock(), it marks the provider closed and drains both session
+// registries. Marking closed is what stops CreateReaderTempInfo from
+// registering a session this scan would miss: a session registered after the
+// drain is tracked by nothing, and its keepalive runs on the etcd client's own
+// context (which this method does not cancel), so it would renew until the
+// process exits and pin the truncated-segment cleanup low-watermark forever.
+//
+// Second, outside the lock, it stops every keepalive. This is the only stage
+// with a correctness dependency: once nothing renews, every lease expires
+// within one TTL even if every revocation below fails.
+//
+// Third, it revokes concurrently under a single shared deadline. Revocation
+// only makes the keys disappear sooner than the TTL, so it must never be
+// allowed to hold shutdown hostage - serial revocations against a partitioned
+// etcd cost one request timeout each, which on a SIGTERM path exceeds any
+// container termination grace period well before the sessions run out.
 func (e *metadataProviderEtcd) Close() error {
 	startTime := time.Now()
-	e.Lock()
-	defer e.Unlock()
 
-	// Close all individual writer locks and their sessions
+	e.Lock()
+	if e.closed {
+		e.Unlock()
+		return nil
+	}
+	e.closed = true
+
+	writerLocks := make(map[string]*SessionLock)
 	e.logWriterLocks.Range(func(key, value interface{}) bool {
 		logName := key.(string)
-		sessionLock := value.(*SessionLock)
-
-		if sessionLock == nil {
-			return true
+		if sessionLock, ok := value.(*SessionLock); ok && sessionLock != nil {
+			writerLocks[logName] = sessionLock
 		}
+		e.logWriterLocks.Delete(key)
+		return true
+	})
 
-		// Mark as invalid first
+	readerSessions := make([]*readerTempSession, 0)
+	e.readerTempSessions.Range(func(key, value interface{}) bool {
+		readerSessions = append(readerSessions, key.(*readerTempSession))
+		e.readerTempSessions.Delete(key)
+		return true
+	})
+	e.Unlock()
+
+	// Stage two: stop every keepalive. Non-blocking, and enough on its own.
+	for _, entry := range readerSessions {
+		entry.Lock()
+		if !entry.closed {
+			entry.closed = true
+			entry.session.Orphan()
+		}
+		entry.Unlock()
+	}
+	for logName, sessionLock := range writerLocks {
 		sessionLock.MarkInvalid()
-
-		// First unlock the mutex
-		if sessionLock.mutex != nil {
-			err := sessionLock.mutex.Unlock(context.Background())
-			if err != nil {
-				logger.Ctx(context.Background()).Warn("Failed to unlock writer lock during close",
-					zap.String("logName", logName),
-					zap.Error(err))
-			}
-		}
-
-		// Close the associated session
 		leaseId := int64(-1)
 		if sessionLock.session != nil {
 			leaseId = int64(sessionLock.session.Lease())
-			closeErr := sessionLock.session.Close()
-			if closeErr != nil {
-				logger.Ctx(context.Background()).Warn("Failed to close lock session during close",
-					zap.String("logName", logName),
-					zap.Error(closeErr))
-			}
+			// Orphan rather than Session.Close(): Close() revokes under a
+			// deadline of one full session TTL on the etcd client's own context.
+			sessionLock.session.Orphan()
 		}
-		logger.Ctx(context.Background()).Warn("Closed writer lock for log", zap.String("logName", logName), zap.Int64("leaseID", leaseId))
-		// Remove from map
-		e.logWriterLocks.Delete(logName)
-		return true
-	})
+		logger.Ctx(context.Background()).Info("Closed writer lock for log", zap.String("logName", logName), zap.Int64("leaseID", leaseId))
+	}
 
-	// Retire every reader temp info session still open so no keepalive — and no
-	// reader-held cleanup low-watermark — outlives the provider. A reader that
-	// closes afterwards finds its session already retired and just deletes its key.
-	e.readerTempSessions.Range(func(key, value interface{}) bool {
-		e.retireReaderTempSession(context.Background(), key.(*readerTempSession))
-		return true
-	})
+	// Stage three: best-effort cleanup, all of it inside one request timeout.
+	ctx, cancel := e.getContextWithTimeout(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	for _, entry := range readerSessions {
+		wg.Add(1)
+		go func(entry *readerTempSession) {
+			defer wg.Done()
+			if _, err := e.client.Revoke(ctx, entry.session.Lease()); err != nil && rpctypes.Error(err) != rpctypes.ErrLeaseNotFound {
+				logger.Ctx(ctx).Warn("revoke reader temp info lease during close failed",
+					zap.String("readerName", entry.readerName),
+					zap.Int64("logId", entry.logId),
+					zap.Error(err))
+			}
+		}(entry)
+	}
+	for logName, sessionLock := range writerLocks {
+		wg.Add(1)
+		go func(logName string, sessionLock *SessionLock) {
+			defer wg.Done()
+			if sessionLock.mutex != nil {
+				if err := sessionLock.mutex.Unlock(ctx); err != nil {
+					logger.Ctx(ctx).Warn("Failed to unlock writer lock during close",
+						zap.String("logName", logName), zap.Error(err))
+				}
+			}
+			if sessionLock.session != nil {
+				if _, err := e.client.Revoke(ctx, sessionLock.session.Lease()); err != nil && rpctypes.Error(err) != rpctypes.ErrLeaseNotFound {
+					logger.Ctx(ctx).Warn("Failed to revoke lock session lease during close",
+						zap.String("logName", logName), zap.Error(err))
+				}
+			}
+		}(logName, sessionLock)
+	}
+	wg.Wait()
 
 	metrics.WpEtcdMetaOperationsTotal.WithLabelValues(e.logNs, "close", "success").Inc()
 	metrics.WpEtcdMetaOperationLatency.WithLabelValues(e.logNs, "close", "success").Observe(float64(time.Since(startTime).Milliseconds()))

--- a/meta/metadata_etcd_reader_session_test.go
+++ b/meta/metadata_etcd_reader_session_test.go
@@ -18,6 +18,7 @@ package meta
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -81,12 +82,14 @@ func setupReaderSessionTest(t *testing.T, logName string, readerName string, fro
 // An open reader that reads nothing (idle or slow consumer) must keep its temp
 // info alive well past the lease TTL. This is exactly the reader the cleanup
 // protection exists for.
+// This is the only case covering the original defect, so it must run in the
+// unit-test target: that target passes -short and excludes ./tests/..., so a
+// short-mode skip here would leave the bug uncovered by every CI target. The
+// TTL is kept small enough that waiting out two of them fits a unit-test
+// budget rather than being skipped.
 func testReaderTempInfoOutlivesLeaseTTLWhileIdle(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping multi-TTL idle wait in short mode")
-	}
 	restoreTTL := readerTempInfoSessionTTLSeconds
-	readerTempInfoSessionTTLSeconds = 5
+	readerTempInfoSessionTTLSeconds = 2
 	defer func() { readerTempInfoSessionTTLSeconds = restoreTTL }()
 
 	env := setupReaderSessionTest(t, "reader_session_idle_test_"+time.Now().Format("20060102150405"), "idle-reader", 1, 10)
@@ -210,6 +213,59 @@ func testUpdateAfterProviderCloseDoesNotResurrectReaderTempInfo(t *testing.T) {
 
 	// A reader closing after the provider did is a no-op, not an error
 	require.NoError(t, env.provider.DeleteReaderTempInfo(context.Background(), env.session))
+}
+
+// A closed provider must refuse to hand out new reader temp info sessions.
+// Close() retires the sessions in its registry, but a session created after
+// that scan is registered too late to be seen by anything: its keepalive runs
+// on the etcd client's own context - which Close() does not cancel - so it
+// renews the lease until the process exits. The orphaned reader key then pins
+// the truncated-segment cleanup low-watermark forever, because the writer's
+// cleanup applies no staleness filter to reader temp info.
+func testCreateReaderTempInfoAfterProviderCloseIsRejected(t *testing.T) {
+	env := setupReaderSessionTest(t, "reader_session_createafterclose_test_"+time.Now().Format("20060102150405"), "pre-close-reader", 1, 10)
+
+	require.NoError(t, env.provider.Close())
+	assert.False(t, env.session.IsActive(), "provider close must retire the sessions it can see")
+
+	session, err := env.provider.CreateReaderTempInfo(context.Background(), "post-close-reader", env.logId, 2, 20)
+	require.Error(t, err, "a closed provider must refuse to create reader temp info")
+	assert.Nil(t, session, "a refused create must not hand out a session")
+
+	// A refused create must leave nothing behind holding a live lease
+	postCloseKey := legacyKeyBuilder().BuildLogReaderTempInfoKey(env.logId, "post-close-reader")
+	resp, err := env.etcdCli.Get(context.Background(), postCloseKey)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(resp.Kvs), "a refused create must not leave a reader temp info key behind")
+}
+
+// Provider Close() must be idempotent and must retire every registered session,
+// so a second close (or a close racing a reader's own close) cannot revoke the
+// same lease twice or block a second time.
+func testProviderCloseIsIdempotentAcrossReaderSessions(t *testing.T) {
+	env := setupReaderSessionTest(t, "reader_session_closeidem_test_"+time.Now().Format("20060102150405"), "idem-reader-0", 1, 10)
+
+	extra := make([]ReaderTempInfoSession, 0, 3)
+	for i := 1; i <= 3; i++ {
+		name := "idem-reader-" + strconv.Itoa(i)
+		s, err := env.provider.CreateReaderTempInfo(context.Background(), name, env.logId, int64(i), int64(i*10))
+		require.NoError(t, err)
+		extra = append(extra, s)
+	}
+
+	require.NoError(t, env.provider.Close())
+	require.NoError(t, env.provider.Close(), "a second provider close must be a no-op")
+
+	assert.False(t, env.session.IsActive())
+	for i, s := range extra {
+		assert.Falsef(t, s.IsActive(), "session %d must be retired by provider close", i+1)
+	}
+
+	// Every reader key is gone, and a reader closing afterwards is a no-op
+	resp, err := env.etcdCli.Get(context.Background(), legacyKeyBuilder().BuildLogAllReaderTempInfosKey(env.logId), clientv3.WithPrefix())
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(resp.Kvs), "provider close must leave no reader temp info behind")
+	require.NoError(t, env.provider.DeleteReaderTempInfo(context.Background(), extra[0]))
 }
 
 // A session this provider never handed out carries no ownership proof and must

--- a/meta/metadata_etcd_test.go
+++ b/meta/metadata_etcd_test.go
@@ -107,6 +107,8 @@ func TestAll(t *testing.T) {
 	t.Run("test update after delete does not resurrect reader temp info", testUpdateAfterDeleteDoesNotResurrectReaderTempInfo)
 	t.Run("test update put failure does not revoke reader temp info lease", testUpdatePutFailureDoesNotRevokeReaderTempInfoLease)
 	t.Run("test update after provider close does not resurrect reader temp info", testUpdateAfterProviderCloseDoesNotResurrectReaderTempInfo)
+	t.Run("test create reader temp info after provider close is rejected", testCreateReaderTempInfoAfterProviderCloseIsRejected)
+	t.Run("test provider close is idempotent across reader sessions", testProviderCloseIsIdempotentAcrossReaderSessions)
 	t.Run("test reader temp info rejects foreign session", testReaderTempInfoRejectsForeignSession)
 	t.Run("test create reader temp info honors caller deadline when etcd unreachable", testCreateReaderTempInfoHonorsCallerDeadlineWhenEtcdUnreachable)
 	t.Run("test create segment cleanup status", testCreateSegmentCleanupStatus)

--- a/woodpecker/log/log_reader.go
+++ b/woodpecker/log/log_reader.go
@@ -37,10 +37,18 @@ const (
 	ReaderScopeName = "LogReader"
 	// UpdateReaderInfoIntervalMs bounds how often a reader re-reports an unchanged
 	// read position. It also bounds how long a temp info key lost to a lease
-	// expiry stays missing, since the periodic report is what re-creates it, so it
-	// is kept well below the session TTL. Idle readers write at this rate, so the
-	// steady-state metadata write load is (reader count / interval).
-	UpdateReaderInfoIntervalMs = 5000
+	// expiry stays missing, since the periodic report is what re-creates it.
+	//
+	// It must stay well above the etcd request timeout. The report is issued
+	// synchronously on the ReadNext path, so when etcd is degraded enough that
+	// each write burns its full timeout, an interval shorter than that timeout
+	// is already elapsed again by the time the next poll comes round: every
+	// batch boundary would then stall for a full timeout instead of one stall
+	// per interval. Shortening the post-lease-loss recovery window is not worth
+	// that trade - opening the window at all takes a full session TTL of
+	// continuous etcd unavailability, i.e. exactly the conditions under which
+	// the tighter interval does the most damage.
+	UpdateReaderInfoIntervalMs = 30000
 	NoDataReadWaitIntervalMs   = 200
 	DefaultBatchEntriesLimit   = 200
 )

--- a/woodpecker/log/log_reader_test.go
+++ b/woodpecker/log/log_reader_test.go
@@ -1336,6 +1336,22 @@ func TestLogReader_ReadNext_IdleReaderThrottlesPositionReports(t *testing.T) {
 		"an idle reader must report its unchanged position at most once per UpdateReaderInfoIntervalMs, not once per poll")
 }
 
+// The position report at ReadNext is synchronous and bounded by the etcd
+// request timeout. If the reporting interval were shorter than that timeout, a
+// degraded etcd would make every report burn its full budget and still leave
+// the interval elapsed by the next poll, so a caught-up reader would stall for
+// a full timeout at every batch boundary instead of once per interval. Guard
+// the ordering between the two so the interval cannot be tightened past it.
+func TestUpdateReaderInfoIntervalOutlastsEtcdRequestTimeout(t *testing.T) {
+	cfg, err := config.NewConfiguration("../../config/woodpecker.yaml")
+	require.NoError(t, err)
+
+	requestTimeoutMs := cfg.Etcd.RequestTimeout.Milliseconds()
+	require.Positive(t, requestTimeoutMs, "etcd request timeout must be configured")
+	assert.Greater(t, int(UpdateReaderInfoIntervalMs), requestTimeoutMs,
+		"reader reporting interval must outlast one etcd request timeout, else a degraded etcd stalls every poll")
+}
+
 func TestLogReader_ReadNext_OtherReadError(t *testing.T) {
 	mockLogHandle := &testLogHandleMock{}
 	mockLogHandle.Test(t)


### PR DESCRIPTION
Follow-up to #266. The [adversarial review](https://github.com/zilliztech/woodpecker/pull/266#issuecomment-5422611865) landed nine minutes after that PR merged, so its five findings are fixed here. All five were verified against the merged code first — none were false positives. My [reply on #266](https://github.com/zilliztech/woodpecker/pull/266#issuecomment-5422905407) records the verification.

## Provider shutdown races session creation (High)

`CreateReaderTempInfo` took no provider lock and registered its session in `readerTempSessions` only after the Put. `Close()` took `e.Lock()` but transitioned no state — there was no `closed` field on `metadataProviderEtcd` at all. So nothing made the two mutually exclusive, and nothing stopped a create that began *after* `Close()` had already drained the registry.

Either way the session ends up tracked by nothing. `Close()` does not close the etcd client, and `newReaderTempSession` deliberately builds the session without `concurrency.WithContext`, so the keepalive runs on `e.client.Ctx()` and renews the lease until the process exits. The orphaned reader key then pins `minTruncatedSegmentId` in `log_writer.go:525-529`, which applies no staleness filter — `RecentReadTimestamp` is written but never read by any production caller — so truncated segments are never physically cleaned and object storage for that log grows without bound.

Registration is now gated on a provider-closed flag set under the same mutex `Close()` takes. A create that loses the race revokes its own session and fails; one that wins is in the registry before the drain. There is no third outcome where a live keepalive ends up untracked.

## Serial blocking revocation on shutdown (Medium)

`Close()` held `e.Lock()` across its whole body and revoked one session at a time, each under its own full `requestTimeout` (10000ms, `config/woodpecker.yaml:220`). A SIGTERM against a partitioned etcd therefore cost one timeout per open session — 60 readers is ~10 minutes — and blew past any container termination grace period.

`Close()` is now three stages:

1. Under the lock: mark closed, drain both registries. No network I/O.
2. Outside the lock: stop every keepalive. This is the only stage with a correctness dependency — once nothing renews, every lease expires within one TTL regardless of what follows.
3. Revoke concurrently under a single shared request timeout. Revocation only makes keys disappear sooner than the TTL, so it must never hold shutdown hostage.

Writer locks move onto the same path. They used `concurrency.Session.Close()`, which revokes under a deadline of one full session TTL — the exact API `closeReaderTempSession` was written to avoid, with a comment saying why. Same stall, longer per-item budget. Pre-existing, not from #266, but it is the same shutdown path.

## `UpdateReaderInfoIntervalMs` 5000 → 30000 (Medium)

A regression I introduced in 54d58cb. At 5000 the interval sat below the etcd request timeout, and the report is synchronous on the `ReadNext` path. When a write burned its full 10s timeout, the interval had already elapsed again by the next 200ms poll (`l.lastReported = now` is assigned before the blocking Put, so `now` is loop-entry time), and every batch boundary stalled for a full timeout instead of one stall per interval.

The tighter interval only shortened the key-absence window after a lease loss — which itself requires a full session TTL of continuous etcd unavailability, i.e. exactly the conditions under which it does the most damage. Reverted, with the lower bound now documented and pinned by a test.

## Reader name uniqueness was undocumented (Low)

The #266 description claimed a same-name reopen swaps in a fresh session. `c2874da` did key the registry by `(logId, readerName)` and `Swap` on reopen; `7bb283c` re-keyed it by `*readerTempSession` pointer and dropped that logic, and the description was not updated. Not reachable today — `OpenLogReader` appends `time.Now().UnixNano()` to every reader name — but `DeleteReaderTempInfo` deletes by name, so a same-name reopen would leave two independently keepalived sessions and closing either would remove the survivor's key. The invariant is now stated on `CreateReaderTempInfo` rather than left implicit.

## Regression test for #265 ran in no CI target (Low)

`testReaderTempInfoOutlivesLeaseTTLWhileIdle` is the only case covering the original defect, but it skipped under `-short`. `unit-test` (`Makefile:125`) passes `-short` and includes `./meta/`; `integration-test` (`Makefile:130`) runs only `./tests/integration/...`, which excludes `./meta/`. So it executed nowhere, and a regression of the exact bug #266 fixed would have gone green. Skip removed, TTL reduced to 2s so the wait fits a unit-test budget.

## Testing

- `go build ./...`, `go vet ./meta/ ./woodpecker/log/` — clean
- `golangci-lint run ./meta/... ./woodpecker/log/...` — 0 issues
- `go test -race -short ./meta/ ./woodpecker/log/ ./common/metrics/` — all pass
- `testCreateReaderTempInfoAfterProviderCloseIsRejected` verified failing on the parent commit first (`An error is expected but got nil`)
- `testReaderTempInfoOutlivesLeaseTTLWhileIdle` confirmed executing under `-race -short` (6.62s), not skipped

`TestNewEmbedClientFromConfig_MinioObjectStorageError` fails in `./woodpecker/`, but it fails identically on a clean worktree at `7d1b3b0` (506.66s vs 535.18s) — it dials Azure blob storage with an empty account name and retries to exhaustion. Pre-existing and unrelated; `./common/objectstorage/` has a sibling failure with the same cause.

## Not covered by a test

The shutdown stall duration itself. Reproducing it needs live `concurrency.Session`s — which require a reachable etcd — together with revocations that hang, which require an unreachable one. Closing the client instead makes `Revoke` fail fast rather than time out, so it exercises neither the old nor the new path. The bound is structural instead: stage 1 does no I/O, stage 2 is non-blocking and alone sufficient for correctness, and stage 3 shares one `getContextWithTimeout` across all revocations, so total shutdown cost is one request timeout regardless of session count.
