### PR TITLE
fix(meta): stop the auditor from truncating a still-Active segment

### DIFF
--- a/woodpecker/log/log_handle.go
+++ b/woodpecker/log/log_handle.go
@@ -907,8 +907,19 @@ func (l *logHandleImpl) CheckAndSetSegmentTruncatedIfNeed(ctx context.Context) e
 			continue
 		}
 
-		if segMetadata.Metadata.State == proto.SegmentState_Truncated {
-			// already truncated, skip
+		// Only a finalized segment may be truncated. Truncated is already done, and an
+		// Active segment still has an in-flight completion holding the revision the
+		// segment was created with: marking it here bumps that revision, so completion's
+		// CAS fails with ErrMetadataRevisionInvalid, which it reads as a writer takeover
+		// and answers by fencing its own LogWriter. Such a segment exists whenever a roll
+		// found a non-empty append queue -- the new segment starts taking writes, and the
+		// truncation frontier can reach past the old one, while its completion is still
+		// running fence/complete RPCs. Skipping it costs one auditor cycle: the next pass
+		// sees Completed and truncates it then. It also keeps the truncated metadata
+		// well-formed, since an Active segment still carries LastEntryId=-1 and
+		// CompletionTime=0 from storeNewSegmentMeta.
+		if segMetadata.Metadata.State != proto.SegmentState_Completed &&
+			segMetadata.Metadata.State != proto.SegmentState_Sealed {
 			continue
 		}
 

--- a/woodpecker/log/log_handle_test.go
+++ b/woodpecker/log/log_handle_test.go
@@ -1877,8 +1877,10 @@ func TestLogHandle_ShouldMoveToTruncationPoint(t *testing.T) {
 	})
 }
 
-// TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_WithActiveSeg tests truncation with active segment needing update
-func TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_WithActiveSeg(t *testing.T) {
+// TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_SkipsFrontierAndLaterSegments tests that
+// only finalized segments strictly below the truncation point are marked: the frontier
+// segment itself and anything after it are left alone regardless of their state.
+func TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_SkipsFrontierAndLaterSegments(t *testing.T) {
 	logHandle, mockMeta := createMockLogHandle(t)
 	ctx := context.Background()
 
@@ -1891,7 +1893,7 @@ func TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_WithActiveSeg(t *testing.T)
 	}, nil)
 
 	segments := map[int64]*meta.SegmentMeta{
-		0: {Metadata: &proto.SegmentMetadata{SegNo: 0, State: proto.SegmentState_Active}, Revision: 1},
+		0: {Metadata: &proto.SegmentMetadata{SegNo: 0, State: proto.SegmentState_Sealed}, Revision: 1},
 		3: {Metadata: &proto.SegmentMetadata{SegNo: 3, State: proto.SegmentState_Completed}, Revision: 1},
 		5: {Metadata: &proto.SegmentMetadata{SegNo: 5, State: proto.SegmentState_Active}, Revision: 1}, // truncation segment - skip
 		8: {Metadata: &proto.SegmentMetadata{SegNo: 8, State: proto.SegmentState_Active}, Revision: 1}, // after truncation - skip
@@ -1901,7 +1903,7 @@ func TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_WithActiveSeg(t *testing.T)
 	// Only segments 0 and 3 (before truncation seg 5) should be marked as truncated
 	mockMeta.EXPECT().UpdateSegmentMetadata(mock.Anything, "test-log", int64(1), mock.MatchedBy(func(sm *meta.SegmentMeta) bool {
 		return sm.Metadata.State == proto.SegmentState_Truncated && sm.Metadata.SegNo == 0
-	}), proto.SegmentState_Active).Return(nil)
+	}), proto.SegmentState_Sealed).Return(nil)
 	mockMeta.EXPECT().UpdateSegmentMetadata(mock.Anything, "test-log", int64(1), mock.MatchedBy(func(sm *meta.SegmentMeta) bool {
 		return sm.Metadata.State == proto.SegmentState_Truncated && sm.Metadata.SegNo == 3
 	}), proto.SegmentState_Completed).Return(nil)
@@ -1924,7 +1926,7 @@ func TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_UpdateError(t *testing.T) {
 	}, nil)
 
 	segments := map[int64]*meta.SegmentMeta{
-		0: {Metadata: &proto.SegmentMetadata{SegNo: 0, State: proto.SegmentState_Active}, Revision: 1},
+		0: {Metadata: &proto.SegmentMetadata{SegNo: 0, State: proto.SegmentState_Completed}, Revision: 1},
 	}
 	mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(segments, nil)
 
@@ -2405,4 +2407,112 @@ func TestLogHandle_GetOrCreateWritableSegmentHandle_RollingNextSegmentAlreadyExi
 
 	mockOldSegment.AssertExpectations(t)
 	mockMeta.AssertExpectations(t)
+}
+
+// truncationAuditSegments returns a snapshot with a still-Active segment sitting below the
+// truncation frontier -- the shape a roll produces when it found a non-empty append queue:
+// segment 4 is the new writable one, segment 2 was rolled away from but its completion has
+// not published Completed yet.
+func truncationAuditSegments() map[int64]*meta.SegmentMeta {
+	return map[int64]*meta.SegmentMeta{
+		1: {Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Completed, LastEntryId: 10}, Revision: 11},
+		2: {Metadata: &proto.SegmentMetadata{SegNo: 2, State: proto.SegmentState_Active, LastEntryId: -1}, Revision: 22},
+		3: {Metadata: &proto.SegmentMetadata{SegNo: 3, State: proto.SegmentState_Sealed, LastEntryId: 30}, Revision: 33},
+		4: {Metadata: &proto.SegmentMetadata{SegNo: 4, State: proto.SegmentState_Active, LastEntryId: -1}, Revision: 44},
+	}
+}
+
+// TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_OnlyTruncatesFinalizedSegments pins the
+// invariant the auditor depends on: it must never rewrite a segment that is still Active.
+// Doing so bumps the segment key's etcd revision, which fails the CAS of that segment's own
+// in-flight completion; completion reads ErrMetadataRevisionInvalid as a writer takeover and
+// fences its LogWriter. Asserting that no update is issued for the Active segment is
+// therefore the same as asserting that its completion cannot be made to lose.
+func TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_OnlyTruncatesFinalizedSegments(t *testing.T) {
+	t.Run("SkipsActiveSegmentBelowFrontier", func(t *testing.T) {
+		logHandle, mockMeta := createMockLogHandle(t)
+		ctx := context.Background()
+
+		mockMeta.EXPECT().GetLogMeta(mock.Anything, "test-log").Return(&meta.LogMeta{
+			Metadata: &proto.LogMeta{TruncatedSegmentId: 4, TruncatedEntryId: 5},
+			Revision: 1,
+		}, nil)
+		mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(truncationAuditSegments(), nil)
+
+		var updatedSegIds []int64
+		var updatedFromStates []proto.SegmentState
+		mockMeta.EXPECT().UpdateSegmentMetadata(mock.Anything, "test-log", int64(1), mock.Anything, mock.Anything).
+			RunAndReturn(func(_ context.Context, _ string, _ int64, segMeta *meta.SegmentMeta, oldState proto.SegmentState) error {
+				updatedSegIds = append(updatedSegIds, segMeta.Metadata.SegNo)
+				updatedFromStates = append(updatedFromStates, oldState)
+				return nil
+			})
+
+		require.NoError(t, logHandle.CheckAndSetSegmentTruncatedIfNeed(ctx))
+
+		// 1 (Completed) and 3 (Sealed) are finalized and below the frontier; 4 is the
+		// frontier itself and is skipped by segment id.
+		assert.ElementsMatch(t, []int64{1, 3}, updatedSegIds)
+		// The regression: segment 2 must not be written at all, and no transition may
+		// ever originate from Active.
+		assert.NotContains(t, updatedSegIds, int64(2))
+		assert.NotContains(t, updatedFromStates, proto.SegmentState_Active)
+	})
+
+	t.Run("PicksUpTheSegmentOnceCompletionPublishesCompleted", func(t *testing.T) {
+		logHandle, mockMeta := createMockLogHandle(t)
+		ctx := context.Background()
+
+		mockMeta.EXPECT().GetLogMeta(mock.Anything, "test-log").Return(&meta.LogMeta{
+			Metadata: &proto.LogMeta{TruncatedSegmentId: 4, TruncatedEntryId: 5},
+			Revision: 1,
+		}, nil)
+
+		// Cycle 1 sees segment 2 mid-completion; cycle 2 sees the Completed it published.
+		firstCycle := truncationAuditSegments()
+		secondCycle := truncationAuditSegments()
+		secondCycle[2].Metadata.State = proto.SegmentState_Completed
+		secondCycle[2].Metadata.LastEntryId = 20
+		secondCycle[1].Metadata.State = proto.SegmentState_Truncated
+		secondCycle[3].Metadata.State = proto.SegmentState_Truncated
+		mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(firstCycle, nil).Once()
+		mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(secondCycle, nil).Once()
+
+		var cycleTwoSegIds []int64
+		var sawFirstCycle bool
+		mockMeta.EXPECT().UpdateSegmentMetadata(mock.Anything, "test-log", int64(1), mock.Anything, mock.Anything).
+			RunAndReturn(func(_ context.Context, _ string, _ int64, segMeta *meta.SegmentMeta, _ proto.SegmentState) error {
+				if sawFirstCycle {
+					cycleTwoSegIds = append(cycleTwoSegIds, segMeta.Metadata.SegNo)
+				}
+				return nil
+			})
+
+		require.NoError(t, logHandle.CheckAndSetSegmentTruncatedIfNeed(ctx))
+		sawFirstCycle = true
+		require.NoError(t, logHandle.CheckAndSetSegmentTruncatedIfNeed(ctx))
+
+		// Skipping costs exactly one auditor cycle: nothing is lost, the segment is
+		// truncated on the next pass.
+		assert.Equal(t, []int64{2}, cycleTwoSegIds)
+	})
+
+	t.Run("SkipsSegmentsAlreadyTruncated", func(t *testing.T) {
+		logHandle, mockMeta := createMockLogHandle(t)
+		ctx := context.Background()
+
+		segments := truncationAuditSegments()
+		segments[1].Metadata.State = proto.SegmentState_Truncated
+		segments[2].Metadata.State = proto.SegmentState_Truncated
+		segments[3].Metadata.State = proto.SegmentState_Truncated
+
+		mockMeta.EXPECT().GetLogMeta(mock.Anything, "test-log").Return(&meta.LogMeta{
+			Metadata: &proto.LogMeta{TruncatedSegmentId: 4, TruncatedEntryId: 5},
+			Revision: 1,
+		}, nil)
+		mockMeta.EXPECT().GetAllSegmentMetadata(mock.Anything, "test-log").Return(segments, nil)
+
+		// No UpdateSegmentMetadata expectation: any call is an unexpected-call failure.
+		require.NoError(t, logHandle.CheckAndSetSegmentTruncatedIfNeed(ctx))
+	})
 }


### PR DESCRIPTION
Fixes #285.

## What

`CheckAndSetSegmentTruncatedIfNeed` guarded only by segment id — everything strictly below the truncation frontier that was not already `Truncated` got rewritten, `Active` included. This restricts the transition to `Completed` and `Sealed`.

## Why it is reachable in normal operation

Single healthy writer, no takeover, no split-brain.

A roll that finds a non-empty append queue returns from `SetRollingReady` immediately without triggering completion, so `GetOrCreateWritableSegmentHandle` creates segment `N` and it starts taking writes while `N-1` is still `Active` with its completion deferred. The frontier moves into `N` within sub-second; the auditor, sampling every 10s, can catch `N-1` mid-completion. Marking it bumps the segment key's etcd revision, so completion's CAS — made against the revision the segment was created with, held across the whole fence + complete round trip — fails with `ErrMetadataRevisionInvalid`. Completion reads that as a writer takeover and fences its own `LogWriter`.

The conflicting writer is the client's own auditor goroutine, so the fence is entirely self-inflicted. On a production cluster this accounted for **every** WAL fencing observed — over one 6-hour window: 103 Active truncations, 103 revision-invalid errors, 103 fencings, against 6897 rolls of which 6412 (93%) took the deferred-completion path.

The issue has the full causal chain, a field timeline, and the two alternatives that were considered and rejected.

## The change

```go
// Only a finalized segment may be truncated. [...]
if segMetadata.Metadata.State != proto.SegmentState_Completed &&
    segMetadata.Metadata.State != proto.SegmentState_Sealed {
    continue
}
```

An allowlist rather than `!= Active`, so a future state cannot silently fall through.

## Cost

An `Active` segment below the frontier is skipped and picked up on the next auditor cycle once completion has published `Completed` — up to one auditor interval (10s) of extra GC delay, nothing else. Gaps are self-healing: every tick re-evaluates a fresh `GetSegments`.

It also keeps the resulting metadata well-formed. A segment truncated straight out of `Active` kept `LastEntryId = -1` and `CompletionTime = 0` from `storeNewSegmentMeta`, permanently losing its extent and making the GC TTL count from `CreateTime` instead of `CompletionTime`.

## Tests

New `TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_OnlyTruncatesFinalizedSegments`, three cases:

* `SkipsActiveSegmentBelowFrontier` — the regression. Asserts no update is issued for the `Active` segment and that no transition originates from `Active`. Since the fencing is caused precisely by that write bumping the revision, asserting the write does not happen is the same as asserting the completion cannot be made to lose.
* `PicksUpTheSegmentOnceCompletionPublishesCompleted` — two consecutive cycles, proving the skip costs exactly one cycle and loses nothing.
* `SkipsSegmentsAlreadyTruncated` — no `UpdateSegmentMetadata` expectation, so any call fails as unexpected.

Verified the new test fails on the unfixed code:

```
--- FAIL: .../SkipsActiveSegmentBelowFrontier
    Error: []int64{1, 2, 3} should not contain 2
    Error: []proto.SegmentState{2, 0, 3} should not contain 0     # 0 == Active
```

Two existing tests asserted the old behaviour and are updated to the intent they were actually covering:

* `_WithActiveSeg` -> `_SkipsFrontierAndLaterSegments`. Its real coverage is the id-based skips of the frontier segment and everything after it; its below-frontier segment moves from `Active` to `Sealed` so it no longer depends on the illegal transition.
* `_UpdateError` — its below-frontier segment moves from `Active` to `Completed` so the update-error branch is still exercised.

Local run (matching the CI unit-test invocation):

```
go test -race -short -failfast -timeout=20m ./woodpecker/log/... ./woodpecker/segment/... ./meta/...
ok  github.com/zilliztech/woodpecker/woodpecker/log      28.830s
ok  github.com/zilliztech/woodpecker/woodpecker/segment  41.493s
ok  github.com/zilliztech/woodpecker/meta                17.735s
```

`tests/integration/e2e_truncate_test.go` calls `CheckAndSetSegmentTruncatedIfNeed` directly to persist Truncated state, but writes synchronously with `logWriter.Write` and only checks after all writes are done, so every segment below its truncation point is long since `Completed`. It needs etcd/object storage and was not run locally — the e2e workflows cover it.
