### PR TITLE
fix(topology): say when placement is unset, and never label it ""

### DIFF
--- a/common/metrics/active_segment_node_test.go
+++ b/common/metrics/active_segment_node_test.go
@@ -17,11 +17,14 @@
 package metrics
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/zilliztech/woodpecker/common/topology"
 )
 
 func TestActiveSegmentNodes_SetAndClear(t *testing.T) {
@@ -43,7 +46,9 @@ func TestActiveSegmentNodes_SetAndClear(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(nodes), count, "one series per node after set")
 	for _, n := range nodes {
-		v := testutil.ToFloat64(WpActiveSegmentNode.WithLabelValues(ns, logId, segId, n.Node, n.AZ))
+		// An unset AZ is rendered "unknown" at the metric boundary (issue #292),
+		// so that is the label the series is filed under.
+		v := testutil.ToFloat64(WpActiveSegmentNode.WithLabelValues(ns, logId, segId, n.Node, topology.LabelOrUnknown(n.AZ)))
 		assert.Equal(t, float64(1), v)
 	}
 
@@ -73,4 +78,54 @@ func TestActiveSegmentNodes_ClearAfterPlacementChange(t *testing.T) {
 	count, err = testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
 	assert.NoError(t, err)
 	assert.Equal(t, 0, count, "all series for the segment removed")
+}
+
+// Issue #292: an unset AZ reached the metric as az="", which is structurally
+// indistinguishable from a recorded placement on a dashboard — a misconfigured
+// cluster looked fine and said nothing for 49 days. The blank label must not be
+// emitted at all; "unknown" is the same word Scope already uses for it.
+func TestActiveSegmentNodes_UnsetAZIsUnknownNeverBlank(t *testing.T) {
+	WpActiveSegmentNode.Reset()
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(WpActiveSegmentNode)
+
+	ns, logId, segId := "bucket/root", "42", "7"
+	SetActiveSegmentNodes(ns, logId, segId, []ActiveSegmentNode{
+		{Node: "10.0.0.1:8000", AZ: ""},
+		{Node: "10.0.0.2:8000", AZ: "us-west-2a"},
+	})
+
+	// The gathered label values are asserted rather than the collector's keys,
+	// because the exposed label is what a dashboard groups by, and that is what
+	// was wrong.
+	families, err := reg.Gather()
+	assert.NoError(t, err)
+
+	var azValues []string
+	for _, family := range families {
+		if family.GetName() != "woodpecker_client_active_segment_node" {
+			continue
+		}
+		for _, m := range family.GetMetric() {
+			for _, label := range m.GetLabel() {
+				if label.GetName() == "az" {
+					azValues = append(azValues, label.GetValue())
+				}
+			}
+		}
+	}
+	sort.Strings(azValues)
+
+	assert.Equal(t, []string{"unknown", "us-west-2a"}, azValues,
+		"an unset AZ is reported as unknown, a real one passes through, and neither is blank")
+	assert.NotContains(t, azValues, "", "a blank az label is never emitted")
+
+	// And the series is reachable under "unknown" rather than under "".
+	assert.Equal(t, float64(1),
+		testutil.ToFloat64(WpActiveSegmentNode.WithLabelValues(ns, logId, segId, "10.0.0.1:8000", "unknown")))
+
+	count, err := testutil.GatherAndCount(reg, "woodpecker_client_active_segment_node")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, count, "one series per node, and normalising did not split one in two")
 }

--- a/common/metrics/client_metrics.go
+++ b/common/metrics/client_metrics.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/zilliztech/woodpecker/common/topology"
 )
 
 // Client metrics are initialized at package level so they are always safe to use.
@@ -398,7 +400,7 @@ func setMonotonicFrontier(frontiers map[string]progressFrontier, segmentGauge, e
 
 // ActiveSegmentNode is one replica of a log's current writable segment: the
 // node's endpoint and the availability zone it sits in (empty when the quorum
-// metadata carries no placement for it).
+// metadata carries no placement for it, which reaches the metric as "unknown").
 type ActiveSegmentNode struct {
 	Node string
 	AZ   string
@@ -406,9 +408,16 @@ type ActiveSegmentNode struct {
 
 // SetActiveSegmentNodes marks each node of an active (writable) segment's quorum
 // with a value of 1 (one series per node). Call when a segment becomes writable.
+//
+// The az label goes through topology.LabelOrUnknown, at the metric boundary
+// rather than at each caller: an unset AZ arrives here from two directions —
+// a server that registered with no placement, and a quorum entry with no
+// placement recorded for that node at all — and `az=""` looks identical to a
+// real value on a dashboard. Normalising here means no future caller can
+// reintroduce the blank label by forgetting to.
 func SetActiveSegmentNodes(logNs, logId, segmentId string, nodes []ActiveSegmentNode) {
 	for _, node := range nodes {
-		WpActiveSegmentNode.WithLabelValues(logNs, logId, segmentId, node.Node, node.AZ).Set(1)
+		WpActiveSegmentNode.WithLabelValues(logNs, logId, segmentId, node.Node, topology.LabelOrUnknown(node.AZ)).Set(1)
 	}
 }
 

--- a/common/topology/topology_utils.go
+++ b/common/topology/topology_utils.go
@@ -54,3 +54,38 @@ func GetCurrentRegion() string {
 func GetCurrentAvailabilityZone() string {
 	return envOrDefault(AvailabilityZoneEnvKey, "")
 }
+
+// LabelOrUnknown renders a placement value for use as a metric label.
+//
+// The empty string is never emitted. A series carrying `az=""` is structurally
+// indistinguishable from one whose placement is genuinely recorded, so a
+// misconfigured deployment produced dashboards that looked fine and said
+// nothing — for 49 days, in the case that prompted this. `unknown` is the same
+// word Scope already uses for the same condition, so the two agree.
+//
+// This is a rendering decision, not a validation one: placement stays optional,
+// and MissingPlacementEnv is what says so out loud at startup.
+func LabelOrUnknown(value string) string {
+	if value == "" {
+		return ScopeUnknown
+	}
+	return value
+}
+
+// MissingPlacementEnv returns the placement environment variables that are
+// unset, in a stable order, so a caller can name them in a startup warning.
+//
+// Deliberately not an error. Placement is genuinely optional for a single-AZ
+// deployment, and refusing to start would break those — but a process that
+// cannot tell local from remote should say so once, loudly, rather than
+// reporting `unknown` forever and leaving somebody to notice from a dashboard.
+func MissingPlacementEnv() []string {
+	var missing []string
+	if os.Getenv(RegionEnvKey) == "" {
+		missing = append(missing, RegionEnvKey)
+	}
+	if os.Getenv(AvailabilityZoneEnvKey) == "" {
+		missing = append(missing, AvailabilityZoneEnvKey)
+	}
+	return missing
+}

--- a/common/topology/topology_utils_test.go
+++ b/common/topology/topology_utils_test.go
@@ -48,3 +48,52 @@ func TestScope(t *testing.T) {
 		})
 	}
 }
+
+// Issue #292: an unset REGION/AVAILABILITY_ZONE became an empty metric label,
+// which is indistinguishable from a recorded placement on a dashboard.
+func TestLabelOrUnknown(t *testing.T) {
+	assert.Equal(t, ScopeUnknown, LabelOrUnknown(""), "an unset placement renders as unknown")
+	assert.Equal(t, "us-west-2a", LabelOrUnknown("us-west-2a"), "a real placement is unchanged")
+	// Deliberately the word Scope already reports for the same condition, so a
+	// dashboard grouping by az and one reading scope agree with each other
+	// rather than inventing a second spelling of "we do not know".
+	assert.Equal(t, "unknown", ScopeUnknown)
+}
+
+// Placement stays optional — this reports, it does not refuse.
+func TestMissingPlacementEnv(t *testing.T) {
+	t.Run("both unset", func(t *testing.T) {
+		t.Setenv(RegionEnvKey, "")
+		t.Setenv(AvailabilityZoneEnvKey, "")
+		assert.Equal(t, []string{RegionEnvKey, AvailabilityZoneEnvKey}, MissingPlacementEnv())
+	})
+
+	t.Run("region unset only", func(t *testing.T) {
+		t.Setenv(RegionEnvKey, "")
+		t.Setenv(AvailabilityZoneEnvKey, "us-west-2a")
+		assert.Equal(t, []string{RegionEnvKey}, MissingPlacementEnv())
+	})
+
+	t.Run("az unset only", func(t *testing.T) {
+		t.Setenv(RegionEnvKey, "us-west-2")
+		t.Setenv(AvailabilityZoneEnvKey, "")
+		assert.Equal(t, []string{AvailabilityZoneEnvKey}, MissingPlacementEnv())
+	})
+
+	t.Run("both set is silent", func(t *testing.T) {
+		t.Setenv(RegionEnvKey, "us-west-2")
+		t.Setenv(AvailabilityZoneEnvKey, "us-west-2a")
+		assert.Empty(t, MissingPlacementEnv(), "a configured process warns about nothing")
+	})
+
+	// CLUSTER_NAME has a real default and is deliberately not part of this:
+	// reporting it would make the warning fire on every correctly configured
+	// single-cluster deployment, which is how warnings get ignored.
+	t.Run("cluster name is not placement", func(t *testing.T) {
+		t.Setenv(ClusterNameEnvKey, "")
+		t.Setenv(RegionEnvKey, "us-west-2")
+		t.Setenv(AvailabilityZoneEnvKey, "us-west-2a")
+		assert.Empty(t, MissingPlacementEnv())
+		assert.Equal(t, DefaultClusterNameValue, GetCurrentClusterName())
+	})
+}

--- a/server/service.go
+++ b/server/service.go
@@ -95,6 +95,21 @@ type NodeStatus struct {
 
 // NewServer creates a new server instance with same bind/advertise ip/port
 func NewServer(ctx context.Context, configuration *config.Configuration, bindPort int, servicePort int, gossipSeeds []string) (*Server, error) {
+	// Placement is optional — a single-AZ deployment legitimately sets neither
+	// — but it is registered into gossip and persisted into every QuorumInfo
+	// this node joins, so an unset value is not a local matter. Said once here
+	// rather than left to be inferred from a dashboard full of "unknown".
+	if missing := topology.MissingPlacementEnv(); len(missing) > 0 {
+		logger.Ctx(ctx).Warn("topology placement is not configured; this node registers with no region/az and cannot classify peers as local or remote",
+			zap.Strings("unset", missing),
+			zap.String("clusterName", topology.GetCurrentClusterName()))
+	} else {
+		logger.Ctx(ctx).Info("topology placement",
+			zap.String("clusterName", topology.GetCurrentClusterName()),
+			zap.String("region", topology.GetCurrentRegion()),
+			zap.String("az", topology.GetCurrentAvailabilityZone()))
+	}
+
 	return NewServerWithConfig(ctx, configuration, &membership.ServerConfig{
 		NodeID:               "", // Will be set in Prepare()
 		BindPort:             bindPort,

--- a/woodpecker/woodpecker_client.go
+++ b/woodpecker/woodpecker_client.go
@@ -29,6 +29,7 @@ import (
 	"github.com/zilliztech/woodpecker/common/logger"
 	"github.com/zilliztech/woodpecker/common/metrics"
 	storageclient "github.com/zilliztech/woodpecker/common/objectstorage"
+	"github.com/zilliztech/woodpecker/common/topology"
 	"github.com/zilliztech/woodpecker/common/tracer"
 	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/meta"
@@ -113,6 +114,19 @@ func NewClient(ctx context.Context, cfg *config.Configuration, etcdClient *clien
 	initTraceErr := tracer.InitTracer(cfg, "woodpecker", 1001)
 	if initTraceErr != nil {
 		logger.Ctx(ctx).Warn("init tracer failed", zap.Error(initTraceErr))
+	}
+	// The client reads its own REGION/AVAILABILITY_ZONE to work out how far each
+	// replica sits from it. Unset, every peer classifies as ScopeUnknown, so the
+	// per-replica traffic metrics stop distinguishing local from cross-region
+	// while still looking well-formed. Warned separately from the server: the
+	// two are configured independently and either can be the one that is wrong.
+	if missing := topology.MissingPlacementEnv(); len(missing) > 0 {
+		logger.Ctx(ctx).Warn("topology placement is not configured; this client cannot classify replicas as local, cross-az or cross-region",
+			zap.Strings("unset", missing))
+	} else {
+		logger.Ctx(ctx).Info("topology placement",
+			zap.String("region", topology.GetCurrentRegion()),
+			zap.String("az", topology.GetCurrentAvailabilityZone()))
 	}
 	clientPool := client.NewLogStoreClientPool(cfg.Woodpecker.Logstore.GRPCConfig.GetClientMaxSendSize(), cfg.Woodpecker.Logstore.GRPCConfig.GetClientMaxRecvSize())
 	c := &woodpeckerClient{


### PR DESCRIPTION
Fixes #292

Two changes, both keeping placement optional — you were right that failing hard is too strong, and a single-AZ deployment legitimately sets neither variable.

## 1. Say it out loud, once

`MissingPlacementEnv()` reports which of `REGION` / `AVAILABILITY_ZONE` are unset. The **server** and the **client** each warn at startup naming them, or log the values when set:

```
WARN  topology placement is not configured; this node registers with no
      region/az and cannot classify peers as local or remote
      {"unset": ["REGION", "AVAILABILITY_ZONE"], "clusterName": "default"}
```

Warned separately on the two sides because they are configured independently and either can be the one that is wrong — your UAT case was server-side, but a client missing its own placement silently degrades every per-replica scope to `unknown` in exactly the same way.

**`CLUSTER_NAME` is deliberately excluded.** It has a real default (`"default"`), so including it would fire the warning on every correctly configured single-cluster deployment — which is how warnings get ignored. There's a test pinning that.

## 2. Never emit `az=""`

`LabelOrUnknown` renders an unset value as `"unknown"` — the word `Scope` already uses for the same condition, so a dashboard grouping by `az` and one reading scope agree rather than carrying two spellings of "we do not know".

Applied at the **metric boundary** in `SetActiveSegmentNodes`, not at each caller. An unset AZ arrives there from two directions — a server that registered with no placement, and a quorum entry with no placement recorded for that node — and normalising once means a later caller cannot reintroduce the blank by forgetting to.

This changes one existing assertion: `TestActiveSegmentNodes_SetAndClear` looked its third node up under `AZ: ""`, which is precisely the behaviour being fixed, so it now looks it up where the series actually is. Flagging it rather than letting it look like incidental churn.

## Two parts of the issue I did not implement, and why

**The dashboard panel already exists.** The issue says the client templates have *"no placement panel — nothing groups by `az` at all"*. Both `dashboard_client.json` and `dashboard_client_k8s.json` already carry **"Active Segment Replicas by AZ"** (panel id 111) running exactly the query proposed:

```promql
count by (az) (woodpecker_client_active_segment_node{...})
```

It landed in **#270** (`enhance(metrics): make per-replica and cross-AZ client traffic observable`), and `dashboard-configmaps.yaml` is already in sync with both. So there is nothing to add — and with change (2) above, that panel now shows a single `unknown` bucket instead of a blank one, which is what the issue wants it to show. I'd rather say this than add a duplicate panel.

**The alert rule needs infrastructure that isn't there yet.** No rule files exist in the repo, `tests/docker/monitor/prometheus.yml` has no `rule_files:`, and `kube-prometheus-values.yaml` sets `alertmanager: { enabled: false }`. Adding the rule means introducing alerting to both monitor stacks — a larger decision than this fix, and one I didn't want to make unilaterally inside a bug fix. Happy to take it as a follow-up if you want it.

## Verification

Both changes mutation-checked rather than only run green:

| mutation | result |
|---|---|
| `LabelOrUnknown` returns its argument unchanged | **2 red** — `TestLabelOrUnknown`, `TestActiveSegmentNodes_UnsetAZIsUnknownNeverBlank` |
| `MissingPlacementEnv` returns `nil` | **3 red** — both-unset, region-only, az-only; the "both set is silent" control stays green |

The metric test asserts the **gathered label values**, not the collector's keys, since the exposed label is what a dashboard groups by and that is what was wrong.

`go build ./...`, `go vet`, `gofmt -l` clean. `./common/topology` and `./common/metrics` pass. The dashboard validation and config-map sync tests (`./tests/k8s/monitor`) pass unchanged.

`./common/objectstorage` fails on this machine for want of a reachable MinIO — it does the same on `master`, so it is environmental rather than from this change.
