### PR TITLE
fix(metrics): drop the per-reader label from the reader bytes counter

### DIFF
--- a/common/metrics/client_metrics.go
+++ b/common/metrics/client_metrics.go
@@ -151,7 +151,7 @@ var (
 		Subsystem: clientRole,
 		Name:      "reader_bytes_read",
 		Help:      "Total bytes read by log readers",
-	}, []string{"log_ns", "log_id", "reader_name"})
+	}, []string{"log_ns", "log_id"})
 	WpLogReaderOperationLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: woodpeckerNamespace,
 		Subsystem: clientRole,

--- a/common/metrics/reader_bytes_read_test.go
+++ b/common/metrics/reader_bytes_read_test.go
@@ -1,0 +1,66 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Readers are short-lived and are recreated constantly — a recovery reader is
+// rebuilt on every scanner restart — so the bytes counter must not carry the
+// reader's identity. Doing so created one permanent series per reader ever
+// opened, and it also lost the bytes of any reader that finished within a
+// single scrape interval. Aggregating per log fixes both.
+func TestReaderBytesRead_AggregatesAcrossReaders(t *testing.T) {
+	WpLogReaderBytesRead.Reset()
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(WpLogReaderBytesRead)
+
+	ns, logId := "bucket/root", "42"
+
+	// Three readers over the life of one log, as scanner restarts would produce.
+	for _, n := range []float64{100, 250, 30} {
+		WpLogReaderBytesRead.WithLabelValues(ns, logId).Add(n)
+	}
+
+	count, err := testutil.GatherAndCount(reg, "woodpecker_client_reader_bytes_read")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count, "one series per log regardless of how many readers ran")
+	assert.Equal(t, float64(380), testutil.ToFloat64(WpLogReaderBytesRead.WithLabelValues(ns, logId)))
+
+	// The label set is the actual regression guard: re-adding a per-reader label
+	// compiles fine and silently reintroduces the unbounded series growth.
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	var labelNames []string
+	for _, f := range families {
+		if f.GetName() != "woodpecker_client_reader_bytes_read" {
+			continue
+		}
+		require.NotEmpty(t, f.GetMetric())
+		for _, l := range f.GetMetric()[0].GetLabel() {
+			labelNames = append(labelNames, l.GetName())
+		}
+	}
+	assert.ElementsMatch(t, []string{"log_ns", "log_id"}, labelNames, "label set must stay per-log")
+}

--- a/tests/docker/monitor/README.md
+++ b/tests/docker/monitor/README.md
@@ -111,7 +111,7 @@ tests/monitor/
 |---|---|---|---|---|
 | `woodpecker_client_read_requests_total` | Counter | log_id | Total read requests | Read QPS |
 | `woodpecker_client_read_entries_total` | Counter | log_id | Total entries read | Read throughput (entries) |
-| `woodpecker_client_reader_bytes_read` | Counter | log_id, reader_name | Bytes read | Read throughput (bytes) |
+| `woodpecker_client_reader_bytes_read` | Counter | log_id | Bytes read | Read throughput (bytes) |
 | `woodpecker_client_reader_operation_latency` | Histogram | log_id, operation, status | Reader operation latency | Read latency P50/P99 |
 
 ### LogHandle / SegmentHandle Module

--- a/woodpecker/log/log_reader.go
+++ b/woodpecker/log/log_reader.go
@@ -165,7 +165,7 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 			l.next += 1
 			l.lastRead = time.Now().UnixMilli() // Update last read timestamp
 			metrics.WpClientReadEntriesTotal.WithLabelValues(l.logNs, l.logIdStr).Inc()
-			metrics.WpLogReaderBytesRead.WithLabelValues(l.logNs, l.logIdStr, l.readerName).Add(float64(len(readEntryData.Values)))
+			metrics.WpLogReaderBytesRead.WithLabelValues(l.logNs, l.logIdStr).Add(float64(len(readEntryData.Values)))
 			metrics.WpClientReadLatency.WithLabelValues(l.logNs, l.logIdStr).Observe(float64(time.Since(start).Milliseconds()))
 			metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "success").Observe(float64(time.Since(start).Milliseconds()))
 			return logMsg, nil
@@ -268,7 +268,7 @@ func (l *logBatchReaderImpl) ReadNext(ctx context.Context) (*LogMessage, error) 
 
 		// update metrics
 		metrics.WpClientReadEntriesTotal.WithLabelValues(l.logNs, l.logIdStr).Inc()
-		metrics.WpLogReaderBytesRead.WithLabelValues(l.logNs, l.logIdStr, l.readerName).Add(float64(len(oneEntry.Values)))
+		metrics.WpLogReaderBytesRead.WithLabelValues(l.logNs, l.logIdStr).Add(float64(len(oneEntry.Values)))
 		metrics.WpClientReadLatency.WithLabelValues(l.logNs, l.logIdStr).Observe(float64(time.Since(start).Milliseconds()))
 		metrics.WpLogReaderOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "read_next", "success").Observe(float64(time.Since(start).Milliseconds()))
 		return logMsg, nil


### PR DESCRIPTION
Closes #293.

`reader_bytes_read` carried `reader_name`, which holds a unique per-reader id
(`…-r-recovery-1788429671580630447`). Nothing ever deleted those series, so one
accumulated for every reader ever opened and stayed for the life of the process —
readers are rebuilt on every scanner restart, and a backoff loop produces several
a minute. Nothing queried the label either: both dashboards already aggregate it
away with `sum(rate(...)) by (log_id)`.

Removing the label rather than deleting the series on close also closes a gap. A
reader that lives less than one scrape interval produced a series that was never
scraped at all, so the bytes it read were lost from the record entirely — scanner
backoff produces exactly that kind of reader. Aggregated per log they are counted
like any others.

The per-reader dimension belongs on a gauge rather than a counter; #290 adds the
reader's position there and deletes it on close.

## Changes

- `common/metrics/client_metrics.go` — drop `reader_name` from the label set
- `woodpecker/log/log_reader.go` — the two increment sites
- `tests/docker/monitor/README.md` — label column
- `common/metrics/reader_bytes_read_test.go` — new test

## Note for the reviewer

**No dashboard change is needed and none is included** — both panels already
aggregate over `reader_name` and keep working unchanged. Flagging this so the
absence is not read as an omission.

The test's real guard is the assertion on the **label set itself**: re-adding a
per-reader label compiles fine and would silently reintroduce the growth, so
counting series alone would not catch it.

## Release note

Removing a label changes series identity, so `sum(rate(woodpecker_client_reader_bytes_read))`
shows a one-scrape discontinuity across the deploy. Both existing panels use
`rate`, so it is a single blip rather than a reset — worth mentioning in the
changelog so nobody reads it as an incident.

## Verification

- `gofmt` clean, `go vet ./common/metrics/ ./woodpecker/log/` clean, `go build ./...` ok
- `go test ./common/metrics/` ok
- `go test ./woodpecker/log/` ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNe2heiUwYkqt67PosjiXi
