### PR TITLE
fix(log): marshal the message before taking the writable segment handle

### DIFF
--- a/woodpecker/log/internal_log_writer.go
+++ b/woodpecker/log/internal_log_writer.go
@@ -162,12 +162,6 @@ func (l *internalLogWriterImpl) Write(ctx context.Context, msg *WriteMessage) *W
 		}
 		close(ch)
 	}
-	writableSegmentHandle, err := l.logHandle.GetOrCreateWritableSegmentHandle(ctx, l.onWriterInvalidated)
-	if err != nil {
-		callback(-1, -1, err)
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
-		return <-ch
-	}
 	bytes, err := MarshalMessage(msg)
 	if err != nil {
 		logger.Ctx(ctx).Warn("serialize message failed", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Error(err))
@@ -176,6 +170,13 @@ func (l *internalLogWriterImpl) Write(ctx context.Context, msg *WriteMessage) *W
 			LogMessageId: nil,
 			Err:          err,
 		}
+	}
+
+	writableSegmentHandle, err := l.logHandle.GetOrCreateWritableSegmentHandle(ctx, l.onWriterInvalidated)
+	if err != nil {
+		callback(-1, -1, err)
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
+		return <-ch
 	}
 
 	writableSegmentHandle.AppendAsync(ctx, bytes, callback)

--- a/woodpecker/log/log_writer.go
+++ b/woodpecker/log/log_writer.go
@@ -239,12 +239,6 @@ func (l *logWriterImpl) Write(ctx context.Context, msg *WriteMessage) *WriteResu
 		}
 		close(ch)
 	}
-	writableSegmentHandle, err := l.logHandle.GetOrCreateWritableSegmentHandle(ctx, l.onWriterInvalidated)
-	if err != nil {
-		callback(-1, -1, err)
-		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
-		return <-ch
-	}
 	bytes, err := MarshalMessage(msg)
 	if err != nil {
 		logger.Ctx(ctx).Warn("serialize message failed", zap.String("logName", l.logHandle.GetName()), zap.Int64("logId", l.logHandle.GetId()), zap.Error(err))
@@ -253,6 +247,13 @@ func (l *logWriterImpl) Write(ctx context.Context, msg *WriteMessage) *WriteResu
 			LogMessageId: nil,
 			Err:          err,
 		}
+	}
+
+	writableSegmentHandle, err := l.logHandle.GetOrCreateWritableSegmentHandle(ctx, l.onWriterInvalidated)
+	if err != nil {
+		callback(-1, -1, err)
+		metrics.WpLogWriterOperationLatency.WithLabelValues(l.logNs, l.logIdStr, "write", "error").Observe(float64(time.Since(start).Milliseconds()))
+		return <-ch
 	}
 
 	writableSegmentHandle.AppendAsync(ctx, bytes, callback)

--- a/woodpecker/log/log_writer_test.go
+++ b/woodpecker/log/log_writer_test.go
@@ -2620,3 +2620,52 @@ func TestMonitorSession_CheckAlive_Success(t *testing.T) {
 		t.Fatal("monitorSession did not exit after writerClose")
 	}
 }
+
+// The writable segment handle is perishable: another writer can roll the segment
+// as soon as GetOrCreateWritableSegmentHandle releases the log handle lock, and
+// AppendAsync on a rolled handle is rejected with ErrSegmentHandleSegmentRolling.
+// Marshalling the payload while holding one stretches that window from a function
+// call to a multi-megabyte proto.Marshal, so appends get rejected for no reason.
+//
+// A message that cannot be marshalled pins the ordering down without racing
+// anything: if the handle is acquired first, the mock records the call even
+// though the write can never proceed. Both WriteAsync paths already marshal
+// first; this keeps the synchronous ones aligned with them.
+func TestWrite_MarshalsBeforeAcquiringWritableHandle(t *testing.T) {
+	// ValidateMsg rejects a message whose Properties and Payload are both empty.
+	invalid := &WriteMessage{}
+
+	newMockHandle := func() *testLogHandleMock {
+		m := &testLogHandleMock{}
+		m.Test(t)
+		m.On("GetName").Return("test-log").Maybe()
+		m.On("GetId").Return(int64(1)).Maybe()
+		// Allowed but not required, so a regression fails on the assertion below
+		// rather than panicking on an unstubbed call.
+		m.On("GetOrCreateWritableSegmentHandle", mock.Anything, mock.Anything).
+			Return(mocks_segment_handle.NewSegmentHandle(t), nil).Maybe()
+		return m
+	}
+
+	t.Run("internalLogWriter", func(t *testing.T) {
+		mockLogHandle := newMockHandle()
+		w := createTestInternalWriter(t, mockLogHandle, nil)
+
+		result := w.Write(context.Background(), invalid)
+
+		require.NotNil(t, result)
+		assert.Error(t, result.Err)
+		mockLogHandle.AssertNotCalled(t, "GetOrCreateWritableSegmentHandle", mock.Anything, mock.Anything)
+	})
+
+	t.Run("logWriter", func(t *testing.T) {
+		mockLogHandle := newMockHandle()
+		w := createTestSessionWriter(t, mockLogHandle, nil, meta.NewSessionLockForTest(nil))
+
+		result := w.Write(context.Background(), invalid)
+
+		require.NotNil(t, result)
+		assert.Error(t, result.Err)
+		mockLogHandle.AssertNotCalled(t, "GetOrCreateWritableSegmentHandle", mock.Anything, mock.Anything)
+	})
+}


### PR DESCRIPTION
Closes #288.

`GetOrCreateWritableSegmentHandle` returns a **perishable** reference: it takes
the log handle lock, decides whether to roll, and releases the lock before
returning. Another writer goroutine can roll that segment immediately
afterwards, and `AppendAsync` on the stale handle is then rejected with
`ErrSegmentHandleSegmentRolling`.

Both synchronous `Write` implementations did the payload marshal **inside** that
window. `MarshalMessage` is `proto.Marshal` over the payload — pure CPU that does
not need the handle at all — and for a multi-megabyte message it stretches a
window that should be one function call into milliseconds. Field rates from a
deployment writing ~2.7 MiB messages imply a window around 16 ms, and every
rejection it produced was avoidable: the append had not been enqueued, and
re-fetching the handle would have returned the new segment immediately.

Both `WriteAsync` implementations already marshal first — they have to, since
their callback captures the marshalled bytes — so this only aligns the
synchronous paths with the correct ordering already present in the same files.

## Changes

- `woodpecker/log/internal_log_writer.go` — `Write`: marshal moved above the handle acquisition
- `woodpecker/log/log_writer.go` — `Write`: same
- `woodpecker/log/log_writer_test.go` — new ordering test

`WriteAsync` is untouched on both implementations. After this all four paths
share the same order: marshal → acquire handle → `AppendAsync`.

## Why this is safe

Verified on the current code:

1. **The callback does not capture `bytes`** in either synchronous `Write` — it is
   referenced only at the `AppendAsync` call and afterwards in the outer scope.
   (This is precisely why `WriteAsync` *must* marshal first: its callback *does*
   use `bytes`, for `WpLogWriterBytesWritten`.)
2. **No fail-fast is lost** — both functions already check writer validity
   (`isWriterValid` / `sessionLock.IsValid()`) at the top, before either operation.
3. **`MarshalMessage` has no dependency on the handle.**

One behavioural difference: a message that is both malformed *and* racing a failed
handle acquisition now reports the serialization error first. `ValidateMsg` failure
is a deterministic caller bug that no retry can fix, so reporting it first is the
more useful of the two — and it avoids doing rolling work for a message that can
never be written.

## About the test

`TestWrite_MarshalsBeforeAcquiringWritableHandle` pins the ordering down **without
racing anything**: it writes a message that cannot be marshalled (`&WriteMessage{}`,
which `ValidateMsg` rejects) and asserts `GetOrCreateWritableSegmentHandle` was
never called. If the handle is acquired first, the mock records the call even
though the write can never proceed.

I verified it actually catches the regression — reverting only the two source files
to the previous ordering and keeping the test:

```
--- FAIL: TestWrite_MarshalsBeforeAcquiringWritableHandle/internalLogWriter
        Error: Should not have called with given arguments
--- FAIL: TestWrite_MarshalsBeforeAcquiringWritableHandle/logWriter
        Error: Should not have called with given arguments
```

Both subtests fail on the old ordering and pass on the new one. A concurrency-based
test was considered and rejected: it would be inherently flaky, whereas this is
deterministic and runs in milliseconds.

## Verification

- `gofmt` clean, `go vet ./woodpecker/log/` clean, `go build ./...` ok
- `go test ./woodpecker/log/` ok (full package, 56s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNe2heiUwYkqt67PosjiXi
