### PR TITLE
enhance(metrics): measure the writable-segment handoff every append passes through

### DIFF
--- a/common/metrics/client_metrics.go
+++ b/common/metrics/client_metrics.go
@@ -121,7 +121,12 @@ var (
 		Subsystem: clientRole,
 		Name:      "log_handle_operation_latency",
 		Help:      "Latency of log handle operations",
-		Buckets:   prometheus.ExponentialBuckets(1, 2, 10), // 1ms to 1024ms
+		// 1ms to 512ms. The third argument is the bucket COUNT, not an exponent:
+		// the first bucket's upper bound is `start` itself, so ten buckets run
+		// 1, 2, 4 ... 2^9 = 512 - reaching 1024 would take eleven. Slower samples
+		// land in the implicit +Inf bucket, and a quantile that falls there reads
+		// as a flat 512 however slow the operation actually was.
+		Buckets: prometheus.ExponentialBuckets(1, 2, 10),
 	}, []string{"log_ns", "log_id", "operation", "status"})
 
 	// Client read metrics

--- a/tests/docker/monitor/README.md
+++ b/tests/docker/monitor/README.md
@@ -119,6 +119,7 @@ tests/monitor/
 | Metric Name | Type | Labels | Description | Key Design Metric |
 |---|---|---|---|---|
 | `woodpecker_client_log_handle_operations_total` | Counter | log_id, operation, status | LogHandle operation count | Metadata operation success rate |
+| `woodpecker_client_log_handle_operation_latency` | Histogram | log_id, operation, status | LogHandle operation latency | Cost of the writable-segment handoff every append passes through |
 | `woodpecker_client_segment_handle_operations_total` | Counter | log_id, operation, status | Segment operation count | Segment rolling/close frequency |
 | `woodpecker_client_segment_handle_pending_append_ops` | Gauge | log_id | Pending append operations | Write backpressure observation |
 | `woodpecker_client_writer_bytes_written` | Counter | log_id | Writer bytes written | Per-writer throughput |

--- a/tests/docker/monitor/grafana/templates/dashboard_client.json
+++ b/tests/docker/monitor/grafana/templates/dashboard_client.json
@@ -1167,12 +1167,125 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 75
+      },
+      "id": 112,
+      "title": "Log Handle Operations",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_log_handle_operations_total{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
+          "legendFormat": "op={{operation}} status={{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Handle Ops Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "id": 114,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_log_handle_operation_latency_bucket{woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (operation, le))",
+          "legendFormat": "op={{operation}} P99",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Handle Op Latency P99",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 84
       },
       "id": 8,
       "panels": [

--- a/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
+++ b/tests/k8s/monitor/grafana/templates/dashboard_client_k8s.json
@@ -1167,12 +1167,125 @@
       "type": "timeseries"
     },
     {
-      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 75
+      },
+      "id": 112,
+      "title": "Log Handle Operations",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 76
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(woodpecker_client_log_handle_operations_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
+          "legendFormat": "op={{operation}} status={{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Handle Ops Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheus}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "id": 114,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_log_handle_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (operation, le))",
+          "legendFormat": "op={{operation}} P99",
+          "refId": "A"
+        }
+      ],
+      "title": "Log Handle Op Latency P99",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 84
       },
       "id": 8,
       "panels": [

--- a/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
+++ b/tests/k8s/monitor/manifests/dashboard-configmaps.yaml
@@ -4636,12 +4636,125 @@ data:
           "type": "timeseries"
         },
         {
-          "collapsed": true,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
             "y": 75
+          },
+          "id": 112,
+          "title": "Log Handle Operations",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 76
+          },
+          "id": 113,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "sum(rate(woodpecker_client_log_handle_operations_total{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (operation, status)",
+              "legendFormat": "op={{operation}} status={{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Log Handle Ops Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "lineWidth": 2,
+                "pointSize": 5,
+                "showPoints": "auto",
+                "spanNulls": false
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 76
+          },
+          "id": 114,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull",
+                "max",
+                "mean"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum(rate(woodpecker_client_log_handle_operation_latency_bucket{namespace=~\"$namespace\", woodpecker_id=~\"$woodpecker_id\", log_ns=~\"$log_ns\"}[1m])) by (operation, le))",
+              "legendFormat": "op={{operation}} P99",
+              "refId": "A"
+            }
+          ],
+          "title": "Log Handle Op Latency P99",
+          "type": "timeseries"
+        },
+        {
+          "collapsed": true,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 84
           },
           "id": 8,
           "panels": [

--- a/woodpecker/log/log_handle.go
+++ b/woodpecker/log/log_handle.go
@@ -459,9 +459,35 @@ func (l *logHandleImpl) fenceAllActiveSegments(ctx context.Context) error {
 	return nil
 }
 
-func (l *logHandleImpl) GetOrCreateWritableSegmentHandle(ctx context.Context, writerInvalidationNotifier func(ctx context.Context, reason string)) (segment.SegmentHandle, error) {
+func (l *logHandleImpl) GetOrCreateWritableSegmentHandle(ctx context.Context, writerInvalidationNotifier func(ctx context.Context, reason string)) (segHandle segment.SegmentHandle, retErr error) {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, LogHandleScopeName, "GetOrCreateWritableSegmentHandle")
 	defer sp.End()
+
+	// Every append passes through here, and the log handle lock makes this the only
+	// serialization point on that path. Time it from entry rather than from the
+	// point the lock is acquired: a caller parked at the mutex behind a roll then
+	// shows up as a slow cached lookup, and that wait is what a blocked append
+	// actually experiences -- it is visible nowhere else today.
+	//
+	// The three paths cost wildly different amounts (a map lookup; an etcd write;
+	// an etcd write plus a completion that is synchronous when the append queue
+	// happens to be empty), so each carries its own operation label. Averaging them
+	// would bury the expensive ones under the cheap path's call volume, which is
+	// exactly the mistake that made rolling cost look negligible.
+	start := time.Now()
+	logIdStr := strconv.FormatInt(l.Id, 10)
+	op := "get_or_create_writable_segment"
+	defer func() {
+		// Registered before `defer l.Unlock()` below, so LIFO ordering runs this
+		// after the lock is released: the observation costs the critical section
+		// nothing.
+		status := "success"
+		if retErr != nil {
+			status = "error"
+		}
+		metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, logIdStr, op, status).Inc()
+		metrics.WpLogHandleOperationLatency.WithLabelValues(l.logNs, logIdStr, op, status).Observe(float64(time.Since(start).Milliseconds()))
+	}()
 
 	l.Lock()
 	defer l.Unlock()
@@ -470,6 +496,7 @@ func (l *logHandleImpl) GetOrCreateWritableSegmentHandle(ctx context.Context, wr
 
 	// create new segment handle if not exists
 	if !writableExists {
+		op = "get_or_create_writable_segment_create"
 		handle, err := l.createAndCacheWritableSegmentHandle(ctx, writerInvalidationNotifier)
 		if err != nil {
 			if werr.ErrMetadataSegmentAlreadyExists.Is(err) {
@@ -488,6 +515,7 @@ func (l *logHandleImpl) GetOrCreateWritableSegmentHandle(ctx context.Context, wr
 
 	// Check if the writable segment handle needs to be rolling close and create a new one
 	if l.shouldRollingCloseAndCreateWritableSegmentHandle(ctx, writeableSegmentHandle) {
+		op = "get_or_create_writable_segment_roll"
 		logger.Ctx(ctx).Debug("start to close segment",
 			zap.String("logName", l.Name),
 			zap.Int64("logId", l.GetId()),

--- a/woodpecker/log/log_handle_test.go
+++ b/woodpecker/log/log_handle_test.go
@@ -2516,3 +2516,86 @@ func TestLogHandle_CheckAndSetSegmentTruncatedIfNeed_OnlyTruncatesFinalizedSegme
 		require.NoError(t, logHandle.CheckAndSetSegmentTruncatedIfNeed(ctx))
 	})
 }
+
+// GetOrCreateWritableSegmentHandle is the only serialization point on the append
+// path, and its three branches cost wildly different amounts: a map lookup, an
+// etcd write, or an etcd write plus a completion that is synchronous when the
+// append queue happens to be empty. They must not share one label — the cheap
+// path's call volume would bury the expensive ones, which is precisely how
+// rolling cost came to look negligible.
+func TestGetOrCreateWritableSegmentHandle_LabelsEachPath(t *testing.T) {
+	count := func(l *logHandleImpl, op, status string) float64 {
+		return testutil.ToFloat64(metrics.WpLogHandleOperationsTotal.WithLabelValues(l.logNs, "1", op, status))
+	}
+
+	t.Run("cached handle", func(t *testing.T) {
+		metrics.WpLogHandleOperationsTotal.Reset()
+		logHandle, _ := createMockLogHandle(t)
+
+		seg := mocks_segment_handle.NewSegmentHandle(t)
+		logHandle.SegmentHandles[1] = seg
+		logHandle.WritableSegmentId = 1
+		seg.EXPECT().IsForceRollingReady(mock.Anything).Return(false)
+		seg.EXPECT().GetSize(mock.Anything).Return(int64(1))
+		seg.EXPECT().GetBlocksCount(mock.Anything).Return(int64(1))
+
+		handle, err := logHandle.GetOrCreateWritableSegmentHandle(context.Background(), nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, seg, handle)
+		assert.Equal(t, float64(1), count(logHandle, "get_or_create_writable_segment", "success"))
+		assert.Equal(t, float64(0), count(logHandle, "get_or_create_writable_segment_create", "success"))
+		assert.Equal(t, float64(0), count(logHandle, "get_or_create_writable_segment_roll", "success"))
+	})
+
+	t.Run("first creation", func(t *testing.T) {
+		metrics.WpLogHandleOperationsTotal.Reset()
+		logHandle, mockMeta := createMockLogHandle(t)
+		logHandle.WritableSegmentId = -1
+		mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.Anything).Return(nil)
+
+		handle, err := logHandle.GetOrCreateWritableSegmentHandle(context.Background(), nil)
+
+		require.NoError(t, err)
+		assert.NotNil(t, handle)
+		assert.Equal(t, float64(1), count(logHandle, "get_or_create_writable_segment_create", "success"))
+		assert.Equal(t, float64(0), count(logHandle, "get_or_create_writable_segment", "success"))
+	})
+
+	t.Run("first creation failure is labelled error", func(t *testing.T) {
+		metrics.WpLogHandleOperationsTotal.Reset()
+		logHandle, mockMeta := createMockLogHandle(t)
+		logHandle.WritableSegmentId = -1
+		mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.Anything).
+			Return(errors.New("storage error"))
+
+		handle, err := logHandle.GetOrCreateWritableSegmentHandle(context.Background(), nil)
+
+		require.Error(t, err)
+		assert.Nil(t, handle)
+		assert.Equal(t, float64(1), count(logHandle, "get_or_create_writable_segment_create", "error"))
+		assert.Equal(t, float64(0), count(logHandle, "get_or_create_writable_segment_create", "success"))
+	})
+
+	t.Run("roll", func(t *testing.T) {
+		metrics.WpLogHandleOperationsTotal.Reset()
+		logHandle, mockMeta := createMockLogHandle(t)
+
+		old := mocks_segment_handle.NewSegmentHandle(t)
+		logHandle.SegmentHandles[1] = old
+		logHandle.WritableSegmentId = 1
+		old.EXPECT().IsForceRollingReady(mock.Anything).Return(false)
+		old.EXPECT().GetSize(mock.Anything).Return(int64(65 * 1024 * 1024)) // past MaxSize
+		old.EXPECT().GetBlocksCount(mock.Anything).Return(int64(1))
+		old.EXPECT().GetId(mock.Anything).Return(int64(1)).Maybe()
+		old.EXPECT().SetRollingReady(mock.Anything).Return(nil).Once()
+		mockMeta.EXPECT().StoreSegmentMetadata(mock.Anything, "test-log", mock.Anything, mock.Anything).Return(nil)
+
+		handle, err := logHandle.GetOrCreateWritableSegmentHandle(context.Background(), nil)
+
+		require.NoError(t, err)
+		assert.NotNil(t, handle)
+		assert.Equal(t, float64(1), count(logHandle, "get_or_create_writable_segment_roll", "success"))
+		assert.Equal(t, float64(0), count(logHandle, "get_or_create_writable_segment", "success"))
+	})
+}


### PR DESCRIPTION
Closes #291.

`GetOrCreateWritableSegmentHandle` is the only serialization point on the append
path — every `Write` and `WriteAsync` on every log goes through it, and it holds
the log handle lock for its whole body. It carried **no instrumentation at all**,
while every other method in the same file already reports through
`WpLogHandleOperations{Total,Latency}`.

On the common path the body is a map lookup plus a rolling-policy check. On a
roll it is an etcd transaction, preceded by a completion that is synchronous
whenever the append queue happens to be empty — around **7% of rolls** in the
field (6897 rolls over one 6-hour window, of which 6412 took the deferred path,
per the #285 fix commit). All of it runs with the lock held, so concurrent
appends are parked at the mutex: not rejected, not retried, just blocked, with
no log line and no metric.

## Design notes for the reviewer

**Timed from function entry, not from lock acquisition.** A caller parked behind
a roll then shows up as a slow *cached lookup* — that wait is what a blocked
append actually experiences, and it is visible nowhere else. A separate
lock-wait metric was considered and turned out to be unnecessary: entry-to-return
timing already captures it, and the two situations are told apart by the
operation label rather than by a second metric.

**Three operation labels, not one:**

| label | branch | cost |
| --- | --- | --- |
| `get_or_create_writable_segment` | cached handle | map lookup |
| `get_or_create_writable_segment_create` | first creation | etcd write |
| `get_or_create_writable_segment_roll` | roll | etcd write + possibly synchronous completion |

Their costs differ by orders of magnitude, and the cheap path dominates by call
volume — averaged together it would bury the other two. That is precisely the
mistake this metric exists to prevent: the append retry counter measures appends
*rejected* because the handle went stale (~3% of rolls) and says nothing about
the 100% that waited at the mutex, yet a low retry rate has already been read as
"rolling is negligible".

**The observation costs the critical section nothing.** The deferred observer is
registered *before* `defer l.Unlock()`, so LIFO ordering runs it after the lock
is released. The added work on the hot path is one `time.Now()` and one
`strconv.FormatInt`.

## Dashboard

**No dashboard queried the `log_handle` family at all** — `WpLogHandleOperationsTotal`
and `WpLogHandleOperationLatency` had existed with no panel anywhere. Both client
dashboards gain a **Log Handle Operations** row (ops rate + P99 latency, broken
down by operation), which also surfaces the seven operations that were already
being recorded.

`manifests/dashboard-configmaps.yaml` is regenerated with
`go test ./tests/k8s/monitor -run TestK8sDashboardConfigMaps_InSync -update`, so
`TestK8sDashboardConfigMaps_InSync` stays green.

Documentation: `tests/docker/monitor/README.md` gains the latency row, which was
missing while its counter sibling was already listed.

## Verification

- `gofmt` clean, `go vet ./woodpecker/log/` clean, `go build ./...` ok
- `go test ./woodpecker/log/` ok (full package)
- `go test ./tests/k8s/monitor -run TestK8sDashboard` ok (validity + configmap sync)
- New `TestGetOrCreateWritableSegmentHandle_LabelsEachPath` covers all three
  branches plus the error status

## Related

#289 (narrowing the provider-wide metadata mutex) should land after this — there
is currently no way to show that change helped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNe2heiUwYkqt67PosjiXi
