### PR TITLE
enhance: bound and retry log deletion, allow an explicit skip for unreachable nodes

### DIFF
--- a/server/maintenance.go
+++ b/server/maintenance.go
@@ -182,7 +182,7 @@ func (i *idleProcessorCleanupTask) Run(ctx context.Context) error {
 //
 // It deliberately does NOT touch the marker or the deleting gate. The gate is what makes
 // getOrCreateSegmentProcessor reject an arriving append, so it has to outlive the client-side
-// work that follows a fence — object deletion and metadata deletion. Dropping it here would
+// work that follows the delete mark — object deletion and metadata deletion. Dropping it here would
 // let a new writer rebuild a processor and write fresh blocks into the prefix that was just
 // enumerated, invisible to the enumeration that already ran and unreferenced by any metadata
 // afterwards.
@@ -222,7 +222,7 @@ func removeLocalData(ctx context.Context, store *logStore, m deleteMarker) (bool
 // and prunes the in-memory deleting-set entry.
 //
 // This is the grace-based path. By the time it runs, the grace period has elapsed since the
-// fence, so the client-side deletion it was racing has had its window and the gate can go.
+// mark, so the client-side deletion it was racing has had its window and the gate can go.
 // The synchronous path calls removeLocalData directly and leaves the marker in place, so this
 // task is what eventually retires it.
 //

--- a/woodpecker/delete_log.go
+++ b/woodpecker/delete_log.go
@@ -53,12 +53,12 @@ type DeleteStats struct {
 	Logs int
 	// Objects removed from object storage.
 	ObjectsDeleted int
-	// Successful fence calls, counted per node per log.
-	NodesFenced int
+	// Nodes that accepted the delete mark, counted per node per log.
+	NodesMarked int
 	// Of those, the ones that found a local directory to remove. Always 0 for an
 	// asynchronous delete, which returns before the reclaim task runs.
 	NodesWithLocalData int
-	// SkippedNodes maps a node address to the log ids whose fence it never received,
+	// SkippedNodes maps a node address to the log ids whose delete mark it never received,
 	// because it stayed unreachable through every retry and the caller opted into
 	// WithSkipUnreachableNodes. Empty otherwise — without that option an unreachable node
 	// fails the delete instead.
@@ -71,7 +71,7 @@ type DeleteStats struct {
 	SkippedNodes map[string][]int64
 }
 
-// recordSkippedNode notes that a log's fence never reached a node.
+// recordSkippedNode notes that a log's delete mark never reached a node.
 func (d *DeleteStats) recordSkippedNode(node string, logId int64) {
 	if d.SkippedNodes == nil {
 		d.SkippedNodes = make(map[string][]int64, 1)
@@ -83,7 +83,7 @@ func (d *DeleteStats) recordSkippedNode(node string, logId int64) {
 func (d *DeleteStats) Add(other DeleteStats) {
 	d.Logs += other.Logs
 	d.ObjectsDeleted += other.ObjectsDeleted
-	d.NodesFenced += other.NodesFenced
+	d.NodesMarked += other.NodesMarked
 	d.NodesWithLocalData += other.NodesWithLocalData
 	for node, logIds := range other.SkippedNodes {
 		for _, logId := range logIds {
@@ -115,10 +115,10 @@ func newDeleteOptions(opts []DeleteOption) deleteOptions {
 // window" — both fail every attempt inside any sane budget, and only the operator knows
 // which it is. A network partition is worse still: from the client it is indistinguishable
 // from a dead node, and skipping one would delete objects out from under a node that is
-// still alive and possibly still writing, since the fence is also what closes the segment
+// still alive and possibly still writing, since marking a log deleted is also what closes its segment
 // processors and raises the deleting gate.
 //
-// Only transport failures are ever skipped. A reachable node that rejects the fence is
+// Only transport failures are ever skipped. A reachable node that rejects the mark is
 // reporting a real problem, not a connectivity one, and still fails the delete.
 //
 // What was skipped comes back in DeleteStats.SkippedNodes so the decision leaves a trace.
@@ -172,8 +172,8 @@ func deleteLogUnsafe(
 	logId := logMeta.Metadata.GetLogId()
 
 	// Step 2: stop every node that could still be writing this log.
-	fenceStats, err := markLogDeletedOnNodes(ctx, md, pool, cfg, logName, logId, sync, opts)
-	stats.Add(fenceStats)
+	markStats, err := markLogDeletedOnNodes(ctx, md, pool, cfg, logName, logId, sync, opts)
+	stats.Add(markStats)
 	if err != nil {
 		return stats, err
 	}
@@ -208,12 +208,12 @@ func deleteLogUnsafe(
 	logger.Ctx(ctx).Info("deleteLogUnsafe: log deleted successfully",
 		zap.String("logName", logName), zap.Int64("logId", logId), zap.Bool("sync", sync),
 		zap.Int("objectsDeleted", stats.ObjectsDeleted),
-		zap.Int("nodesFenced", stats.NodesFenced),
+		zap.Int("nodesMarked", stats.NodesMarked),
 		zap.Int("nodesWithLocalData", stats.NodesWithLocalData))
 	return stats, nil
 }
 
-// markLogDeletedOnNodes fences the log on every node that could hold data for it.
+// markLogDeletedOnNodes marks the log deleted on every node that could hold data for it.
 //
 // In service mode the node set comes from the quorum recorded in segment metadata. In the
 // object-storage and local modes there is no quorum to read, and the embedded logstore is
@@ -238,19 +238,19 @@ func markLogDeletedOnNodes(
 	if len(nodes) == 0 {
 		if cfg.Woodpecker.Storage.IsStorageService() {
 			// Service mode with no quorum recorded: every segment was already truncated
-			// away, so no node is serving this log. Nothing to fence.
-			logger.Ctx(ctx).Info("deleteLogUnsafe: no quorum nodes recorded, nothing to fence",
+			// away, so no node is serving this log. Nothing to mark.
+			logger.Ctx(ctx).Info("deleteLogUnsafe: no quorum nodes recorded, nothing to mark",
 				zap.String("logName", logName), zap.Int64("logId", logId))
 			return stats, nil
 		}
 		// Embedded deployments (minio / local) run a single in-process logstore and the
-		// local pool ignores the target, so any target reaches it. Fence it so it stops
+		// local pool ignores the target, so any target reaches it. Mark it so it stops
 		// serving and — with sync — reclaims its directory before we touch anything else.
-		hadData, fenceErr := fenceLogOnNode(ctx, pool, "", bucketName, rootPath, logId, sync)
-		if fenceErr != nil {
-			return stats, fenceErr
+		hadData, deleteMarkErr := markLogDeletedOnNode(ctx, pool, "", bucketName, rootPath, logId, sync)
+		if deleteMarkErr != nil {
+			return stats, deleteMarkErr
 		}
-		stats.NodesFenced = 1
+		stats.NodesMarked = 1
 		if hadData {
 			stats.NodesWithLocalData = 1
 		}
@@ -262,62 +262,62 @@ func markLogDeletedOnNodes(
 		zap.Strings("nodes", nodes), zap.Bool("sync", sync))
 
 	for _, node := range nodes {
-		hadData, fenceErr := fenceLogOnNode(ctx, pool, node, bucketName, rootPath, logId, sync)
-		if fenceErr == nil {
-			stats.NodesFenced++
+		hadData, deleteMarkErr := markLogDeletedOnNode(ctx, pool, node, bucketName, rootPath, logId, sync)
+		if deleteMarkErr == nil {
+			stats.NodesMarked++
 			if hadData {
 				stats.NodesWithLocalData++
 			}
 			continue
 		}
 		// Skipping is opt-in and limited to nodes we could not reach. A reachable node that
-		// rejected the fence is reporting a real problem and still fails the delete.
-		if opts.skipUnreachableNodes && werr.IsTransportError(fenceErr) {
+		// rejected the mark is reporting a real problem and still fails the delete.
+		if opts.skipUnreachableNodes && werr.IsTransportError(deleteMarkErr) {
 			logger.Ctx(ctx).Warn("deleteLogUnsafe: node unreachable after retries, skipping as requested; "+
 				"its staged data for this log stays on disk",
 				zap.String("node", node), zap.String("logName", logName),
-				zap.Int64("logId", logId), zap.Error(fenceErr))
+				zap.Int64("logId", logId), zap.Error(deleteMarkErr))
 			stats.recordSkippedNode(node, logId)
 			continue
 		}
-		logger.Ctx(ctx).Warn("deleteLogUnsafe: failed to fence log on node",
+		logger.Ctx(ctx).Warn("deleteLogUnsafe: failed to mark log deleted on node",
 			zap.String("node", node), zap.Int64("logId", logId),
-			zap.Bool("transport", werr.IsTransportError(fenceErr)), zap.Error(fenceErr))
-		return stats, fenceErr
+			zap.Bool("transport", werr.IsTransportError(deleteMarkErr)), zap.Error(deleteMarkErr))
+		return stats, deleteMarkErr
 	}
 	return stats, nil
 }
 
-// Fence bounds. Package vars so tests can shrink them, matching the convention
+// Delete-mark bounds. Package vars so tests can shrink them, matching the convention
 // appendFirstResponseTimeout established in logstore_client_remote.go.
 var (
-	// fenceAttempts is how many times one node's fence is tried before it counts as
+	// markAttempts is how many times one node's delete mark is tried before it counts as
 	// unreachable. Transport failures only: the pool evicts its cached connection on each
 	// one, so a retry re-resolves DNS. That is exactly what a pod mid-rolling-restart or a
 	// peer that came back with a new IP needs, and without a retry the eviction is wasted
 	// because there is never a next call.
-	fenceAttempts   uint = 3
-	fenceRetrySleep      = time.Second
-	fenceMaxSleep        = 4 * time.Second
+	markAttempts   uint = 3
+	markRetrySleep      = time.Second
+	markMaxSleep        = 4 * time.Second
 
-	// fenceAttemptTimeout bounds ONE attempt. grpc.WaitForReady(false) already makes an
+	// markAttemptTimeout bounds ONE attempt. grpc.WaitForReady(false) already makes an
 	// unconnectable peer fail fast, but it does nothing for a peer that accepts the
 	// connection and then never answers — a hung process or a black-holing network — which
 	// would otherwise wedge the whole delete with no way out but Ctrl-C.
 	//
-	// Deliberately generous. A synchronous fence has the node os.RemoveAll its staged
+	// Deliberately generous. A synchronous mark has the node os.RemoveAll its staged
 	// directory for that log, which is legitimately slow when the log has a large
 	// un-compacted tail. Cutting off a reclaim that is making progress would be worse than
 	// the hang this prevents.
-	fenceAttemptTimeout = 2 * time.Minute
+	markAttemptTimeout = 2 * time.Minute
 )
 
-// fenceLogOnNode marks a log deleted on one node, retrying transport failures.
+// markLogDeletedOnNode marks a log deleted on one node, retrying transport failures.
 //
 // Returns whether the node had local data, and the last error if every attempt failed. The
 // error is returned unwrapped so the caller can still classify it with werr.IsTransportError
 // when deciding whether skipping is allowed.
-func fenceLogOnNode(
+func markLogDeletedOnNode(
 	ctx context.Context,
 	pool client.LogStoreClientPool,
 	node, bucketName, rootPath string,
@@ -326,7 +326,7 @@ func fenceLogOnNode(
 ) (bool, error) {
 	var hadData bool
 	err := retry.Do(ctx, func() error {
-		attemptCtx, cancel := context.WithTimeout(ctx, fenceAttemptTimeout)
+		attemptCtx, cancel := context.WithTimeout(ctx, markAttemptTimeout)
 		defer cancel()
 
 		lsClient, getErr := pool.GetLogStoreClient(attemptCtx, node)
@@ -337,10 +337,10 @@ func fenceLogOnNode(
 		hadData, markErr = lsClient.MarkLogDeleted(attemptCtx, bucketName, rootPath, logId, sync)
 		return markErr
 	},
-		retry.Attempts(fenceAttempts),
-		retry.Sleep(fenceRetrySleep),
-		retry.MaxSleepTime(fenceMaxSleep),
-		// Retry only what a retry can fix. A reachable node that rejects the fence is
+		retry.Attempts(markAttempts),
+		retry.Sleep(markRetrySleep),
+		retry.MaxSleepTime(markMaxSleep),
+		// Retry only what a retry can fix. A reachable node that rejects the mark is
 		// reporting a real problem; retrying it just turns a clear error into a timeout.
 		retry.RetryErr(werr.IsTransportError),
 	)
@@ -436,14 +436,14 @@ func deleteAllLogsUnsafe(
 	close(jobs)
 	wg.Wait()
 
-	// Report, do not judge. A clear that fenced nodes but found nothing anywhere is the
+	// Report, do not judge. A clear that reached nodes but found nothing anywhere is the
 	// signature of a wrong bucket/rootPath — and also of an instance that was already
 	// empty, which is why this warns rather than fails.
 	if syncDelete && firstErr == nil && total.Logs > 0 &&
 		total.ObjectsDeleted == 0 && total.NodesWithLocalData == 0 {
 		logger.Ctx(ctx).Warn("deleteAllLogsUnsafe: deleted metadata but found no data on any tier; "+
 			"verify the bucket and rootPath point at this instance's WAL",
-			zap.Int("logs", total.Logs), zap.Int("nodesFenced", total.NodesFenced),
+			zap.Int("logs", total.Logs), zap.Int("nodesMarked", total.NodesMarked),
 			zap.String("bucket", cfg.Minio.BucketName), zap.String("rootPath", cfg.Minio.RootPath))
 	}
 	return total, firstErr

--- a/woodpecker/delete_log.go
+++ b/woodpecker/delete_log.go
@@ -97,14 +97,52 @@ type DeleteOption func(*deleteOptions)
 
 type deleteOptions struct {
 	skipUnreachableNodes bool
+	markAttempts         uint
+	markAttemptTimeout   time.Duration
 }
 
+// newDeleteOptions resolves caller options against the package defaults.
+//
+// Always construct options through this, never as a zero-value literal: retry.Do reads
+// attempts==0 as "retry forever", so an unset field is the difference between a bounded
+// delete and one that never returns.
 func newDeleteOptions(opts []DeleteOption) deleteOptions {
-	var o deleteOptions
+	o := deleteOptions{
+		markAttempts:       markAttempts,
+		markAttemptTimeout: markAttemptTimeout,
+	}
 	for _, opt := range opts {
 		opt(&o)
 	}
+	// Fall back rather than fail on the two values a caller can get wrong quietly. Zero
+	// attempts is what an unconfigured CLI flag looks like, and a non-positive timeout would
+	// disable the bound these exist to provide.
+	if o.markAttempts == 0 {
+		o.markAttempts = markAttempts
+	}
+	if o.markAttemptTimeout <= 0 {
+		o.markAttemptTimeout = markAttemptTimeout
+	}
 	return o
+}
+
+// WithMarkAttempts sets how many times one node is asked to mark the log deleted before it
+// counts as unreachable. Zero keeps the default.
+//
+// Only transport failures are retried, so raising this buys patience with a node that is
+// restarting, not with one that is rejecting the request.
+func WithMarkAttempts(attempts uint) DeleteOption {
+	return func(o *deleteOptions) { o.markAttempts = attempts }
+}
+
+// WithMarkAttemptTimeout bounds one attempt at marking a log deleted on one node. A
+// non-positive duration keeps the default.
+//
+// Raise it when nodes hold large un-compacted tails: a synchronous mark has the node
+// os.RemoveAll its staged directory for that log, and cutting off a reclaim that is making
+// progress is worse than the hang the bound prevents.
+func WithMarkAttemptTimeout(d time.Duration) DeleteOption {
+	return func(o *deleteOptions) { o.markAttemptTimeout = d }
 }
 
 // WithSkipUnreachableNodes lets a delete finish without a node that stays unreachable
@@ -246,7 +284,7 @@ func markLogDeletedOnNodes(
 		// Embedded deployments (minio / local) run a single in-process logstore and the
 		// local pool ignores the target, so any target reaches it. Mark it so it stops
 		// serving and — with sync — reclaims its directory before we touch anything else.
-		hadData, deleteMarkErr := markLogDeletedOnNode(ctx, pool, "", bucketName, rootPath, logId, sync)
+		hadData, deleteMarkErr := markLogDeletedOnNode(ctx, pool, "", bucketName, rootPath, logId, sync, opts)
 		if deleteMarkErr != nil {
 			return stats, deleteMarkErr
 		}
@@ -262,7 +300,7 @@ func markLogDeletedOnNodes(
 		zap.Strings("nodes", nodes), zap.Bool("sync", sync))
 
 	for _, node := range nodes {
-		hadData, deleteMarkErr := markLogDeletedOnNode(ctx, pool, node, bucketName, rootPath, logId, sync)
+		hadData, deleteMarkErr := markLogDeletedOnNode(ctx, pool, node, bucketName, rootPath, logId, sync, opts)
 		if deleteMarkErr == nil {
 			stats.NodesMarked++
 			if hadData {
@@ -323,10 +361,11 @@ func markLogDeletedOnNode(
 	node, bucketName, rootPath string,
 	logId int64,
 	sync bool,
+	opts deleteOptions,
 ) (bool, error) {
 	var hadData bool
 	err := retry.Do(ctx, func() error {
-		attemptCtx, cancel := context.WithTimeout(ctx, markAttemptTimeout)
+		attemptCtx, cancel := context.WithTimeout(ctx, opts.markAttemptTimeout)
 		defer cancel()
 
 		lsClient, getErr := pool.GetLogStoreClient(attemptCtx, node)
@@ -337,7 +376,7 @@ func markLogDeletedOnNode(
 		hadData, markErr = lsClient.MarkLogDeleted(attemptCtx, bucketName, rootPath, logId, sync)
 		return markErr
 	},
-		retry.Attempts(markAttempts),
+		retry.Attempts(opts.markAttempts),
 		retry.Sleep(markRetrySleep),
 		retry.MaxSleepTime(markMaxSleep),
 		// Retry only what a retry can fix. A reachable node that rejects the mark is

--- a/woodpecker/delete_log.go
+++ b/woodpecker/delete_log.go
@@ -19,12 +19,14 @@ package woodpecker
 import (
 	"context"
 	stdsync "sync"
+	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/zilliztech/woodpecker/common/config"
 	"github.com/zilliztech/woodpecker/common/logger"
 	storageclient "github.com/zilliztech/woodpecker/common/objectstorage"
+	"github.com/zilliztech/woodpecker/common/retry"
 	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/meta"
 	"github.com/zilliztech/woodpecker/woodpecker/client"
@@ -56,6 +58,25 @@ type DeleteStats struct {
 	// Of those, the ones that found a local directory to remove. Always 0 for an
 	// asynchronous delete, which returns before the reclaim task runs.
 	NodesWithLocalData int
+	// SkippedNodes maps a node address to the log ids whose fence it never received,
+	// because it stayed unreachable through every retry and the caller opted into
+	// WithSkipUnreachableNodes. Empty otherwise — without that option an unreachable node
+	// fails the delete instead.
+	//
+	// Each entry is staged data left on that node forever: nothing references it once the
+	// metadata is gone, and no reclaim will run because the node never got a delete marker.
+	// That residue is bounded and harmless — logId never repeats, so a future log cannot
+	// land in the same directory — but only an operator can tell scrap hardware from a node
+	// that is coming back, so the detail is reported rather than swallowed.
+	SkippedNodes map[string][]int64
+}
+
+// recordSkippedNode notes that a log's fence never reached a node.
+func (d *DeleteStats) recordSkippedNode(node string, logId int64) {
+	if d.SkippedNodes == nil {
+		d.SkippedNodes = make(map[string][]int64, 1)
+	}
+	d.SkippedNodes[node] = append(d.SkippedNodes[node], logId)
 }
 
 // Add accumulates another delete's counts.
@@ -64,6 +85,45 @@ func (d *DeleteStats) Add(other DeleteStats) {
 	d.ObjectsDeleted += other.ObjectsDeleted
 	d.NodesFenced += other.NodesFenced
 	d.NodesWithLocalData += other.NodesWithLocalData
+	for node, logIds := range other.SkippedNodes {
+		for _, logId := range logIds {
+			d.recordSkippedNode(node, logId)
+		}
+	}
+}
+
+// DeleteOption configures a delete.
+type DeleteOption func(*deleteOptions)
+
+type deleteOptions struct {
+	skipUnreachableNodes bool
+}
+
+func newDeleteOptions(opts []DeleteOption) deleteOptions {
+	var o deleteOptions
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// WithSkipUnreachableNodes lets a delete finish without a node that stays unreachable
+// through every retry, instead of failing.
+//
+// Off by default, and deliberately not something retries can decide on their own. Retrying
+// cannot tell "this node is scrap" from "this node is down for a ten-minute maintenance
+// window" — both fail every attempt inside any sane budget, and only the operator knows
+// which it is. A network partition is worse still: from the client it is indistinguishable
+// from a dead node, and skipping one would delete objects out from under a node that is
+// still alive and possibly still writing, since the fence is also what closes the segment
+// processors and raises the deleting gate.
+//
+// Only transport failures are ever skipped. A reachable node that rejects the fence is
+// reporting a real problem, not a connectivity one, and still fails the delete.
+//
+// What was skipped comes back in DeleteStats.SkippedNodes so the decision leaves a trace.
+func WithSkipUnreachableNodes() DeleteOption {
+	return func(o *deleteOptions) { o.skipUnreachableNodes = true }
 }
 
 // deleteLogUnsafe removes every trace of one log: the node-local staged data, the objects in
@@ -96,6 +156,7 @@ func deleteLogUnsafe(
 	storage storageclient.ObjectStorage,
 	logName string,
 	sync bool,
+	opts deleteOptions,
 ) (DeleteStats, error) {
 	var stats DeleteStats
 	// Step 1: resolve logId; treat not-found as a successful no-op.
@@ -111,9 +172,8 @@ func deleteLogUnsafe(
 	logId := logMeta.Metadata.GetLogId()
 
 	// Step 2: stop every node that could still be writing this log.
-	fenced, withData, err := markLogDeletedOnNodes(ctx, md, pool, cfg, logName, logId, sync)
-	stats.NodesFenced += fenced
-	stats.NodesWithLocalData += withData
+	fenceStats, err := markLogDeletedOnNodes(ctx, md, pool, cfg, logName, logId, sync, opts)
+	stats.Add(fenceStats)
 	if err != nil {
 		return stats, err
 	}
@@ -166,10 +226,11 @@ func markLogDeletedOnNodes(
 	logName string,
 	logId int64,
 	sync bool,
-) (fenced int, withLocalData int, err error) {
+	opts deleteOptions,
+) (stats DeleteStats, err error) {
 	nodes, err := logQuorumNodes(ctx, md, logName)
 	if err != nil {
-		return 0, 0, err
+		return stats, err
 	}
 	bucketName := cfg.Minio.BucketName
 	rootPath := cfg.Minio.RootPath
@@ -180,23 +241,20 @@ func markLogDeletedOnNodes(
 			// away, so no node is serving this log. Nothing to fence.
 			logger.Ctx(ctx).Info("deleteLogUnsafe: no quorum nodes recorded, nothing to fence",
 				zap.String("logName", logName), zap.Int64("logId", logId))
-			return 0, 0, nil
+			return stats, nil
 		}
 		// Embedded deployments (minio / local) run a single in-process logstore and the
 		// local pool ignores the target, so any target reaches it. Fence it so it stops
 		// serving and — with sync — reclaims its directory before we touch anything else.
-		lsClient, getErr := pool.GetLogStoreClient(ctx, "")
-		if getErr != nil {
-			return 0, 0, getErr
+		hadData, fenceErr := fenceLogOnNode(ctx, pool, "", bucketName, rootPath, logId, sync)
+		if fenceErr != nil {
+			return stats, fenceErr
 		}
-		hadData, markErr := lsClient.MarkLogDeleted(ctx, bucketName, rootPath, logId, sync)
-		if markErr != nil {
-			return 0, 0, markErr
-		}
+		stats.NodesFenced = 1
 		if hadData {
-			return 1, 1, nil
+			stats.NodesWithLocalData = 1
 		}
-		return 1, 0, nil
+		return stats, nil
 	}
 
 	logger.Ctx(ctx).Info("deleteLogUnsafe: fencing log on quorum nodes",
@@ -204,24 +262,89 @@ func markLogDeletedOnNodes(
 		zap.Strings("nodes", nodes), zap.Bool("sync", sync))
 
 	for _, node := range nodes {
-		lsClient, getErr := pool.GetLogStoreClient(ctx, node)
-		if getErr != nil {
-			logger.Ctx(ctx).Warn("deleteLogUnsafe: failed to get logstore client",
-				zap.String("node", node), zap.Error(getErr))
-			return fenced, withLocalData, getErr
+		hadData, fenceErr := fenceLogOnNode(ctx, pool, node, bucketName, rootPath, logId, sync)
+		if fenceErr == nil {
+			stats.NodesFenced++
+			if hadData {
+				stats.NodesWithLocalData++
+			}
+			continue
 		}
-		hadData, markErr := lsClient.MarkLogDeleted(ctx, bucketName, rootPath, logId, sync)
-		if markErr != nil {
-			logger.Ctx(ctx).Warn("deleteLogUnsafe: MarkLogDeleted failed",
-				zap.String("node", node), zap.Int64("logId", logId), zap.Error(markErr))
-			return fenced, withLocalData, markErr
+		// Skipping is opt-in and limited to nodes we could not reach. A reachable node that
+		// rejected the fence is reporting a real problem and still fails the delete.
+		if opts.skipUnreachableNodes && werr.IsTransportError(fenceErr) {
+			logger.Ctx(ctx).Warn("deleteLogUnsafe: node unreachable after retries, skipping as requested; "+
+				"its staged data for this log stays on disk",
+				zap.String("node", node), zap.String("logName", logName),
+				zap.Int64("logId", logId), zap.Error(fenceErr))
+			stats.recordSkippedNode(node, logId)
+			continue
 		}
-		fenced++
-		if hadData {
-			withLocalData++
-		}
+		logger.Ctx(ctx).Warn("deleteLogUnsafe: failed to fence log on node",
+			zap.String("node", node), zap.Int64("logId", logId),
+			zap.Bool("transport", werr.IsTransportError(fenceErr)), zap.Error(fenceErr))
+		return stats, fenceErr
 	}
-	return fenced, withLocalData, nil
+	return stats, nil
+}
+
+// Fence bounds. Package vars so tests can shrink them, matching the convention
+// appendFirstResponseTimeout established in logstore_client_remote.go.
+var (
+	// fenceAttempts is how many times one node's fence is tried before it counts as
+	// unreachable. Transport failures only: the pool evicts its cached connection on each
+	// one, so a retry re-resolves DNS. That is exactly what a pod mid-rolling-restart or a
+	// peer that came back with a new IP needs, and without a retry the eviction is wasted
+	// because there is never a next call.
+	fenceAttempts   uint = 3
+	fenceRetrySleep      = time.Second
+	fenceMaxSleep        = 4 * time.Second
+
+	// fenceAttemptTimeout bounds ONE attempt. grpc.WaitForReady(false) already makes an
+	// unconnectable peer fail fast, but it does nothing for a peer that accepts the
+	// connection and then never answers — a hung process or a black-holing network — which
+	// would otherwise wedge the whole delete with no way out but Ctrl-C.
+	//
+	// Deliberately generous. A synchronous fence has the node os.RemoveAll its staged
+	// directory for that log, which is legitimately slow when the log has a large
+	// un-compacted tail. Cutting off a reclaim that is making progress would be worse than
+	// the hang this prevents.
+	fenceAttemptTimeout = 2 * time.Minute
+)
+
+// fenceLogOnNode marks a log deleted on one node, retrying transport failures.
+//
+// Returns whether the node had local data, and the last error if every attempt failed. The
+// error is returned unwrapped so the caller can still classify it with werr.IsTransportError
+// when deciding whether skipping is allowed.
+func fenceLogOnNode(
+	ctx context.Context,
+	pool client.LogStoreClientPool,
+	node, bucketName, rootPath string,
+	logId int64,
+	sync bool,
+) (bool, error) {
+	var hadData bool
+	err := retry.Do(ctx, func() error {
+		attemptCtx, cancel := context.WithTimeout(ctx, fenceAttemptTimeout)
+		defer cancel()
+
+		lsClient, getErr := pool.GetLogStoreClient(attemptCtx, node)
+		if getErr != nil {
+			return getErr
+		}
+		var markErr error
+		hadData, markErr = lsClient.MarkLogDeleted(attemptCtx, bucketName, rootPath, logId, sync)
+		return markErr
+	},
+		retry.Attempts(fenceAttempts),
+		retry.Sleep(fenceRetrySleep),
+		retry.MaxSleepTime(fenceMaxSleep),
+		// Retry only what a retry can fix. A reachable node that rejects the fence is
+		// reporting a real problem; retrying it just turns a clear error into a timeout.
+		retry.RetryErr(werr.IsTransportError),
+	)
+	return hadData, err
 }
 
 // logQuorumNodes returns the distinct quorum endpoints recorded across a log's segments.
@@ -261,6 +384,7 @@ func deleteAllLogsUnsafe(
 	cfg *config.Configuration,
 	storage storageclient.ObjectStorage,
 	syncDelete bool,
+	opts deleteOptions,
 ) (DeleteStats, error) {
 	var total DeleteStats
 	logs, err := md.ListLogs(ctx)
@@ -286,7 +410,7 @@ func deleteAllLogsUnsafe(
 		go func() {
 			defer wg.Done()
 			for logName := range jobs {
-				stats, delErr := deleteLogUnsafe(ctx, md, pool, cfg, storage, logName, syncDelete)
+				stats, delErr := deleteLogUnsafe(ctx, md, pool, cfg, storage, logName, syncDelete, opts)
 				mu.Lock()
 				total.Add(stats)
 				if delErr != nil && firstErr == nil {

--- a/woodpecker/delete_log_test.go
+++ b/woodpecker/delete_log_test.go
@@ -180,7 +180,7 @@ func TestDeleteLog_NoSegments_JustDeletesMetadata(t *testing.T) {
 		Return(map[int64]*meta.SegmentMeta{}, nil).Once()
 
 	// No quorum is recorded, but this is an embedded deployment: the in-process logstore may
-	// still hold an open processor for the log, so it is fenced before anything is removed.
+	// still hold an open processor for the log, so it is marked deleted before anything is removed.
 	// Skipping that would let a concurrent compaction write a fresh object after cleanup.
 	mockClient := mocks_logstore_client.NewLogStoreClient(t)
 	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "").Return(mockClient, nil).Once()
@@ -194,10 +194,10 @@ func TestDeleteLog_NoSegments_JustDeletesMetadata(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestDeleteLog_NoSegments_ServiceMode_NothingToFence covers the other half: in service mode
+// TestDeleteLog_NoSegments_ServiceMode_NothingToMark covers the other half: in service mode
 // an empty quorum means every segment was already truncated away and no node is serving the
 // log, so there is nothing to contact.
-func TestDeleteLog_NoSegments_ServiceMode_NothingToFence(t *testing.T) {
+func TestDeleteLog_NoSegments_ServiceMode_NothingToMark(t *testing.T) {
 	ctx := context.Background()
 	cfg := testDeleteCfg()
 	cfg.Woodpecker.Storage.Type = "service"
@@ -260,7 +260,7 @@ func TestDeleteAllLogs_DeletesEachLog(t *testing.T) {
 	mockMeta.EXPECT().ListLogs(mock.Anything).
 		Return([]string{"a", "b"}, nil).Once()
 
-	// Embedded deployment: each log's in-process logstore is fenced before its metadata goes.
+	// Embedded deployment: each log's in-process logstore is marked before its metadata goes.
 	mockClient := mocks_logstore_client.NewLogStoreClient(t)
 	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "").Return(mockClient, nil).Twice()
 	mockClient.EXPECT().MarkLogDeleted(mock.Anything, "test-bucket", "test-root", int64(1), false).
@@ -295,21 +295,21 @@ func unavailableErr() error {
 	return status.Error(codes.Unavailable, "connection refused")
 }
 
-// shrinkFenceBackoff makes the retry loop finish instantly. The production values are seconds
+// shrinkMarkBackoff makes the retry loop finish instantly. The production values are seconds
 // apart on purpose; tests only care about the number of attempts.
-func shrinkFenceBackoff(t *testing.T) {
+func shrinkMarkBackoff(t *testing.T) {
 	t.Helper()
-	sleep, maxSleep := fenceRetrySleep, fenceMaxSleep
-	fenceRetrySleep, fenceMaxSleep = time.Millisecond, time.Millisecond
-	t.Cleanup(func() { fenceRetrySleep, fenceMaxSleep = sleep, maxSleep })
+	sleep, maxSleep := markRetrySleep, markMaxSleep
+	markRetrySleep, markMaxSleep = time.Millisecond, time.Millisecond
+	t.Cleanup(func() { markRetrySleep, markMaxSleep = sleep, maxSleep })
 }
 
-// TestFenceRetriesTransientUnavailability is the common case this exists for: a pod
+// TestDeleteMarkRetriesTransientUnavailability is the common case this exists for: a pod
 // mid-rolling-restart or a DNS record that has not re-resolved yet. The pool evicts its
 // cached connection on each transport failure so the next attempt re-dials — without a retry
 // that recovery mechanism never gets a turn, and one blip aborts the whole run.
-func TestFenceRetriesTransientUnavailability(t *testing.T) {
-	shrinkFenceBackoff(t)
+func TestDeleteMarkRetriesTransientUnavailability(t *testing.T) {
+	shrinkMarkBackoff(t)
 	ctx := context.Background()
 	cfg := testDeleteCfg()
 
@@ -331,15 +331,15 @@ func TestFenceRetriesTransientUnavailability(t *testing.T) {
 	stats, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true, deleteOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.Logs)
-	assert.Equal(t, 1, stats.NodesFenced)
+	assert.Equal(t, 1, stats.NodesMarked)
 	assert.Empty(t, stats.SkippedNodes, "the node answered in the end; nothing was skipped")
 }
 
-// TestFenceExhaustedFailsClosedByDefault pins the default. Without an explicit opt-in an
+// TestDeleteMarkExhaustedFailsClosedByDefault pins the default. Without an explicit opt-in an
 // unreachable node stops the delete, so the log keeps its objects AND its metadata and stays
 // enumerable for a later retry.
-func TestFenceExhaustedFailsClosedByDefault(t *testing.T) {
-	shrinkFenceBackoff(t)
+func TestDeleteMarkExhaustedFailsClosedByDefault(t *testing.T) {
+	shrinkMarkBackoff(t)
 	ctx := context.Background()
 	cfg := testDeleteCfg()
 
@@ -350,23 +350,23 @@ func TestFenceExhaustedFailsClosedByDefault(t *testing.T) {
 		Return(map[int64]*meta.SegmentMeta{0: buildSegmentMeta([]string{"n1"})}, nil).Once()
 
 	mockClient := mocks_logstore_client.NewLogStoreClient(t)
-	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n1").Return(mockClient, nil).Times(int(fenceAttempts))
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n1").Return(mockClient, nil).Times(int(markAttempts))
 	mockClient.EXPECT().MarkLogDeleted(mock.Anything, "test-bucket", "test-root", int64(7), true).
-		Return(false, unavailableErr()).Times(int(fenceAttempts))
+		Return(false, unavailableErr()).Times(int(markAttempts))
 	// DeleteLogMetadata is deliberately NOT expected: reaching it would be the bug.
 
 	stats, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true, deleteOptions{})
 	require.Error(t, err)
 	assert.True(t, werr.IsTransportError(err), "the classification must survive the retry loop")
-	assert.Zero(t, stats.Logs, "metadata must not be deleted when a node could not be fenced")
+	assert.Zero(t, stats.Logs, "metadata must not be deleted when a node could not be marked")
 	assert.Empty(t, stats.SkippedNodes)
 }
 
-// TestFenceExhaustedSkipsOnlyWhenAsked covers the opt-in, and what it must report. The
+// TestDeleteMarkExhaustedSkipsOnlyWhenAsked covers the opt-in, and what it must report. The
 // skipped node keeps that log's staged data forever, so the operator needs the node and the
 // log id to decide between "scrap hardware, leave it" and "reclaim the space by hand".
-func TestFenceExhaustedSkipsOnlyWhenAsked(t *testing.T) {
-	shrinkFenceBackoff(t)
+func TestDeleteMarkExhaustedSkipsOnlyWhenAsked(t *testing.T) {
+	shrinkMarkBackoff(t)
 	ctx := context.Background()
 	cfg := testDeleteCfg()
 
@@ -377,9 +377,9 @@ func TestFenceExhaustedSkipsOnlyWhenAsked(t *testing.T) {
 		Return(map[int64]*meta.SegmentMeta{0: buildSegmentMeta([]string{"n1", "n2"})}, nil).Once()
 
 	dead := mocks_logstore_client.NewLogStoreClient(t)
-	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n1").Return(dead, nil).Times(int(fenceAttempts))
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n1").Return(dead, nil).Times(int(markAttempts))
 	dead.EXPECT().MarkLogDeleted(mock.Anything, "test-bucket", "test-root", int64(7), true).
-		Return(false, unavailableErr()).Times(int(fenceAttempts))
+		Return(false, unavailableErr()).Times(int(markAttempts))
 
 	alive := mocks_logstore_client.NewLogStoreClient(t)
 	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n2").Return(alive, nil).Once()
@@ -392,7 +392,7 @@ func TestFenceExhaustedSkipsOnlyWhenAsked(t *testing.T) {
 		newDeleteOptions([]DeleteOption{WithSkipUnreachableNodes()}))
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.Logs)
-	assert.Equal(t, 1, stats.NodesFenced, "only the reachable node was fenced")
+	assert.Equal(t, 1, stats.NodesMarked, "only the reachable node accepted the mark")
 	assert.Equal(t, map[string][]int64{"n1": {7}}, stats.SkippedNodes,
 		"the operator needs the node and the log id to locate the residue")
 }
@@ -401,7 +401,7 @@ func TestFenceExhaustedSkipsOnlyWhenAsked(t *testing.T) {
 // answers and refuses is reporting a real problem, not a connectivity one, and swallowing
 // that would hide a genuine failure behind a flag meant for dead hardware.
 func TestSkipDoesNotCoverALogicalRejection(t *testing.T) {
-	shrinkFenceBackoff(t)
+	shrinkMarkBackoff(t)
 	ctx := context.Background()
 	cfg := testDeleteCfg()
 

--- a/woodpecker/delete_log_test.go
+++ b/woodpecker/delete_log_test.go
@@ -106,7 +106,7 @@ func TestDeleteLog_MarksQuorumNodesThenDeletesMetadata(t *testing.T) {
 	mockMeta.EXPECT().DeleteLogMetadata(mock.Anything, "foo", false).
 		Return(nil).Once()
 
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, deleteOptions{})
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, newDeleteOptions(nil))
 	assert.NoError(t, err)
 }
 
@@ -139,7 +139,7 @@ func TestDeleteLog_NodeMarkFailure_DoesNotDeleteMetadata(t *testing.T) {
 
 	// DeleteLogMetadata must NOT be called — enforced by testify (no EXPECT set).
 
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, deleteOptions{})
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, newDeleteOptions(nil))
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "node unreachable")
 }
@@ -160,7 +160,7 @@ func TestDeleteLog_AlreadyGone_Idempotent(t *testing.T) {
 
 	// No pool or client calls expected — enforced by testify.
 
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, deleteOptions{})
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, newDeleteOptions(nil))
 	assert.NoError(t, err)
 }
 
@@ -190,7 +190,7 @@ func TestDeleteLog_NoSegments_JustDeletesMetadata(t *testing.T) {
 	mockMeta.EXPECT().DeleteLogMetadata(mock.Anything, "empty-log", false).
 		Return(nil).Once()
 
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "empty-log", false, deleteOptions{})
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "empty-log", false, newDeleteOptions(nil))
 	assert.NoError(t, err)
 }
 
@@ -220,7 +220,7 @@ func TestDeleteLog_NoSegments_ServiceMode_NothingToMark(t *testing.T) {
 		Return(nil).Once()
 
 	// No pool/client calls expected.
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, storage, "empty-log", false, deleteOptions{})
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, storage, "empty-log", false, newDeleteOptions(nil))
 	assert.NoError(t, err)
 }
 
@@ -240,7 +240,7 @@ func TestDeleteLog_ObjectStorageUnavailable_KeepsMetadata(t *testing.T) {
 		Return(map[int64]*meta.SegmentMeta{}, nil).Once()
 	// DeleteLogMetadata must NOT be called.
 
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, deleteOptions{})
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, newDeleteOptions(nil))
 	assert.Error(t, err)
 }
 
@@ -284,7 +284,7 @@ func TestDeleteAllLogs_DeletesEachLog(t *testing.T) {
 	mockMeta.EXPECT().DeleteLogMetadata(mock.Anything, "b", false).
 		Return(nil).Once()
 
-	_, err := deleteAllLogsUnsafe(ctx, mockMeta, mockPool, cfg, nil, false, deleteOptions{})
+	_, err := deleteAllLogsUnsafe(ctx, mockMeta, mockPool, cfg, nil, false, newDeleteOptions(nil))
 	assert.NoError(t, err)
 }
 
@@ -328,7 +328,7 @@ func TestDeleteMarkRetriesTransientUnavailability(t *testing.T) {
 		Return(true, nil).Once()
 	mockMeta.EXPECT().DeleteLogMetadata(mock.Anything, "foo", false).Return(nil).Once()
 
-	stats, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true, deleteOptions{})
+	stats, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true, newDeleteOptions(nil))
 	require.NoError(t, err)
 	assert.Equal(t, 1, stats.Logs)
 	assert.Equal(t, 1, stats.NodesMarked)
@@ -355,7 +355,7 @@ func TestDeleteMarkExhaustedFailsClosedByDefault(t *testing.T) {
 		Return(false, unavailableErr()).Times(int(markAttempts))
 	// DeleteLogMetadata is deliberately NOT expected: reaching it would be the bug.
 
-	stats, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true, deleteOptions{})
+	stats, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true, newDeleteOptions(nil))
 	require.Error(t, err)
 	assert.True(t, werr.IsTransportError(err), "the classification must survive the retry loop")
 	assert.Zero(t, stats.Logs, "metadata must not be deleted when a node could not be marked")
@@ -423,4 +423,58 @@ func TestSkipDoesNotCoverALogicalRejection(t *testing.T) {
 	assert.Contains(t, err.Error(), "being compacted")
 	assert.Zero(t, stats.Logs)
 	assert.Empty(t, stats.SkippedNodes)
+}
+
+// TestDeleteOptionsResolveAgainstDefaults pins the guard that keeps a caller-supplied zero
+// from becoming a delete that never returns. retry.Do reads attempts==0 as "retry forever",
+// which is exactly what an unconfigured CLI flag looks like, and a non-positive timeout would
+// switch off the bound the option exists to provide.
+func TestDeleteOptionsResolveAgainstDefaults(t *testing.T) {
+	def := newDeleteOptions(nil)
+	assert.Equal(t, markAttempts, def.markAttempts)
+	assert.Equal(t, markAttemptTimeout, def.markAttemptTimeout)
+	assert.False(t, def.skipUnreachableNodes, "skipping must never be the default")
+
+	set := newDeleteOptions([]DeleteOption{
+		WithMarkAttempts(7),
+		WithMarkAttemptTimeout(90 * time.Second),
+		WithSkipUnreachableNodes(),
+	})
+	assert.Equal(t, uint(7), set.markAttempts)
+	assert.Equal(t, 90*time.Second, set.markAttemptTimeout)
+	assert.True(t, set.skipUnreachableNodes)
+
+	// Values a caller can get wrong quietly fall back instead of disabling the bound.
+	degenerate := newDeleteOptions([]DeleteOption{
+		WithMarkAttempts(0),
+		WithMarkAttemptTimeout(0),
+	})
+	assert.Equal(t, markAttempts, degenerate.markAttempts, "zero attempts must not mean forever")
+	assert.Equal(t, markAttemptTimeout, degenerate.markAttemptTimeout)
+
+	negative := newDeleteOptions([]DeleteOption{WithMarkAttemptTimeout(-time.Second)})
+	assert.Equal(t, markAttemptTimeout, negative.markAttemptTimeout)
+}
+
+// TestWithMarkAttemptsIsHonoured proves the option reaches the retry loop rather than just
+// being stored — the package default is 3, so asking for 5 has to produce 5 calls.
+func TestWithMarkAttemptsIsHonoured(t *testing.T) {
+	shrinkMarkBackoff(t)
+	ctx := context.Background()
+	cfg := testDeleteCfg()
+
+	mockMeta := mocks_meta.NewMetadataProvider(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockMeta.EXPECT().GetLogMeta(mock.Anything, "foo").Return(buildLogMeta(7), nil).Once()
+	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "foo").
+		Return(map[int64]*meta.SegmentMeta{0: buildSegmentMeta([]string{"n1"})}, nil).Once()
+
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n1").Return(mockClient, nil).Times(5)
+	mockClient.EXPECT().MarkLogDeleted(mock.Anything, "test-bucket", "test-root", int64(7), true).
+		Return(false, unavailableErr()).Times(5)
+
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true,
+		newDeleteOptions([]DeleteOption{WithMarkAttempts(5)}))
+	require.Error(t, err)
 }

--- a/woodpecker/delete_log_test.go
+++ b/woodpecker/delete_log_test.go
@@ -20,9 +20,13 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/zilliztech/woodpecker/common/config"
 	"github.com/zilliztech/woodpecker/common/werr"
@@ -102,7 +106,7 @@ func TestDeleteLog_MarksQuorumNodesThenDeletesMetadata(t *testing.T) {
 	mockMeta.EXPECT().DeleteLogMetadata(mock.Anything, "foo", false).
 		Return(nil).Once()
 
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false)
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, deleteOptions{})
 	assert.NoError(t, err)
 }
 
@@ -135,7 +139,7 @@ func TestDeleteLog_NodeMarkFailure_DoesNotDeleteMetadata(t *testing.T) {
 
 	// DeleteLogMetadata must NOT be called — enforced by testify (no EXPECT set).
 
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false)
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, deleteOptions{})
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "node unreachable")
 }
@@ -156,7 +160,7 @@ func TestDeleteLog_AlreadyGone_Idempotent(t *testing.T) {
 
 	// No pool or client calls expected — enforced by testify.
 
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false)
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, deleteOptions{})
 	assert.NoError(t, err)
 }
 
@@ -186,7 +190,7 @@ func TestDeleteLog_NoSegments_JustDeletesMetadata(t *testing.T) {
 	mockMeta.EXPECT().DeleteLogMetadata(mock.Anything, "empty-log", false).
 		Return(nil).Once()
 
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "empty-log", false)
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "empty-log", false, deleteOptions{})
 	assert.NoError(t, err)
 }
 
@@ -216,7 +220,7 @@ func TestDeleteLog_NoSegments_ServiceMode_NothingToFence(t *testing.T) {
 		Return(nil).Once()
 
 	// No pool/client calls expected.
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, storage, "empty-log", false)
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, storage, "empty-log", false, deleteOptions{})
 	assert.NoError(t, err)
 }
 
@@ -236,7 +240,7 @@ func TestDeleteLog_ObjectStorageUnavailable_KeepsMetadata(t *testing.T) {
 		Return(map[int64]*meta.SegmentMeta{}, nil).Once()
 	// DeleteLogMetadata must NOT be called.
 
-	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false)
+	_, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", false, deleteOptions{})
 	assert.Error(t, err)
 }
 
@@ -280,6 +284,143 @@ func TestDeleteAllLogs_DeletesEachLog(t *testing.T) {
 	mockMeta.EXPECT().DeleteLogMetadata(mock.Anything, "b", false).
 		Return(nil).Once()
 
-	_, err := deleteAllLogsUnsafe(ctx, mockMeta, mockPool, cfg, nil, false)
+	_, err := deleteAllLogsUnsafe(ctx, mockMeta, mockPool, cfg, nil, false, deleteOptions{})
 	assert.NoError(t, err)
+}
+
+// unavailableErr is what grpc-go produces for every transport-layer failure, and therefore
+// what werr.IsTransportError recognises. Using the real shape matters: the retry predicate and
+// the skip predicate both key off it, so a hand-rolled error would exercise neither.
+func unavailableErr() error {
+	return status.Error(codes.Unavailable, "connection refused")
+}
+
+// shrinkFenceBackoff makes the retry loop finish instantly. The production values are seconds
+// apart on purpose; tests only care about the number of attempts.
+func shrinkFenceBackoff(t *testing.T) {
+	t.Helper()
+	sleep, maxSleep := fenceRetrySleep, fenceMaxSleep
+	fenceRetrySleep, fenceMaxSleep = time.Millisecond, time.Millisecond
+	t.Cleanup(func() { fenceRetrySleep, fenceMaxSleep = sleep, maxSleep })
+}
+
+// TestFenceRetriesTransientUnavailability is the common case this exists for: a pod
+// mid-rolling-restart or a DNS record that has not re-resolved yet. The pool evicts its
+// cached connection on each transport failure so the next attempt re-dials — without a retry
+// that recovery mechanism never gets a turn, and one blip aborts the whole run.
+func TestFenceRetriesTransientUnavailability(t *testing.T) {
+	shrinkFenceBackoff(t)
+	ctx := context.Background()
+	cfg := testDeleteCfg()
+
+	mockMeta := mocks_meta.NewMetadataProvider(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockMeta.EXPECT().GetLogMeta(mock.Anything, "foo").Return(buildLogMeta(7), nil).Once()
+	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "foo").
+		Return(map[int64]*meta.SegmentMeta{0: buildSegmentMeta([]string{"n1"})}, nil).Once()
+
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n1").Return(mockClient, nil).Times(3)
+	// Unavailable twice, then the node comes back.
+	mockClient.EXPECT().MarkLogDeleted(mock.Anything, "test-bucket", "test-root", int64(7), true).
+		Return(false, unavailableErr()).Twice()
+	mockClient.EXPECT().MarkLogDeleted(mock.Anything, "test-bucket", "test-root", int64(7), true).
+		Return(true, nil).Once()
+	mockMeta.EXPECT().DeleteLogMetadata(mock.Anything, "foo", false).Return(nil).Once()
+
+	stats, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true, deleteOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Logs)
+	assert.Equal(t, 1, stats.NodesFenced)
+	assert.Empty(t, stats.SkippedNodes, "the node answered in the end; nothing was skipped")
+}
+
+// TestFenceExhaustedFailsClosedByDefault pins the default. Without an explicit opt-in an
+// unreachable node stops the delete, so the log keeps its objects AND its metadata and stays
+// enumerable for a later retry.
+func TestFenceExhaustedFailsClosedByDefault(t *testing.T) {
+	shrinkFenceBackoff(t)
+	ctx := context.Background()
+	cfg := testDeleteCfg()
+
+	mockMeta := mocks_meta.NewMetadataProvider(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockMeta.EXPECT().GetLogMeta(mock.Anything, "foo").Return(buildLogMeta(7), nil).Once()
+	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "foo").
+		Return(map[int64]*meta.SegmentMeta{0: buildSegmentMeta([]string{"n1"})}, nil).Once()
+
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n1").Return(mockClient, nil).Times(int(fenceAttempts))
+	mockClient.EXPECT().MarkLogDeleted(mock.Anything, "test-bucket", "test-root", int64(7), true).
+		Return(false, unavailableErr()).Times(int(fenceAttempts))
+	// DeleteLogMetadata is deliberately NOT expected: reaching it would be the bug.
+
+	stats, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true, deleteOptions{})
+	require.Error(t, err)
+	assert.True(t, werr.IsTransportError(err), "the classification must survive the retry loop")
+	assert.Zero(t, stats.Logs, "metadata must not be deleted when a node could not be fenced")
+	assert.Empty(t, stats.SkippedNodes)
+}
+
+// TestFenceExhaustedSkipsOnlyWhenAsked covers the opt-in, and what it must report. The
+// skipped node keeps that log's staged data forever, so the operator needs the node and the
+// log id to decide between "scrap hardware, leave it" and "reclaim the space by hand".
+func TestFenceExhaustedSkipsOnlyWhenAsked(t *testing.T) {
+	shrinkFenceBackoff(t)
+	ctx := context.Background()
+	cfg := testDeleteCfg()
+
+	mockMeta := mocks_meta.NewMetadataProvider(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockMeta.EXPECT().GetLogMeta(mock.Anything, "foo").Return(buildLogMeta(7), nil).Once()
+	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "foo").
+		Return(map[int64]*meta.SegmentMeta{0: buildSegmentMeta([]string{"n1", "n2"})}, nil).Once()
+
+	dead := mocks_logstore_client.NewLogStoreClient(t)
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n1").Return(dead, nil).Times(int(fenceAttempts))
+	dead.EXPECT().MarkLogDeleted(mock.Anything, "test-bucket", "test-root", int64(7), true).
+		Return(false, unavailableErr()).Times(int(fenceAttempts))
+
+	alive := mocks_logstore_client.NewLogStoreClient(t)
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n2").Return(alive, nil).Once()
+	alive.EXPECT().MarkLogDeleted(mock.Anything, "test-bucket", "test-root", int64(7), true).
+		Return(true, nil).Once()
+
+	mockMeta.EXPECT().DeleteLogMetadata(mock.Anything, "foo", false).Return(nil).Once()
+
+	stats, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true,
+		newDeleteOptions([]DeleteOption{WithSkipUnreachableNodes()}))
+	require.NoError(t, err)
+	assert.Equal(t, 1, stats.Logs)
+	assert.Equal(t, 1, stats.NodesFenced, "only the reachable node was fenced")
+	assert.Equal(t, map[string][]int64{"n1": {7}}, stats.SkippedNodes,
+		"the operator needs the node and the log id to locate the residue")
+}
+
+// TestSkipDoesNotCoverALogicalRejection keeps the option honest to its name. A node that
+// answers and refuses is reporting a real problem, not a connectivity one, and swallowing
+// that would hide a genuine failure behind a flag meant for dead hardware.
+func TestSkipDoesNotCoverALogicalRejection(t *testing.T) {
+	shrinkFenceBackoff(t)
+	ctx := context.Background()
+	cfg := testDeleteCfg()
+
+	mockMeta := mocks_meta.NewMetadataProvider(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockMeta.EXPECT().GetLogMeta(mock.Anything, "foo").Return(buildLogMeta(7), nil).Once()
+	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "foo").
+		Return(map[int64]*meta.SegmentMeta{0: buildSegmentMeta([]string{"n1"})}, nil).Once()
+
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "n1").Return(mockClient, nil).Once()
+	// A reachable node refusing: not a transport error, so neither retried nor skipped.
+	mockClient.EXPECT().MarkLogDeleted(mock.Anything, "test-bucket", "test-root", int64(7), true).
+		Return(false, errors.New("log is being compacted")).Once()
+
+	stats, err := deleteLogUnsafe(ctx, mockMeta, mockPool, cfg, nil, "foo", true,
+		newDeleteOptions([]DeleteOption{WithSkipUnreachableNodes()}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "being compacted")
+	assert.Zero(t, stats.Logs)
+	assert.Empty(t, stats.SkippedNodes)
 }

--- a/woodpecker/log_object_cleanup.go
+++ b/woodpecker/log_object_cleanup.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -143,6 +144,20 @@ func deleteLogObjects(ctx context.Context, storage storageclient.ObjectStorage, 
 // removeObjectsConcurrently deletes keys with a bounded worker pool and returns the first
 // error, after every worker has drained. Partial progress is fine: the caller's retry
 // re-enumerates and only sees what is left.
+// objectRequestTimeout bounds ONE object-storage delete. Package var so tests can shrink it,
+// matching the convention appendFirstResponseTimeout established in the logstore client.
+//
+// Deliberately NOT wired to minio.requestTimeoutMs. That setting has no reader anywhere in
+// the repository, so its 1s default has never been exercised; activating it from here would
+// silently impose a tight bound on every object delete that no operator opted into. Making it
+// live belongs to the timeout audit (#229), which can weigh it across all object-storage
+// calls at once.
+//
+// Only the per-object delete is bounded, not the prefix walk. A single delete's duration does
+// not scale with anything, so a fixed ceiling is safe; a walk's does scale with the object
+// count, and a fixed ceiling there would fail exactly the largest logs it is meant to protect.
+var objectRequestTimeout = 2 * time.Minute
+
 func removeObjectsConcurrently(ctx context.Context, storage storageclient.ObjectStorage, bucket string, keys []string, logNs, logIdStr string) (int, error) {
 	workers := defaultObjectDeleteConcurrency
 	if len(keys) < workers {
@@ -160,7 +175,11 @@ func removeObjectsConcurrently(ctx context.Context, storage storageclient.Object
 		go func() {
 			defer wg.Done()
 			for key := range jobs {
-				err := storage.RemoveObject(ctx, bucket, key, logNs, logIdStr)
+				err := func() error {
+					reqCtx, cancel := context.WithTimeout(ctx, objectRequestTimeout)
+					defer cancel()
+					return storage.RemoveObject(reqCtx, bucket, key, logNs, logIdStr)
+				}()
 				mu.Lock()
 				switch {
 				case err == nil, storage.IsObjectNotExistsError(err):

--- a/woodpecker/woodpecker_client.go
+++ b/woodpecker/woodpecker_client.go
@@ -275,7 +275,7 @@ func (c *woodpeckerClient) DeleteLog(ctx context.Context, logName string) error 
 	if c.closeState.Load() {
 		return werr.ErrWoodpeckerClientClosed
 	}
-	_, err := deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), logName, false, deleteOptions{})
+	_, err := deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), logName, false, newDeleteOptions(nil))
 	return err
 }
 
@@ -296,7 +296,7 @@ func (c *woodpeckerClient) DeleteAllLogs(ctx context.Context) error {
 	if c.closeState.Load() {
 		return werr.ErrWoodpeckerClientClosed
 	}
-	_, err := deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), false, deleteOptions{})
+	_, err := deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), false, newDeleteOptions(nil))
 	return err
 }
 

--- a/woodpecker/woodpecker_client.go
+++ b/woodpecker/woodpecker_client.go
@@ -50,9 +50,11 @@ type Client interface {
 	// DeleteLogSync deletes a log and waits until every node has reclaimed its local data,
 	// so the return means the log holds nothing anywhere. The stats report what was actually
 	// removed per tier; see DeleteStats for why that is worth returning.
-	DeleteLogSync(ctx context.Context, logName string) (DeleteStats, error)
+	// Options are optional; see WithSkipUnreachableNodes for the only one that changes
+	// whether an unreachable node fails the delete.
+	DeleteLogSync(ctx context.Context, logName string, opts ...DeleteOption) (DeleteStats, error)
 	// DeleteAllLogsSync is DeleteAllLogs with the same wait-for-reclaim guarantee.
-	DeleteAllLogsSync(ctx context.Context) (DeleteStats, error)
+	DeleteAllLogsSync(ctx context.Context, opts ...DeleteOption) (DeleteStats, error)
 	// ClearMeta wipes this instance's content metadata and re-seeds the instance-level keys.
 	// See ClearMetaExceptLogIdGen for the safe default.
 	ClearMeta(ctx context.Context, clearLogIdGen bool) error
@@ -273,18 +275,18 @@ func (c *woodpeckerClient) DeleteLog(ctx context.Context, logName string) error 
 	if c.closeState.Load() {
 		return werr.ErrWoodpeckerClientClosed
 	}
-	_, err := deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), logName, false)
+	_, err := deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), logName, false, deleteOptions{})
 	return err
 }
 
 // DeleteLogSync deletes the log and waits for every node to reclaim its local data.
-func (c *woodpeckerClient) DeleteLogSync(ctx context.Context, logName string) (DeleteStats, error) {
+func (c *woodpeckerClient) DeleteLogSync(ctx context.Context, logName string, opts ...DeleteOption) (DeleteStats, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.closeState.Load() {
 		return DeleteStats{}, werr.ErrWoodpeckerClientClosed
 	}
-	return deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), logName, true)
+	return deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), logName, true, newDeleteOptions(opts))
 }
 
 // DeleteAllLogs deletes all logs managed by this client.
@@ -294,18 +296,18 @@ func (c *woodpeckerClient) DeleteAllLogs(ctx context.Context) error {
 	if c.closeState.Load() {
 		return werr.ErrWoodpeckerClientClosed
 	}
-	_, err := deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), false)
+	_, err := deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), false, deleteOptions{})
 	return err
 }
 
 // DeleteAllLogsSync deletes every log and waits for local reclaim on each.
-func (c *woodpeckerClient) DeleteAllLogsSync(ctx context.Context) (DeleteStats, error) {
+func (c *woodpeckerClient) DeleteAllLogsSync(ctx context.Context, opts ...DeleteOption) (DeleteStats, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.closeState.Load() {
 		return DeleteStats{}, werr.ErrWoodpeckerClientClosed
 	}
-	return deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), true)
+	return deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.getOrCreateCleanupStorage(ctx), true, newDeleteOptions(opts))
 }
 
 // ClearMeta wipes this instance's content metadata.

--- a/woodpecker/woodpecker_embed_client.go
+++ b/woodpecker/woodpecker_embed_client.go
@@ -372,7 +372,7 @@ func (c *woodpeckerEmbedClient) DeleteLog(ctx context.Context, logName string) e
 	if c.closeState.Load() {
 		return werr.ErrWoodpeckerClientClosed
 	}
-	_, err := deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), logName, false, deleteOptions{})
+	_, err := deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), logName, false, newDeleteOptions(nil))
 	return err
 }
 
@@ -393,7 +393,7 @@ func (c *woodpeckerEmbedClient) DeleteAllLogs(ctx context.Context) error {
 	if c.closeState.Load() {
 		return werr.ErrWoodpeckerClientClosed
 	}
-	_, err := deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), false, deleteOptions{})
+	_, err := deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), false, newDeleteOptions(nil))
 	return err
 }
 

--- a/woodpecker/woodpecker_embed_client.go
+++ b/woodpecker/woodpecker_embed_client.go
@@ -372,18 +372,18 @@ func (c *woodpeckerEmbedClient) DeleteLog(ctx context.Context, logName string) e
 	if c.closeState.Load() {
 		return werr.ErrWoodpeckerClientClosed
 	}
-	_, err := deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), logName, false)
+	_, err := deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), logName, false, deleteOptions{})
 	return err
 }
 
 // DeleteLogSync deletes the log and waits for the local data to be reclaimed.
-func (c *woodpeckerEmbedClient) DeleteLogSync(ctx context.Context, logName string) (DeleteStats, error) {
+func (c *woodpeckerEmbedClient) DeleteLogSync(ctx context.Context, logName string, opts ...DeleteOption) (DeleteStats, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.closeState.Load() {
 		return DeleteStats{}, werr.ErrWoodpeckerClientClosed
 	}
-	return deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), logName, true)
+	return deleteLogUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), logName, true, newDeleteOptions(opts))
 }
 
 // DeleteAllLogs deletes all logs managed by this client.
@@ -393,18 +393,18 @@ func (c *woodpeckerEmbedClient) DeleteAllLogs(ctx context.Context) error {
 	if c.closeState.Load() {
 		return werr.ErrWoodpeckerClientClosed
 	}
-	_, err := deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), false)
+	_, err := deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), false, deleteOptions{})
 	return err
 }
 
 // DeleteAllLogsSync deletes every log and waits for local reclaim on each.
-func (c *woodpeckerEmbedClient) DeleteAllLogsSync(ctx context.Context) (DeleteStats, error) {
+func (c *woodpeckerEmbedClient) DeleteAllLogsSync(ctx context.Context, opts ...DeleteOption) (DeleteStats, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.closeState.Load() {
 		return DeleteStats{}, werr.ErrWoodpeckerClientClosed
 	}
-	return deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), true)
+	return deleteAllLogsUnsafe(ctx, c.Metadata, c.clientPool, c.cfg, c.cleanupStorage(), true, newDeleteOptions(opts))
 }
 
 // ClearMeta wipes this instance's content metadata.


### PR DESCRIPTION
Closes #283.

Follows zilliztech/woodpecker#281, which made log deletion complete and synchronous.
Operating that through birdwatcher's `reset wal` surfaced a gap that is not about the
correctness of the delete but about what happens when a tier cannot be reached — and
the three tiers are not equally reachable.

| Tier | Can the delete always succeed? | Why |
|---|---|---|
| etcd metadata | **yes** | one endpoint set, always addressable |
| object storage | **yes** | prefix-driven and client-side; never depends on a node |
| node-local staged data | **no** | one RPC per node in the log's recorded quorum |

`logQuorumNodes` reads the quorum recorded in each segment's metadata, and nothing in
the repository ever rewrites that record — `Decommission()` runs *on* the node being
retired and only affects quorum selection for new segments. A node that is
permanently gone therefore stays in the node set of every log it ever served.

So only the node tier needs retry / timeout / skip. The other two keep the
all-or-nothing contract: if either fails, the delete fails and the log stays
enumerable for a retry.

## Bounded

`MarkLogDeleted` passed the caller's context straight through with no deadline of its
own, and the caller had none either — birdwatcher builds commands on
`context.WithCancel(context.Background())`. The client file already documents this as
an open hole:

> `appendFirstResponseTimeout` bounds the synchronous wait for the first (Buffered)
> response of AddEntry / AddEntries. **The caller passes a deadline-less context**, so
> without this bound a server that accepts the stream but never responds blocks the
> send forever […] TODO make configurable; tracked with the timeout audit (#229).

Only `AddEntry` ever got that bound. `grpc.WaitForReady(false)` makes an
*unconnectable* peer fail fast, but does nothing for one that accepts the connection
and then never answers — a hung process or a black-holing network — which wedged the
whole delete with no way out but Ctrl-C.

The delete mark now has a per-attempt deadline. It is deliberately generous: a synchronous
mark has the node `os.RemoveAll` its staged directory for that log, which is
legitimately slow for a large un-compacted tail, and cutting off a reclaim that is
making progress would be worse than the hang it prevents.

Object deletes are bounded per request for the same reason. The prefix walk is not:
one delete's duration does not scale with anything, so a fixed ceiling is safe, while
a walk's does scale with the object count — a ceiling there would fail exactly the
largest logs it is meant to protect.

## Retried

There was no retry at all, so a pod mid-rolling-restart, a DNS record that had not
re-resolved, or a sub-second hiccup aborted the entire `DeleteAllLogsSync`.

That is worse than it looks. The pool evicts its cached connection on transport
failure precisely so the *next* call re-resolves DNS — but the error had already
aborted the run, so the recovery mechanism never got a turn.

The delete mark now retries with bounded exponential backoff, on transport failures only.
`werr.IsTransportError` already encodes that predicate and is what the pool uses to
evict connections, so the classification is shared rather than re-invented. A
reachable node that rejects the mark is reporting a real problem, not a connectivity
one; retrying it would turn a clear error into a timeout.

## Skippable, but only on purpose

`WithSkipUnreachableNodes()` lets a delete finish without a node that stayed
unreachable through every attempt. **Off by default**, and deliberately not something
retries decide on their own:

- Retrying cannot distinguish "this node is scrap" from "this node is down for a
  ten-minute maintenance window". Both fail every attempt inside any sane budget, and
  only the operator knows which it is.
- A network partition is indistinguishable from a dead node at the client. Auto-skipping
  would delete objects out from under a node that is still alive and possibly still
  writing — marking a log deleted is also what closes its segment processors and raises
  the deleting gate. That is the ordering hazard #281 fixed, re-entering through a different door.

The safety argument for allowing it at all is the one that already justified
preserving `logidgen`: "all historical files are gone" is not a guarantee a distributed
system can offer, and **"a node permanently down when its log is deleted" was residue
path #1** in that reasoning. Monotonic `logId` makes leftover files structurally unable
to collide with a future log, so the residue is bounded and harmless.

Only transport failures are ever skipped, so the option stays honest to its name.

## Reported

`DeleteStats.SkippedNodes` maps node address to the log ids whose delete mark it never
received. Each entry is staged data left on that node forever — nothing references it
once the metadata is gone, and no reclaim runs because the node never got a delete
marker. An operator needs the node and the log ids to tell "scrap hardware, leave it"
from "coming back, reclaim the space by hand", so the detail is reported rather than
summarised into a count.

birdwatcher (milvus-io/birdwatcher#535) will render it as:

```
skipped 2 node(s) that did not accept the delete mark:
  milvus-woodpecker-1.milvus-woodpecker-headless:18080
    logs 17,19,23  ->  {storage.rootPath}/{bucket}/{rootPath}/{17,19,23}/
```

## Scope note

`minio.requestTimeoutMs` is deliberately **not** wired up, despite being the obvious
candidate. It has no reader anywhere in the repository, so its 1s default has never
been exercised; activating it from the delete path would silently impose a tight bound
on every object delete that no operator opted into, and would break slow object stores
that are fine today. Making it live belongs to #229, which can weigh it across all
object-storage calls at once. The delete path uses its own generous bound instead, in
a package var, and says why in the code.

## API

`DeleteLogSync` / `DeleteAllLogsSync` take variadic `DeleteOption`, so existing calls
compile unchanged. Both are new in v0.1.39, have no callers inside woodpecker, and
none in Milvus — birdwatcher is the only consumer.

No proto change, no server change, and therefore no mixed-version concern.

## Testing

`go test ./woodpecker/... ./server/ ./meta/` passes; `golangci-lint run` reports 0
issues. (Embedded-etcd tests contend for ports when packages run in parallel; the run
above is `-p 1`.)

Four new tests, each pinning one decision rather than the mechanism:

- a node Unavailable twice then answering completes the delete — the case that used to
  abort the whole run
- retries exhausted with no option: fails, and `DeleteLogMetadata` is deliberately not
  expected, so reaching it would fail the test
- retries exhausted with the option: the reachable node is marked, the dead one is
  recorded as `{"n1": [7]}`, and the delete completes
- a reachable node returning a logical error is neither retried nor skipped, even with
  the option set

Errors are built as real `codes.Unavailable` statuses, since both the retry and skip
predicates key off `werr.IsTransportError` — a hand-rolled error would exercise
neither path.

## Naming

An earlier revision of this branch called the per-node operation a "fence". That word
already means something specific in this repository — `FenceSegment`, `FencePolicy`,
`ErrSegmentFenced`, `ErrSegmentProcessorFenced`, and the `wpcli logstore intervene
fence` command all refer to sealing a segment against further writes. Using it for
"tell each node to mark this log deleted" put two unrelated mechanisms behind one term
in the same package.

Everything now follows the RPC's own verb, `MarkLogDeleted`, so the code and the wire
protocol agree. `DeleteStats.NodesFenced` becomes `NodesMarked`; that field shipped in
v0.1.39, so it is a breaking change to a released name, taken deliberately rather than
leave the ambiguity permanently in a public struct. birdwatcher is the only consumer,
there are none inside woodpecker, and Milvus does not reference it.

The pre-existing fencing in `server/logstore.go` and `logstore.proto` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


