### PR TITLE
fix(reader): fail ReadNext once the reader's session is retired

### DIFF
--- a/woodpecker/log/log_reader.go
+++ b/woodpecker/log/log_reader.go
@@ -142,6 +142,17 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 			// Continue with read operation
 		}
 
+		// A retired session means this reader is permanently dead: either it was
+		// closed, or the metadata provider was. Nothing revives it, so reading on
+		// would serve entries for a reader that no longer exists in metadata -
+		// and whose segments the writer's cleanup therefore no longer protects.
+		// Checked ahead of the cached batch so a closed reader cannot drain what
+		// it already fetched either.
+		if !l.readerTempSession.IsActive() {
+			metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "error").Observe(float64(time.Since(start).Milliseconds()))
+			return nil, werr.ErrLogReaderClosed
+		}
+
 		// get if cache fragment exists
 		if l.batch != nil && l.next < len(l.batch.Entries) {
 			readEntryData := l.batch.Entries[l.next]

--- a/woodpecker/log/log_reader_test.go
+++ b/woodpecker/log/log_reader_test.go
@@ -182,16 +182,18 @@ func newTestConfig() *config.Configuration {
 
 func TestLogReader_GetName(t *testing.T) {
 	reader := &logBatchReaderImpl{
-		readerName: "my-reader",
+		readerTempSession: &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
+		readerName:        "my-reader",
 	}
 	assert.Equal(t, "my-reader", reader.GetName())
 }
 
 func TestLogReader_ReadNext_NilLogHandle(t *testing.T) {
 	reader := &logBatchReaderImpl{
-		logHandle: nil,
-		logIdStr:  "1",
-		logNs:     "",
+		readerTempSession: &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
+		logHandle:         nil,
+		logIdStr:          "1",
+		logNs:             "",
 	}
 
 	ctx := context.Background()
@@ -206,6 +208,7 @@ func TestLogReader_ReadNext_ContextCancelled(t *testing.T) {
 	mockLogHandle.Test(t)
 
 	reader := &logBatchReaderImpl{
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 		logName:              "test-log",
 		logId:                1,
 		logIdStr:             "1",
@@ -241,6 +244,7 @@ func TestLogReader_ReadNext_FromCachedBatch(t *testing.T) {
 	require.NoError(t, err)
 
 	reader := &logBatchReaderImpl{
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 		logName:              "test-log",
 		logId:                1,
 		logIdStr:             "1",
@@ -276,6 +280,7 @@ func TestLogReader_ReadNext_CachedBatchCorruptedData(t *testing.T) {
 	mockLogHandle.Test(t)
 
 	reader := &logBatchReaderImpl{
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 		logName:              "test-log",
 		logId:                1,
 		logIdStr:             "1",
@@ -318,6 +323,7 @@ func TestLogReader_ReadNext_FreshBatchRead(t *testing.T) {
 	require.NoError(t, err)
 
 	reader := &logBatchReaderImpl{
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 		logName:              "test-log",
 		logId:                1,
 		logIdStr:             "1",
@@ -379,6 +385,7 @@ func TestLogReader_ReadNext_SegmentEOF_MovesToNextSegment(t *testing.T) {
 	require.NoError(t, err)
 
 	reader := &logBatchReaderImpl{
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 		logName:              "test-log",
 		logId:                1,
 		logIdStr:             "1",
@@ -438,10 +445,11 @@ func TestLogReader_ReadNext_SegmentEOF_MovesToNextSegment(t *testing.T) {
 
 func TestLogReader_UnmarshalAndCreateLogMessage(t *testing.T) {
 	reader := &logBatchReaderImpl{
-		logName:    "test-log",
-		logId:      1,
-		logIdStr:   "1",
-		readerName: "test-reader",
+		readerTempSession: &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
+		logName:           "test-log",
+		logId:             1,
+		logIdStr:          "1",
+		readerName:        "test-reader",
 	}
 
 	t.Run("Success", func(t *testing.T) {
@@ -473,6 +481,7 @@ func TestLogReader_UnmarshalAndCreateLogMessage(t *testing.T) {
 
 func TestLogReader_WaitWithContext(t *testing.T) {
 	reader := &logBatchReaderImpl{
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 		logName:              "test-log",
 		logId:                1,
 		logIdStr:             "1",
@@ -516,6 +525,7 @@ func TestLogReader_IsEntryInCurrentSegment(t *testing.T) {
 		mockSegHandle.EXPECT().GetId(mock.Anything).Return(int64(0)).Maybe()
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -539,6 +549,7 @@ func TestLogReader_IsEntryInCurrentSegment(t *testing.T) {
 		})
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -563,6 +574,7 @@ func TestLogReader_IsEntryInCurrentSegment(t *testing.T) {
 		mockSegHandle.EXPECT().GetId(mock.Anything).Return(int64(0)).Maybe()
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -587,6 +599,7 @@ func TestLogReader_IsEntryInCurrentSegment(t *testing.T) {
 		mockSegHandle.EXPECT().GetId(mock.Anything).Return(int64(0)).Maybe()
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -607,6 +620,7 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		mockLogHandle.Test(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -632,6 +646,7 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -667,6 +682,7 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		mockTruncatedSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -705,6 +721,7 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		mockLiveSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -744,6 +761,7 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		mockSeg7 := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -779,6 +797,7 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		mockSeg1 := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -815,6 +834,7 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		mockSeg6 := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -848,6 +868,7 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		mockSeg1 := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -881,6 +902,7 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		mockLogHandle.Test(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -905,6 +927,7 @@ func TestLogReader_FindNextReadableSegment(t *testing.T) {
 		mockLogHandle.Test(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -932,6 +955,7 @@ func TestLogReader_HandleTailRead(t *testing.T) {
 		mockLogHandle.Test(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -958,6 +982,7 @@ func TestLogReader_HandleTailRead(t *testing.T) {
 		mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -985,6 +1010,7 @@ func TestLogReader_HandleTailRead(t *testing.T) {
 		mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -1011,6 +1037,7 @@ func TestLogReader_HandleTailRead(t *testing.T) {
 		mockLogHandle.Test(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -1038,6 +1065,7 @@ func TestLogReader_HandleTailRead(t *testing.T) {
 		mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -1067,6 +1095,7 @@ func TestLogReader_GetNextSegHandleAndIDs(t *testing.T) {
 		mockLogHandle.Test(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -1092,6 +1121,7 @@ func TestLogReader_GetNextSegHandleAndIDs(t *testing.T) {
 		mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -1120,6 +1150,7 @@ func TestLogReader_GetNextSegHandleAndIDs(t *testing.T) {
 		mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 		reader := &logBatchReaderImpl{
+			readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 			logName:              "test-log",
 			logId:                1,
 			logIdStr:             "1",
@@ -1234,6 +1265,7 @@ func TestLogReader_ReadNext_EntryNotFound_ContextCancelled(t *testing.T) {
 	mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 	reader := &logBatchReaderImpl{
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 		logName:              "test-log",
 		logId:                1,
 		logIdStr:             "1",
@@ -1336,6 +1368,66 @@ func TestLogReader_ReadNext_IdleReaderThrottlesPositionReports(t *testing.T) {
 		"an idle reader must report its unchanged position at most once per UpdateReaderInfoIntervalMs, not once per poll")
 }
 
+// A retired session means this reader is permanently dead - the reader closed,
+// or the metadata provider did - and nothing ever revives it. Reading on would
+// keep serving entries while the reader is already gone from the metadata
+// store, so the writer's cleanup no longer protects the segments being read.
+// Fail the read instead, the way os.File and sql.DB do after Close.
+func TestLogReader_ReadNext_RetiredSessionFailsFast(t *testing.T) {
+	mockLogHandle := &testLogHandleMock{}
+	mockLogHandle.Test(t)
+
+	reader := &logBatchReaderImpl{
+		logName:              "test-log",
+		logId:                1,
+		logIdStr:             "1",
+		logHandle:            mockLogHandle,
+		pendingReadSegmentId: 0,
+		pendingReadEntryId:   0,
+		readerName:           "test-reader",
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader", retired: true},
+		logNs:                "",
+		lastRead:             time.Now().UnixMilli(),
+	}
+
+	msg, err := reader.ReadNext(context.Background())
+	assert.Nil(t, msg)
+	require.Error(t, err)
+	assert.True(t, werr.ErrLogReaderClosed.Is(err), "expected ErrLogReaderClosed, got %v", err)
+}
+
+// A cached batch must not be drained past the reader's death either: the check
+// has to precede the fast path that returns already-fetched entries.
+func TestLogReader_ReadNext_RetiredSessionDoesNotDrainCachedBatch(t *testing.T) {
+	mockLogHandle := &testLogHandleMock{}
+	mockLogHandle.Test(t)
+
+	data, err := MarshalMessage(&WriteMessage{Payload: []byte("cached payload")})
+	require.NoError(t, err)
+
+	reader := &logBatchReaderImpl{
+		logName:              "test-log",
+		logId:                1,
+		logIdStr:             "1",
+		logHandle:            mockLogHandle,
+		pendingReadSegmentId: 0,
+		pendingReadEntryId:   0,
+		readerName:           "test-reader",
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader", retired: true},
+		logNs:                "",
+		batch: &proto.BatchReadResult{
+			Entries: []*proto.LogEntry{{SegId: 0, EntryId: 0, Values: data}},
+		},
+		next:     0,
+		lastRead: time.Now().UnixMilli(),
+	}
+
+	msg, err := reader.ReadNext(context.Background())
+	assert.Nil(t, msg)
+	require.Error(t, err)
+	assert.True(t, werr.ErrLogReaderClosed.Is(err), "expected ErrLogReaderClosed, got %v", err)
+}
+
 func TestLogReader_ReadNext_OtherReadError(t *testing.T) {
 	mockLogHandle := &testLogHandleMock{}
 	mockLogHandle.Test(t)
@@ -1343,6 +1435,7 @@ func TestLogReader_ReadNext_OtherReadError(t *testing.T) {
 	mockSegHandle := mocks_segment_handle.NewSegmentHandle(t)
 
 	reader := &logBatchReaderImpl{
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 		logName:              "test-log",
 		logId:                1,
 		logIdStr:             "1",
@@ -1391,6 +1484,7 @@ func TestLogReader_ReadNext_MultipleBatchEntries(t *testing.T) {
 	data2, _ := MarshalMessage(writeMsg2)
 
 	reader := &logBatchReaderImpl{
+		readerTempSession:    &fakeReaderTempSession{logId: 1, readerName: "test-reader"},
 		logName:              "test-log",
 		logId:                1,
 		logIdStr:             "1",
@@ -1429,8 +1523,11 @@ func TestLogReader_ReadNext_MultipleBatchEntries(t *testing.T) {
 type fakeReaderTempSession struct {
 	logId      int64
 	readerName string
+	// retired stands in for a session the provider has already taken back,
+	// either because the reader closed or because the provider did
+	retired bool
 }
 
 func (s *fakeReaderTempSession) LogId() int64       { return s.logId }
 func (s *fakeReaderTempSession) ReaderName() string { return s.readerName }
-func (s *fakeReaderTempSession) IsActive() bool     { return true }
+func (s *fakeReaderTempSession) IsActive() bool     { return !s.retired }


### PR DESCRIPTION
Closes #277.

## Problem

`ReadNext` kept serving entries after the reader was closed:

```go
reader.Close(ctx)                  // session retired, temp info key deleted
msg, err := reader.ReadNext(ctx)   // err == nil, msg is a real message
```

`logBatchReaderImpl` carries no closed state and nothing on the read path consulted the session it holds, so a use-after-close read on silently — including draining whatever was already in the cached batch. The only code that noticed was the position report, whose refusal was swallowed into a Warn.

That is worse than a lost report. A retired reader is gone from `GetAllReaderTempInfoForLog`, so the writer's cleanup no longer protects the segments it is still reading. If a writer elsewhere truncates and cleans, `findNextReadableSegment` silently advances past the cleaned range and the application loses entries with no error at all.

## Why failing fast is the right response

A retired session is terminal. `entry.closed` is set in exactly one place, `retireReaderTempSession`, reached from `DeleteReaderTempInfo` (the reader closing itself) and from provider `Close()`. Nothing ever clears it. Reopening is not a recovery path either — when the cause is provider `Close()`, `CreateReaderTempInfo` refuses.

So `ReadNext` now returns `werr.ErrLogReaderClosed`, matching what the equivalent APIs do (`os.File.Read` → `ErrClosed`, `sql.DB` → `ErrConnDone`). That error already existed at `common/werr/errors.go:81`, was unused anywhere in the repo, and is already marked non-retryable — the semantics line up exactly.

The check sits after the context check and ahead of the cached-batch fast path, so a dead reader cannot drain what it prefetched. `IsActive()` is used rather than a reader-local closed flag because it covers both terminal causes with one check, and this is the purpose it was added for — it had no production caller until now.

## Milvus is unaffected

Verified end to end. Milvus closes strictly inside-out:

```
openerAdaptorImpl.Close()
├─ walInstances.Range → wal.Close()
│    └─ walAdaptorImpl.Close()
│         ├─ scanners.Range → scanner.Close()
│         │    ├─ ScannerHelper.Close()   blocks until executeConsumer exits
│         │    └─ reader.Close()          no ReadNext in flight here
│         └─ rwWALImpls.Close()           writer + log handle
└─ openerCache → opener.Close()           only now: woodpecker client → provider
```

`ScannerHelper.Close()` blocks on `BlockAndGetResult()` until the consuming goroutine calls `Finish`, so no `ReadNext` can be running against a retired session, and the provider is only closed once every reader and writer already is. Milvus therefore never observes the old behaviour and will not observe the new error.

The point is that this ordering is a discipline the caller keeps, not something the API enforced or documented.

## Contract change

`ReadNext` gains an error it has never returned. Callers that treat any non-context error from it as terminal — Milvus's `scannerImpl.executeConsumer` calls `s.Finish(err)` — will surface it as a scanner failure rather than reading on silently. That is the intended behaviour, and per the ordering above it cannot fire in Milvus today.

## Test literals

Tests in this package build `logBatchReaderImpl` directly and left `readerTempSession` nil, which was invisible while nothing dereferenced it. Production readers always have one — `NewLogBatchReader` rejects nil — so the 34 literals now set one, rather than the read path tolerating nil.

## Testing

- Both new tests verified failing first. `TestLogReader_ReadNext_RetiredSessionDoesNotDrainCachedBatch` returned a real `LogMessage` before the fix, which is the bug in one line of output.
- `go test -race -short ./woodpecker/log/ ./meta/` — pass
- `golangci-lint run ./woodpecker/log/...` — 0 issues
