### PR TITLE
fix(client): stop FastSuccess from cancelling a replica that is still answering

### DIFF
--- a/common/channel/local_result_channel.go
+++ b/common/channel/local_result_channel.go
@@ -126,6 +126,15 @@ func (l *LocalResultChannel) Close(ctx context.Context) error {
 	return nil
 }
 
+// String renders the channel without exposing its fields to reflection; see the
+// comment on RemoteResultChannel.String for why a mutex-guarded type has to
+// control how it is printed.
+func (l *LocalResultChannel) String() string {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return fmt.Sprintf("LocalResultChannel{identifier:%s closed:%v}", l.identifier, l.closed)
+}
+
 func (l *LocalResultChannel) IsClosed() bool {
 	l.mu.RLock()
 	defer l.mu.RUnlock()

--- a/common/channel/local_result_channel.go
+++ b/common/channel/local_result_channel.go
@@ -92,7 +92,7 @@ func (l *LocalResultChannel) ReadResult(ctx context.Context) (*AppendResult, err
 		)
 		return r, nil
 	case <-ctx.Done():
-		return nil, ctx.Err()
+		return nil, readBudgetExhausted(ctx.Err())
 	}
 }
 

--- a/common/channel/local_result_channel_test.go
+++ b/common/channel/local_result_channel_test.go
@@ -680,3 +680,19 @@ func TestLocalResultChannel_TryReadResult(t *testing.T) {
 	assert.False(t, ok)
 	assert.Nil(t, r)
 }
+
+// TestLocalResultChannel_StringIsWhatFmtUses mirrors the remote case: the batch
+// path hands these to a mocked AppendEntries, so they are formatted by code this
+// package does not control while the drain goroutine is closing them.
+func TestLocalResultChannel_StringIsWhatFmtUses(t *testing.T) {
+	resultChannel := NewLocalResultChannel("test-local-stringer")
+
+	rendered := fmt.Sprintf("%v", resultChannel)
+	assert.Equal(t, resultChannel.String(), rendered, "fmt must render via Stringer, not by reflecting over the fields")
+	assert.Contains(t, rendered, "test-local-stringer")
+	assert.Contains(t, rendered, "closed:false")
+	assert.NotContains(t, rendered, "mu:", "reflected field output would mean fmt is reading the fields directly")
+
+	assert.NoError(t, resultChannel.Close(context.Background()))
+	assert.Contains(t, fmt.Sprintf("%v", resultChannel), "closed:true")
+}

--- a/common/channel/local_result_channel_test.go
+++ b/common/channel/local_result_channel_test.go
@@ -97,7 +97,7 @@ func TestLocalResultChannel_ReadTimeout(t *testing.T) {
 	// Try to read from empty channel with timeout
 	_, err := rc.ReadResult(ctx)
 	assert.Error(t, err)
-	assert.Equal(t, context.DeadlineExceeded, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestLocalResultChannel_SendTimeout(t *testing.T) {
@@ -304,7 +304,7 @@ func TestLocalResultChannel_ReadResultTimeout(t *testing.T) {
 	duration := time.Since(start)
 
 	assert.Error(t, err)
-	assert.Equal(t, context.DeadlineExceeded, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 	// Should timeout around 100ms, not much longer
 	assert.True(t, duration < 200*time.Millisecond, "ReadResult took too long: %v", duration)
 }
@@ -415,7 +415,7 @@ func TestLocalResultChannel_ConcurrentReads(t *testing.T) {
 
 	for _, err := range errors {
 		// The other reader should get a context timeout (channel empty, no more data)
-		assert.Equal(t, context.DeadlineExceeded, err, "non-winning reader should timeout")
+		assert.ErrorIs(t, err, context.DeadlineExceeded, "non-winning reader should timeout")
 	}
 }
 
@@ -567,7 +567,7 @@ func TestLocalResultChannel_MultipleReadersOneMessage(t *testing.T) {
 
 	for _, err := range errors {
 		// The other readers should get a context timeout (channel empty, no more data)
-		assert.Equal(t, context.DeadlineExceeded, err, "non-winning reader should timeout")
+		assert.ErrorIs(t, err, context.DeadlineExceeded, "non-winning reader should timeout")
 	}
 }
 

--- a/common/channel/local_result_channel_test.go
+++ b/common/channel/local_result_channel_test.go
@@ -97,7 +97,14 @@ func TestLocalResultChannel_ReadTimeout(t *testing.T) {
 	// Try to read from empty channel with timeout
 	_, err := rc.ReadResult(ctx)
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	// Both classifications the append paths perform must match. This is the channel
+	// the batch drain reads, and a bare DeadlineExceeded is not classifiable
+	// downstream: the entry would take a terminal failure and spend none of its
+	// retries on what is only a timeout.
+	assert.True(t, werr.IsRetryableErr(err),
+		"a timed-out read must be retryable, not terminal")
+	assert.ErrorIs(t, err, context.DeadlineExceeded,
+		"the append path's read-timeout branch tests for this")
 }
 
 func TestLocalResultChannel_SendTimeout(t *testing.T) {

--- a/common/channel/remote_result_channel.go
+++ b/common/channel/remote_result_channel.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -136,13 +137,30 @@ func (r *RemoteResultChannel) ReadResult(ctx context.Context) (*AppendResult, er
 	// response. Without this ctx is decorative on this path: a peer that accepts
 	// the entry and then goes silent blocks the read for as long as the
 	// connection survives.
+	budgetExpired := &atomic.Bool{}
 	if deadline, ok := ctx.Deadline(); ok && cancel != nil {
-		budgetTimer := time.AfterFunc(time.Until(deadline), cancel)
+		budgetTimer := time.AfterFunc(time.Until(deadline), func() {
+			budgetExpired.Store(true)
+			cancel()
+		})
 		defer budgetTimer.Stop()
 	}
 
 	resultResponse, readErr := ch.Recv()
 	if readErr != nil {
+		if budgetExpired.Load() {
+			// The read ran out of its own budget. Recv reports that as a bare gRPC
+			// status, which nothing downstream can classify: errors.Is against
+			// context.DeadlineExceeded does not match it, and werr.IsRetryableErr
+			// extracts a woodpeckerError and so returns false - so the caller would
+			// treat a timeout as a terminal failure and spend none of its retries
+			// on it. Report the timeout as what it is, and keep the transport
+			// detail in the log.
+			logger.Ctx(ctx).Warn("append result read exceeded its budget",
+				zap.String("identifier", r.identifier),
+				zap.Error(readErr))
+			return nil, werr.ErrAppendOpTimeout.WithCauseErr(context.DeadlineExceeded)
+		}
 		logger.Ctx(ctx).Warn("failed to read result from remote channel",
 			zap.String("identifier", r.identifier),
 			zap.Error(readErr))

--- a/common/channel/remote_result_channel.go
+++ b/common/channel/remote_result_channel.go
@@ -127,7 +127,19 @@ func (r *RemoteResultChannel) ReadResult(ctx context.Context) (*AppendResult, er
 	// If gRPC stream is available, read from it
 	r.mu.RLock()
 	ch := r.ch
+	cancel := r.cancel
 	r.mu.RUnlock()
+
+	// Recv observes only the stream's own context, which carries no deadline, so
+	// the caller's budget has to be enforced by cancelling that stream when it
+	// runs out - the same device AppendEntry already uses to bound the first
+	// response. Without this ctx is decorative on this path: a peer that accepts
+	// the entry and then goes silent blocks the read for as long as the
+	// connection survives.
+	if deadline, ok := ctx.Deadline(); ok && cancel != nil {
+		budgetTimer := time.AfterFunc(time.Until(deadline), cancel)
+		defer budgetTimer.Stop()
+	}
 
 	resultResponse, readErr := ch.Recv()
 	if readErr != nil {

--- a/common/channel/remote_result_channel.go
+++ b/common/channel/remote_result_channel.go
@@ -207,6 +207,21 @@ func (r *RemoteResultChannel) Close(ctx context.Context) error {
 	return nil
 }
 
+// String renders the channel without exposing its fields to reflection.
+//
+// This type is mutable and mutex-guarded, so anything that renders it by walking
+// its fields - fmt's default struct formatting, and through it testify's
+// argument diffing - reads `closed` and `ch` with no lock and races a concurrent
+// Close. A result channel is handed to LogStoreClient.AppendEntry and is
+// therefore held, and printed, by code this package does not control, so
+// controlling the rendering here is what makes that safe.
+func (r *RemoteResultChannel) String() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return fmt.Sprintf("RemoteResultChannel{identifier:%s closed:%v streamed:%v}",
+		r.identifier, r.closed, r.ch != nil)
+}
+
 func (r *RemoteResultChannel) IsClosed() bool {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/common/channel/remote_result_channel.go
+++ b/common/channel/remote_result_channel.go
@@ -108,7 +108,7 @@ func (r *RemoteResultChannel) ReadResult(ctx context.Context) (*AppendResult, er
 		for {
 			select {
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return nil, readBudgetExhausted(ctx.Err())
 			case <-ticker.C:
 				r.mu.RLock()
 				if r.closed {
@@ -159,7 +159,7 @@ func (r *RemoteResultChannel) ReadResult(ctx context.Context) (*AppendResult, er
 			logger.Ctx(ctx).Warn("append result read exceeded its budget",
 				zap.String("identifier", r.identifier),
 				zap.Error(readErr))
-			return nil, werr.ErrAppendOpTimeout.WithCauseErr(context.DeadlineExceeded)
+			return nil, readBudgetExhausted(context.DeadlineExceeded)
 		}
 		logger.Ctx(ctx).Warn("failed to read result from remote channel",
 			zap.String("identifier", r.identifier),

--- a/common/channel/remote_result_channel_test.go
+++ b/common/channel/remote_result_channel_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/zilliztech/woodpecker/proto"
@@ -424,6 +425,75 @@ func TestRemoteResultChannel_ReadResult_ViaStream_Synced(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.Equal(t, int64(100), result.SyncedId)
 	assert.NoError(t, result.Err)
+}
+
+// TestRemoteResultChannel_ReadResult_ViaStream_HonoursCallerDeadline pins the
+// bound on the async ack read.
+//
+// Recv observes only the stream's own context, which carries no deadline, so
+// before this the ctx passed here was decorative on the stream path: a peer that
+// accepted the entry and then went silent blocked the read until the connection
+// died. That went unnoticed because FastSuccess used to cancel the stream at
+// quorum — which is exactly the cancellation being removed.
+func TestRemoteResultChannel_ReadResult_ViaStream_HonoursCallerDeadline(t *testing.T) {
+	resultChannel := NewRemoteResultChannel("test-read-stream-budget")
+	streamCtx, streamCancel := context.WithCancel(context.Background())
+	defer streamCancel()
+
+	// A replica that accepted the entry and never sends its durability ack.
+	stream := &mockStreamClient{
+		recvFunc: func() (*proto.AddEntryResponse, error) {
+			<-streamCtx.Done()
+			return nil, streamCtx.Err()
+		},
+	}
+	resultChannel.InitResponseStream(stream, streamCtx, streamCancel)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	type readOutcome struct {
+		result *AppendResult
+		err    error
+	}
+	done := make(chan readOutcome, 1)
+	go func() {
+		result, err := resultChannel.ReadResult(ctx)
+		done <- readOutcome{result: result, err: err}
+	}()
+
+	select {
+	case outcome := <-done:
+		assert.Error(t, outcome.err, "a read that ran out of budget must report it")
+		assert.Nil(t, outcome.result)
+	case <-time.After(10 * time.Second):
+		t.Fatal("ReadResult ignored the caller's deadline: a silent peer blocks it indefinitely")
+	}
+}
+
+// TestRemoteResultChannel_ReadResult_ViaStream_DeadlineNotReached checks the
+// budget only fires when it is actually exhausted: an ack that arrives in time
+// is returned, and the stream it came on is left alone.
+func TestRemoteResultChannel_ReadResult_ViaStream_DeadlineNotReached(t *testing.T) {
+	resultChannel := NewRemoteResultChannel("test-read-stream-in-budget")
+	streamCtx, streamCancel := context.WithCancel(context.Background())
+	defer streamCancel()
+
+	stream := &mockStreamClient{
+		recvFunc: func() (*proto.AddEntryResponse, error) {
+			return &proto.AddEntryResponse{EntryId: 42, State: proto.AddEntryState_Synced}, nil
+		},
+	}
+	resultChannel.InitResponseStream(stream, streamCtx, streamCancel)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := resultChannel.ReadResult(ctx)
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(42), result.SyncedId)
+	assert.NoError(t, streamCtx.Err(), "an in-budget read must not cancel the stream")
 }
 
 func TestRemoteResultChannel_ReadResult_ViaStream_Failed(t *testing.T) {

--- a/common/channel/remote_result_channel_test.go
+++ b/common/channel/remote_result_channel_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/proto"
 )
 
@@ -464,8 +465,17 @@ func TestRemoteResultChannel_ReadResult_ViaStream_HonoursCallerDeadline(t *testi
 
 	select {
 	case outcome := <-done:
-		assert.Error(t, outcome.err, "a read that ran out of budget must report it")
+		require.Error(t, outcome.err, "a read that ran out of budget must report it")
 		assert.Nil(t, outcome.result)
+
+		// Recv reports the cancellation as a bare gRPC status, which nothing
+		// downstream can classify: the caller would record a terminal failure and
+		// spend none of its retries on what is only a timeout. Both of the
+		// classifications the append path actually performs must match.
+		assert.True(t, werr.IsRetryableErr(outcome.err),
+			"a timed-out read must be retryable, not terminal")
+		assert.ErrorIs(t, outcome.err, context.DeadlineExceeded,
+			"the append path's read-timeout branch tests for this")
 	case <-time.After(10 * time.Second):
 		t.Fatal("ReadResult ignored the caller's deadline: a silent peer blocks it indefinitely")
 	}

--- a/common/channel/remote_result_channel_test.go
+++ b/common/channel/remote_result_channel_test.go
@@ -156,7 +156,7 @@ func TestRemoteResultChannel_ReadResult_NotInitialized(t *testing.T) {
 	result, err := channel.ReadResult(ctx)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Equal(t, context.DeadlineExceeded, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestRemoteResultChannel_ReadResult_Closed(t *testing.T) {
@@ -272,7 +272,7 @@ func TestRemoteResultChannel_ReadResult_ContextCancellation(t *testing.T) {
 	result, err := channel.ReadResult(ctx)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Equal(t, context.DeadlineExceeded, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 // Test the workflow that simulates real usage in append operations

--- a/common/channel/remote_result_channel_test.go
+++ b/common/channel/remote_result_channel_test.go
@@ -272,7 +272,12 @@ func TestRemoteResultChannel_ReadResult_ContextCancellation(t *testing.T) {
 	result, err := channel.ReadResult(ctx)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	// No stream is installed, so this is the polling exit rather than the stream
+	// one; it must classify the same way.
+	assert.True(t, werr.IsRetryableErr(err),
+		"a timed-out read must be retryable, not terminal")
+	assert.ErrorIs(t, err, context.DeadlineExceeded,
+		"the append path's read-timeout branch tests for this")
 }
 
 // Test the workflow that simulates real usage in append operations

--- a/common/channel/remote_result_channel_test.go
+++ b/common/channel/remote_result_channel_test.go
@@ -19,6 +19,7 @@ package channel
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -591,4 +592,43 @@ func TestRemoteResultChannel_ReadResult_DirectResultAlreadySet(t *testing.T) {
 	result, err := channel.ReadResult(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(77), result.SyncedId)
+}
+
+// TestRemoteResultChannel_StringIsWhatFmtUses pins the property the Stringer was
+// added for. A result channel is handed to LogStoreClient.AppendEntry, so it is
+// retained and printed by code this package does not control - testify formats
+// every recorded call argument with %v when it asserts expectations. fmt's
+// default rendering walks the struct's fields with no lock, which races a
+// concurrent Close; consulting Stringer instead is what makes that safe, so the
+// test asserts fmt actually takes that path rather than just that the method
+// exists.
+func TestRemoteResultChannel_StringIsWhatFmtUses(t *testing.T) {
+	resultChannel := NewRemoteResultChannel("test-stringer")
+
+	rendered := fmt.Sprintf("%v", resultChannel)
+	assert.Equal(t, resultChannel.String(), rendered, "fmt must render via Stringer, not by reflecting over the fields")
+	assert.Contains(t, rendered, "test-stringer")
+	assert.Contains(t, rendered, "closed:false")
+	assert.NotContains(t, rendered, "mu:", "reflected field output would mean fmt is reading the fields directly")
+
+	assert.NoError(t, resultChannel.Close(context.Background()))
+	assert.Contains(t, fmt.Sprintf("%v", resultChannel), "closed:true")
+}
+
+// TestRemoteResultChannel_StringIsSafeWhileClosing is the race the Stringer
+// exists to remove: rendering concurrently with the Close that the reading
+// goroutine performs. It only proves anything under -race.
+func TestRemoteResultChannel_StringIsSafeWhileClosing(t *testing.T) {
+	resultChannel := NewRemoteResultChannel("test-stringer-race")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		time.Sleep(2 * time.Millisecond)
+		_ = resultChannel.Close(context.Background())
+	}()
+	for i := 0; i < 200; i++ {
+		_ = fmt.Sprintf("%v", resultChannel)
+	}
+	<-done
 }

--- a/common/channel/result_channel.go
+++ b/common/channel/result_channel.go
@@ -18,6 +18,9 @@ package channel
 
 import (
 	"context"
+	"errors"
+
+	"github.com/zilliztech/woodpecker/common/werr"
 )
 
 // ResultChannel is an abstract interface for handling asynchronous result notifications.
@@ -38,4 +41,23 @@ type ResultChannel interface {
 type AppendResult struct {
 	SyncedId int64
 	Err      error
+}
+
+// readBudgetExhausted renders a read that ended because its caller's context did.
+//
+// A deadline means the ack ran late, and every ReadResult has to report that the
+// same way, because what consumes it decides an entry's fate: the append path
+// asks werr.IsRetryableErr, which extracts a woodpeckerError and so answers
+// false for a bare context error. An entry whose ack merely ran late would then
+// go terminal with none of its retries spent. Wrapping keeps errors.Is working,
+// which is what the read-timeout log branch tests for.
+//
+// A cancellation is the caller's own decision - the server reads on the gRPC
+// stream's context and sees one whenever a client goes away - so it is passed
+// through as itself rather than relabelled a timeout.
+func readBudgetExhausted(cause error) error {
+	if errors.Is(cause, context.DeadlineExceeded) {
+		return werr.ErrAppendOpTimeout.WithCauseErr(cause)
+	}
+	return cause
 }

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -1242,6 +1242,16 @@ func TestServer_AddEntry_ReadResultContextError(t *testing.T) {
 	_ = err
 	require.GreaterOrEqual(t, len(stream.responses), 1)
 	assert.Equal(t, proto.AddEntryState_Buffered, stream.responses[0].State)
+
+	// And never the durability ack. The server waits for it on the stream's own
+	// context, so a client that cancels the stream ends that wait: the entry is
+	// still buffered and will still be flushed, but this side never gets to say
+	// so. That is what a client cancelling a replica it had stopped waiting for
+	// used to do to every append.
+	for i, resp := range stream.responses {
+		assert.NotEqual(t, proto.AddEntryState_Synced, resp.State,
+			"response %d: a cancelled stream cannot carry the ack", i)
+	}
 }
 
 // === SelectNodes with actual ServerNode ===

--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -385,6 +385,12 @@ func (op *AppendOp) FastFail(ctx context.Context, err error) {
 				zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId), zap.Int64("entryId", op.entryId))
 			continue
 		}
+		if ch.IsClosed() {
+			// Its reader has already finished with it and retired it: there is
+			// nobody left to wake, and both SendResult and Close on a closed
+			// channel would only produce a warning.
+			continue
+		}
 		sendErr := ch.SendResult(ctx, &channel.AppendResult{
 			SyncedId: -1,
 			Err:      err,
@@ -413,26 +419,20 @@ func (op *AppendOp) FastSuccess(ctx context.Context) {
 		return // Already called
 	}
 
-	for index, ch := range op.resultChannels {
-		if ch == nil {
-			logger.Ctx(ctx).Debug("FastSuccess channel is nil, skipping",
-				zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId), zap.Int64("entryId", op.entryId))
-			continue
-		}
-		sendErr := ch.SendResult(ctx, &channel.AppendResult{
-			SyncedId: op.entryId,
-			Err:      nil,
-		})
-		if sendErr != nil {
-			logger.Ctx(ctx).Warn("send FastSuccess result to channel failed",
-				zap.Int("channelIndex", index), zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId), zap.Int64("entryId", op.entryId), zap.Error(sendErr))
-		}
-		// Deliberately not closed here, unlike FastFail. Quorum is satisfied but
-		// the replicas outside it are still answering, and closing a
-		// RemoteResultChannel cancels the replica's stream mid-answer. Each
-		// channel is closed by its own receivedAckCallback once that replica has
-		// actually answered - see the comment there.
-	}
+	// FastSuccess deliberately touches no result channel, unlike FastFail.
+	//
+	// Quorum is satisfied, so there is nothing left to hurry. The replicas that
+	// answered have already retired their own channels, and writing into those
+	// only fails and logs - once per replica per entry, on every successful
+	// append, which is the very cost this change exists to remove. The replicas
+	// still answering are the whole point: a synthetic success written to one of
+	// them would be read INSTEAD of that replica's real answer, and on the batch
+	// path it would land in a one-slot buffer, so the drain would consume the
+	// synthetic result while the replica's actual ack was dropped as
+	// "channel is full".
+	//
+	// Closing is likewise left to each channel's reader; for a
+	// RemoteResultChannel, Close cancels the replica's stream mid-answer.
 
 	op.callback(op.segmentId, op.entryId, nil)
 	logger.Ctx(ctx).Debug("FastSuccess completed",

--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -192,18 +192,26 @@ func (op *AppendOp) sendWriteRequest(ctx context.Context, cli client.LogStoreCli
 	startRequestTime := time.Now()
 
 	if len(op.resultChannels) > serverIndex {
-		// (Re)create the result channel when the slot is empty or holds a channel
-		// whose type doesn't match the client. The batch path installs a
-		// LocalResultChannel here; a remote client's single-entry AppendEntry
-		// requires a RemoteResultChannel and rejects a LocalResultChannel with
-		// ErrInternalError. A matching channel is reused (retry idempotency).
-		_, isRemoteChannel := op.resultChannels[serverIndex].(*channel.RemoteResultChannel)
-		if op.resultChannels[serverIndex] == nil || isRemoteChannel != cli.IsRemoteClient() {
-			if cli.IsRemoteClient() {
-				op.resultChannels[serverIndex] = channel.NewRemoteResultChannel(op.Identifier())
-			} else {
-				op.resultChannels[serverIndex] = channel.NewLocalResultChannel(op.Identifier())
-			}
+		// A fresh result channel per attempt, never a reused one.
+		//
+		// The goroutine spawned below owns the channel it is handed and closes it
+		// on the way out, and that close runs outside op.mu. Reusing the slot would
+		// let the previous attempt's close land on THIS attempt's channel and cancel
+		// the stream it just opened - which fails this attempt, spends another retry,
+		// and can repeat until the budget is gone.
+		//
+		// Nothing worth carrying over survives an attempt anyway. Every attempt opens
+		// its own stream, context and cancel; InitResponseStream overwrites all three
+		// without cancelling the previous ones, and leaves any result already recorded
+		// in place for the next read to return instead of the new stream's.
+		//
+		// Building it fresh also picks the type the client requires, which is what the
+		// type check here existed for: a remote client's single-entry AppendEntry
+		// rejects the LocalResultChannel the batch path leaves in this slot.
+		if cli.IsRemoteClient() {
+			op.resultChannels[serverIndex] = channel.NewRemoteResultChannel(op.Identifier())
+		} else {
+			op.resultChannels[serverIndex] = channel.NewLocalResultChannel(op.Identifier())
 		}
 	}
 
@@ -219,8 +227,43 @@ func (op *AppendOp) sendWriteRequest(ctx context.Context, cli client.LogStoreCli
 func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime time.Time, entryId int64, resultChan channel.ResultChannel, err error, serverIndex int, serverAddr string) {
 	ctx, sp := logger.NewIntentCtxWithParent(ctx, "AppendOp", "receivedAckCallback")
 	defer sp.End()
+
+	// This goroutine is the only reader of resultChan and the last user of the
+	// stream behind it, so it owns retiring both.
+	//
+	// Retiring them HERE rather than in FastSuccess is the point. FastSuccess runs
+	// the moment the ack quorum is reached, while the replica outside that quorum
+	// is still answering perfectly normally; for a RemoteResultChannel, Close()
+	// cancels that replica's gRPC stream, so its normal completion came back as
+	// "rpc error: code = Canceled" and was logged as a failure once per entry.
+	//
+	// The deferred call guarantees it happens on every exit path; the explicit
+	// calls below make it happen as soon as the replica's answer is in, so the
+	// stream is not held across the segment-handle bookkeeping that follows -
+	// which takes that handle's lock.
+	//
+	// FastFail still closes early, deliberately: there the entry is abandoned and
+	// the waiters should stop at once rather than sit out their read budget.
+	// Close is idempotent, so an early close and this one cannot conflict.
+	channelRetired := false
+	retireResultChannel := func() {
+		if channelRetired || resultChan == nil {
+			return
+		}
+		channelRetired = true
+		if closeErr := resultChan.Close(ctx); closeErr != nil {
+			logger.Ctx(ctx).Warn("failed to close append result channel",
+				zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId),
+				zap.Int64("entryId", op.entryId), zap.String("serverAddr", serverAddr), zap.Error(closeErr))
+		}
+	}
+	defer retireResultChannel()
+
 	// sync call error, return directly
 	if err != nil {
+		// The send never got far enough for an ack to arrive, so nothing is
+		// waiting on this channel any more.
+		retireResultChannel()
 		// Skip further processing if operation already completed via FastFail/FastSuccess
 		if op.fastCalled.Load() {
 			return
@@ -235,6 +278,8 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 	defer cancel()
 	syncedResult, readChanErr := resultChan.ReadResult(subCtx)
 	sp.AddEvent("wait callback", trace.WithAttributes(attribute.Int64("elapsedTime", time.Since(startRequestTime).Milliseconds()), attribute.Int("serverIndex", serverIndex), attribute.String("serverAddr", serverAddr)))
+	// The read was the last use of this channel and of the stream behind it.
+	retireResultChannel()
 
 	// If operation already completed via FastFail/FastSuccess, skip further processing
 	if op.fastCalled.Load() {
@@ -382,11 +427,11 @@ func (op *AppendOp) FastSuccess(ctx context.Context) {
 			logger.Ctx(ctx).Warn("send FastSuccess result to channel failed",
 				zap.Int("channelIndex", index), zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId), zap.Int64("entryId", op.entryId), zap.Error(sendErr))
 		}
-		closeErr := ch.Close(ctx)
-		if closeErr != nil {
-			logger.Ctx(ctx).Warn("failed to close channel in FastSuccess",
-				zap.Int("channelIndex", index), zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId), zap.Int64("entryId", op.entryId), zap.Error(closeErr))
-		}
+		// Deliberately not closed here, unlike FastFail. Quorum is satisfied but
+		// the replicas outside it are still answering, and closing a
+		// RemoteResultChannel cancels the replica's stream mid-answer. Each
+		// channel is closed by its own receivedAckCallback once that replica has
+		// actually answered - see the comment there.
 	}
 
 	op.callback(op.segmentId, op.entryId, nil)

--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -135,10 +135,17 @@ func replicaOutcome(result *channel.AppendResult, entryId int64) string {
 // replica_append_total read about two outcomes per entry on a cluster writing
 // three copies, understating cross-AZ write traffic by the same proportion.
 //
-// Only an answer is counted there. A failure observed after the op completed may
-// be our own doing - FastFail cancels every replica still in flight - and
-// counting that would put self-inflicted cancellations into the error series,
-// which is the same mistake this change removes from the logs.
+// Only an answer is counted there, and a non-nil result is what an answer looks
+// like. A read that produced none may have failed for our own reasons - FastFail
+// cancels every replica still in flight - and counting that would put
+// self-inflicted cancellations into the error series, which is the same mistake
+// this change removes from the logs.
+//
+// The result, not the error, is what decides that. A remote channel reports a
+// server that answered "sync failed" as a non-nil result AND a non-nil error,
+// while a local one reports the same answer with no error at all; keying on the
+// error would drop a genuinely failing replica on the service-mode path and keep
+// it on the embedded one.
 func (op *AppendOp) recordReplicaAnswer(serverIndex int, result *channel.AppendResult) {
 	if status := replicaOutcome(result, op.entryId); status != "" {
 		op.recordReplicaResult(serverIndex, status)
@@ -319,7 +326,7 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 
 	// If operation already completed via FastFail/FastSuccess, skip further processing
 	if op.fastCalled.Load() {
-		if readChanErr == nil {
+		if syncedResult != nil {
 			op.recordReplicaAnswer(serverIndex, syncedResult)
 		}
 		logger.Ctx(ctx).Debug("received ack but already fast completed",
@@ -381,7 +388,7 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 // entry-id order) instead of spawning a goroutine per op.
 func (op *AppendOp) applyNodeAck(ctx context.Context, startRequestTime time.Time, result *channel.AppendResult, readErr error, serverIndex int, serverAddr string) {
 	if op.fastCalled.Load() {
-		if readErr == nil {
+		if result != nil {
 			op.recordReplicaAnswer(serverIndex, result)
 		}
 		return

--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -298,25 +298,23 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 	// FastFail still closes early, deliberately: there the entry is abandoned and
 	// the waiters should stop at once rather than sit out their read budget.
 	// Close is idempotent, so an early close and this one cannot conflict.
-	channelRetired := false
-	retireResultChannel := func() {
-		if channelRetired || resultChan == nil {
+	// The guard keeps the retire to a single attempt: a Close that fails is not
+	// worth retrying on the next exit path, and the ack must not depend on it.
+	retired := false
+	retire := func() {
+		if retired {
 			return
 		}
-		channelRetired = true
-		if closeErr := resultChan.Close(ctx); closeErr != nil {
-			logger.Ctx(ctx).Warn("failed to close append result channel",
-				zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId),
-				zap.Int64("entryId", op.entryId), zap.String("serverAddr", serverAddr), zap.Error(closeErr))
-		}
+		retired = true
+		op.retireResultChannel(ctx, resultChan, serverAddr)
 	}
-	defer retireResultChannel()
+	defer retire()
 
 	// sync call error, return directly
 	if err != nil {
 		// The send never got far enough for an ack to arrive, so nothing is
 		// waiting on this channel any more.
-		retireResultChannel()
+		retire()
 		// Skip further processing if operation already completed via FastFail/FastSuccess
 		if op.fastCalled.Load() {
 			return
@@ -332,7 +330,7 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 	syncedResult, readChanErr := resultChan.ReadResult(subCtx)
 	sp.AddEvent("wait callback", trace.WithAttributes(attribute.Int64("elapsedTime", time.Since(startRequestTime).Milliseconds()), attribute.Int("serverIndex", serverIndex), attribute.String("serverAddr", serverAddr)))
 	// The read was the last use of this channel and of the stream behind it.
-	retireResultChannel()
+	retire()
 
 	// If operation already completed via FastFail/FastSuccess, skip further processing
 	if op.fastCalled.Load() {
@@ -389,6 +387,21 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 
 	logger.Ctx(ctx).Debug("synced received, keep async waiting",
 		zap.Int64("syncedId", syncedResult.SyncedId), zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId), zap.Int64("entryId", op.entryId), zap.String("serverAddr", serverAddr))
+}
+
+// retireResultChannel closes a result channel this op's reader owns. Only the
+// reader can know that a channel will never be read again, so retiring it is the
+// reader's job on both the single-entry and the batch path. Close is idempotent,
+// so an early retire and the deferred one cannot conflict.
+func (op *AppendOp) retireResultChannel(ctx context.Context, resultChan channel.ResultChannel, serverAddr string) {
+	if resultChan == nil {
+		return
+	}
+	if closeErr := resultChan.Close(ctx); closeErr != nil {
+		logger.Ctx(ctx).Warn("failed to close append result channel",
+			zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId),
+			zap.Int64("entryId", op.entryId), zap.String("serverAddr", serverAddr), zap.Error(closeErr))
+	}
 }
 
 // applyNodeAck processes a single node's durability result for this op: quorum

--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -46,6 +46,16 @@ type Operation interface {
 	Execute()
 }
 
+// appendAckReadTimeout bounds how long a replica's durability ack is waited for
+// on the single-entry path. Package var so tests can shrink it, matching
+// batchAckReadTimeout on the batch path. TODO make configurable.
+//
+// It is also the retry unit: an unresponsive replica costs one of these per
+// attempt, so a peer that accepts an entry and never answers takes
+// appendAckReadTimeout x MaxRetries before the entry is given up on, and the
+// entries queued behind it wait that long too because acks are ordered.
+var appendAckReadTimeout = 30 * time.Second
+
 var _ Operation = (*AppendOp)(nil)
 
 // AppendOp represents an operation to append data to a log segment.
@@ -317,7 +327,7 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 		return
 	}
 	// async call error, wait until syncedCh closed
-	subCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // TODO configurable
+	subCtx, cancel := context.WithTimeout(context.Background(), appendAckReadTimeout)
 	defer cancel()
 	syncedResult, readChanErr := resultChan.ReadResult(subCtx)
 	sp.AddEvent("wait callback", trace.WithAttributes(attribute.Int64("elapsedTime", time.Since(startRequestTime).Milliseconds()), attribute.Int("serverIndex", serverIndex), attribute.String("serverAddr", serverAddr)))

--- a/woodpecker/segment/append_op.go
+++ b/woodpecker/segment/append_op.go
@@ -109,6 +109,42 @@ func (op *AppendOp) Identifier() string {
 	return fmt.Sprintf("%d/%d/%d", op.logId, op.segmentId, op.entryId)
 }
 
+// replicaOutcome classifies one replica's answer to this entry.
+//
+// It is the only place that decides what success means for the per-replica
+// counters, so the single-entry ack path, the batch drain, and the post-quorum
+// recording in both cannot drift apart. An empty result means the answer says
+// nothing about THIS entry: a replica still catching up reports a lower
+// SyncedId, and that is neither a success nor a failure to write down.
+func replicaOutcome(result *channel.AppendResult, entryId int64) string {
+	if result == nil || result.SyncedId == -1 || result.Err != nil {
+		return "error"
+	}
+	if result.SyncedId < entryId {
+		return ""
+	}
+	return "success"
+}
+
+// recordReplicaAnswer counts a replica's answer when it says something about
+// this entry.
+//
+// It exists for the paths that run after the op has already been completed
+// elsewhere. A replica outside the ack quorum still answers, and its answer is
+// as real as the ones that made the quorum - dropping it is why
+// replica_append_total read about two outcomes per entry on a cluster writing
+// three copies, understating cross-AZ write traffic by the same proportion.
+//
+// Only an answer is counted there. A failure observed after the op completed may
+// be our own doing - FastFail cancels every replica still in flight - and
+// counting that would put self-inflicted cancellations into the error series,
+// which is the same mistake this change removes from the logs.
+func (op *AppendOp) recordReplicaAnswer(serverIndex int, result *channel.AppendResult) {
+	if status := replicaOutcome(result, op.entryId); status != "" {
+		op.recordReplicaResult(serverIndex, status)
+	}
+}
+
 // recordReplicaResult counts one replica's outcome for this entry, labelled by
 // how far that replica sits from this client. A quorum append writes to every
 // replica, so this is where cross-AZ write traffic becomes visible.
@@ -283,6 +319,9 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 
 	// If operation already completed via FastFail/FastSuccess, skip further processing
 	if op.fastCalled.Load() {
+		if readChanErr == nil {
+			op.recordReplicaAnswer(serverIndex, syncedResult)
+		}
 		logger.Ctx(ctx).Debug("received ack but already fast completed",
 			zap.Int64("logId", op.logId), zap.Int64("segId", op.segmentId), zap.Int64("entryId", op.entryId), zap.String("serverAddr", serverAddr))
 		return
@@ -342,6 +381,9 @@ func (op *AppendOp) receivedAckCallback(ctx context.Context, startRequestTime ti
 // entry-id order) instead of spawning a goroutine per op.
 func (op *AppendOp) applyNodeAck(ctx context.Context, startRequestTime time.Time, result *channel.AppendResult, readErr error, serverIndex int, serverAddr string) {
 	if op.fastCalled.Load() {
+		if readErr == nil {
+			op.recordReplicaAnswer(serverIndex, result)
+		}
 		return
 	}
 	if readErr != nil {

--- a/woodpecker/segment/append_op_replica_lifetime_test.go
+++ b/woodpecker/segment/append_op_replica_lifetime_test.go
@@ -18,6 +18,7 @@ package segment
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -153,4 +154,104 @@ func TestAppendOp_receivedAckCallback_ClosesItsOwnChannel(t *testing.T) {
 
 		assert.True(t, rc.IsClosed(), "the close must cover every exit path, not just the happy one")
 	})
+}
+
+// recordingResultChannel wraps a real channel and records every SendResult that
+// reached it. It is how these tests state "FastSuccess must not write here" as an
+// assertion rather than as an absent log line.
+type recordingResultChannel struct {
+	channel.ResultChannel
+	mu    sync.Mutex
+	sends []error
+}
+
+func newRecordingChannel(identifier string) *recordingResultChannel {
+	return &recordingResultChannel{ResultChannel: channel.NewLocalResultChannel(identifier)}
+}
+
+func (r *recordingResultChannel) SendResult(ctx context.Context, result *channel.AppendResult) error {
+	sendErr := r.ResultChannel.SendResult(ctx, result)
+	r.mu.Lock()
+	r.sends = append(r.sends, sendErr)
+	r.mu.Unlock()
+	return sendErr
+}
+
+// seed delivers a result the way a replica would, without counting as a send
+// made by the code under test.
+func (r *recordingResultChannel) seed(t *testing.T, result *channel.AppendResult) {
+	t.Helper()
+	require.NoError(t, r.ResultChannel.SendResult(context.Background(), result))
+}
+
+func (r *recordingResultChannel) sendCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.sends)
+}
+
+// TestAppendOp_QuorumSuccess_WritesNothingIntoRetiredChannels pins the ordering
+// that decides whether this change actually removes log volume or just moves it.
+//
+// Once the reading goroutine owns its channel, it retires the channel BEFORE the
+// quorum bookkeeping that follows - and that bookkeeping runs FastSuccess
+// synchronously in the same goroutine. So by the time FastSuccess iterates the
+// replica channels, every replica that answered has already closed its own. A
+// FastSuccess that still wrote into them would fail and warn once per acking
+// replica on EVERY successful append, which is exactly the cost this change
+// exists to remove.
+func TestAppendOp_QuorumSuccess_WritesNothingIntoRetiredChannels(t *testing.T) {
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	quorumInfo := &proto.QuorumInfo{Wq: 3, Aq: 2, Es: 3, Nodes: []string{"n1", "n2", "n3"}}
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"),
+		func(int64, int64, error) {}, nil, mockHandle, quorumInfo, nil)
+
+	channels := make([]*recordingResultChannel, 3)
+	op.resultChannels = make([]channel.ResultChannel, 3)
+	for i := range channels {
+		channels[i] = newRecordingChannel(op.Identifier())
+		op.resultChannels[i] = channels[i]
+	}
+
+	// The real FastSuccess, driven exactly as production drives it: synchronously
+	// from inside the acking goroutine the moment the quorum is reached.
+	mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(3)).
+		Run(func(ctx context.Context, _ int64) { op.FastSuccess(ctx) }).Return().Once()
+
+	// Two of the three replicas answer; the third is still in flight.
+	for i := 0; i < 2; i++ {
+		channels[i].seed(t, &channel.AppendResult{SyncedId: 3})
+		op.receivedAckCallback(context.Background(), time.Now(), 3, channels[i], nil, i, quorumInfo.Nodes[i])
+	}
+
+	require.True(t, op.fastCalled.Load(), "the quorum must have triggered FastSuccess")
+	assert.True(t, channels[0].IsClosed(), "an answering replica retires its own channel")
+	assert.True(t, channels[1].IsClosed(), "an answering replica retires its own channel")
+	assert.False(t, channels[2].IsClosed(), "the in-flight replica must be left alone")
+
+	for i, resultChan := range channels {
+		assert.Equal(t, 0, resultChan.sendCount(),
+			"FastSuccess wrote into replica %d's channel: retired ones only produce a warning, "+
+				"and an in-flight one would return the synthetic result instead of the replica's real answer", i)
+	}
+}
+
+// TestAppendOp_FastFail_SkipsChannelsTheirReaderRetired is the same ordering seen
+// from the failure side: HandleAppendRequestFailure is also called after the
+// reader retired its channel, and drives FastFail synchronously.
+func TestAppendOp_FastFail_SkipsChannelsTheirReaderRetired(t *testing.T) {
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"),
+		func(int64, int64, error) {}, nil, nil,
+		&proto.QuorumInfo{Wq: 2, Aq: 2, Es: 2, Nodes: []string{"n1", "n2"}}, nil)
+
+	retired := newRecordingChannel("retired")
+	require.NoError(t, retired.ResultChannel.Close(context.Background()))
+	live := newRecordingChannel("live")
+	op.resultChannels = []channel.ResultChannel{retired, live}
+
+	op.FastFail(context.Background(), werr.ErrSegmentFenced)
+
+	assert.Equal(t, 0, retired.sendCount(), "a retired channel has no waiter left to wake")
+	assert.Equal(t, 1, live.sendCount(), "a live waiter must still be stopped, and told why")
+	assert.True(t, live.IsClosed(), "FastFail still closes what it woke")
 }

--- a/woodpecker/segment/append_op_replica_lifetime_test.go
+++ b/woodpecker/segment/append_op_replica_lifetime_test.go
@@ -1,0 +1,156 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segment
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/zilliztech/woodpecker/common/channel"
+	"github.com/zilliztech/woodpecker/common/werr"
+	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_segment_handle"
+	"github.com/zilliztech/woodpecker/proto"
+)
+
+// An append is acknowledged to the caller as soon as Aq replicas have answered,
+// which with Es=3,Aq=2 normally leaves exactly one replica still answering. What
+// happens to that replica is what these tests pin: it must be left to finish and
+// then retired by whoever was reading it, never cancelled by the completion of
+// the quorum it was not part of.
+
+// silentAckStream stands in for a replica that accepted the entry and has not
+// sent its durability ack yet: Recv blocks until the stream's own context ends,
+// exactly as a real gRPC stream does.
+type silentAckStream struct {
+	streamCtx context.Context
+}
+
+func (s *silentAckStream) Recv() (*proto.AddEntryResponse, error) {
+	<-s.streamCtx.Done()
+	return nil, s.streamCtx.Err()
+}
+
+func (s *silentAckStream) CloseSend() error             { return nil }
+func (s *silentAckStream) Header() (metadata.MD, error) { return nil, nil }
+func (s *silentAckStream) Trailer() metadata.MD         { return nil }
+func (s *silentAckStream) Context() context.Context     { return s.streamCtx }
+func (s *silentAckStream) SendMsg(m any) error          { return nil }
+func (s *silentAckStream) RecvMsg(m any) error          { return nil }
+
+// inFlightReplicas installs n RemoteResultChannels on the op, each holding a
+// stream that has not answered yet, and reports which of their cancels have
+// fired.
+func inFlightReplicas(t *testing.T, op *AppendOp, n int) ([]*channel.RemoteResultChannel, []*atomic.Bool) {
+	t.Helper()
+	channels := make([]*channel.RemoteResultChannel, n)
+	cancelled := make([]*atomic.Bool, n)
+	op.resultChannels = make([]channel.ResultChannel, n)
+	for i := 0; i < n; i++ {
+		flag := &atomic.Bool{}
+		streamCtx, streamCancel := context.WithCancel(context.Background())
+		rc := channel.NewRemoteResultChannel(op.Identifier())
+		rc.InitResponseStream(&silentAckStream{streamCtx: streamCtx}, streamCtx, func() {
+			flag.Store(true)
+			streamCancel()
+		})
+		channels[i] = rc
+		cancelled[i] = flag
+		op.resultChannels[i] = rc
+		t.Cleanup(streamCancel)
+	}
+	return channels, cancelled
+}
+
+// TestAppendOp_FastSuccess_DoesNotCancelInFlightReplicaStreams is the regression
+// test for the defect itself. FastSuccess used to close every result channel,
+// and for a RemoteResultChannel Close cancels the replica's gRPC stream — so the
+// replica outside the quorum had its normal completion turned into
+// "rpc error: code = Canceled", logged as a failure once per entry.
+func TestAppendOp_FastSuccess_DoesNotCancelInFlightReplicaStreams(t *testing.T) {
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"),
+		func(int64, int64, error) {}, nil, nil,
+		&proto.QuorumInfo{Wq: 3, Aq: 2, Es: 3, Nodes: []string{"n1", "n2", "n3"}}, nil)
+	channels, cancelled := inFlightReplicas(t, op, 3)
+
+	op.FastSuccess(context.Background())
+
+	for i := range channels {
+		assert.False(t, channels[i].IsClosed(), "replica %d: FastSuccess must not close the channel", i)
+		assert.False(t, cancelled[i].Load(), "replica %d: FastSuccess must not cancel the stream", i)
+	}
+}
+
+// TestAppendOp_FastFail_CancelsInFlightReplicaStreams is the deliberate contrast.
+// The entry is abandoned there, so every waiter should stop at once rather than
+// sit out its read budget.
+func TestAppendOp_FastFail_CancelsInFlightReplicaStreams(t *testing.T) {
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"),
+		func(int64, int64, error) {}, nil, nil,
+		&proto.QuorumInfo{Wq: 3, Aq: 2, Es: 3, Nodes: []string{"n1", "n2", "n3"}}, nil)
+	channels, cancelled := inFlightReplicas(t, op, 3)
+
+	op.FastFail(context.Background(), werr.ErrSegmentFenced)
+
+	for i := range channels {
+		assert.True(t, channels[i].IsClosed(), "replica %d: FastFail must close the channel", i)
+		assert.True(t, cancelled[i].Load(), "replica %d: FastFail must cancel the stream", i)
+	}
+}
+
+// TestAppendOp_receivedAckCallback_ClosesItsOwnChannel pins the other half of the
+// exchange: with FastSuccess no longer closing, the reading goroutine must, or
+// the stream and the goroutine behind it are never released.
+func TestAppendOp_receivedAckCallback_ClosesItsOwnChannel(t *testing.T) {
+	t.Run("after a normal ack", func(t *testing.T) {
+		mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+		mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(3)).Return().Once()
+		op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"),
+			func(int64, int64, error) {}, nil, mockHandle,
+			&proto.QuorumInfo{Wq: 1, Aq: 1, Es: 1, Nodes: []string{"n1"}}, nil)
+
+		rc := channel.NewLocalResultChannel(op.Identifier())
+		require.NoError(t, rc.SendResult(context.Background(), &channel.AppendResult{SyncedId: 3}))
+		op.resultChannels = []channel.ResultChannel{rc}
+
+		op.receivedAckCallback(context.Background(), time.Now(), 3, rc, nil, 0, "n1")
+
+		assert.True(t, rc.IsClosed(), "the reader owns the channel and must close it on the success path")
+	})
+
+	t.Run("after a send error", func(t *testing.T) {
+		op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"),
+			func(int64, int64, error) {}, nil, nil,
+			&proto.QuorumInfo{Wq: 1, Aq: 1, Es: 1, Nodes: []string{"n1"}}, nil)
+		// fastCalled short-circuits the failure handling, so this exercises the
+		// earliest return in the function — the close must still happen.
+		op.fastCalled.Store(true)
+
+		rc := channel.NewLocalResultChannel(op.Identifier())
+		op.resultChannels = []channel.ResultChannel{rc}
+
+		op.receivedAckCallback(context.Background(), time.Now(), 3, rc, werr.ErrInternalError, 0, "n1")
+
+		assert.True(t, rc.IsClosed(), "the close must cover every exit path, not just the happy one")
+	})
+}

--- a/woodpecker/segment/append_op_replica_lifetime_test.go
+++ b/woodpecker/segment/append_op_replica_lifetime_test.go
@@ -161,8 +161,10 @@ func TestAppendOp_receivedAckCallback_ClosesItsOwnChannel(t *testing.T) {
 // assertion rather than as an absent log line.
 type recordingResultChannel struct {
 	channel.ResultChannel
-	mu    sync.Mutex
-	sends []error
+	mu       sync.Mutex
+	sends    []error
+	closeErr error
+	closes   int
 }
 
 func newRecordingChannel(identifier string) *recordingResultChannel {
@@ -182,6 +184,27 @@ func (r *recordingResultChannel) SendResult(ctx context.Context, result *channel
 func (r *recordingResultChannel) seed(t *testing.T, result *channel.AppendResult) {
 	t.Helper()
 	require.NoError(t, r.ResultChannel.SendResult(context.Background(), result))
+}
+
+// Close reports closeErr when one is set, standing in for a ResultChannel
+// implementation whose close can fail. Neither of the two in the repo can, so
+// this is the only way to reach the handling of that error.
+func (r *recordingResultChannel) Close(ctx context.Context) error {
+	r.mu.Lock()
+	r.closes++
+	forced := r.closeErr
+	r.mu.Unlock()
+	closeErr := r.ResultChannel.Close(ctx)
+	if forced != nil {
+		return forced
+	}
+	return closeErr
+}
+
+func (r *recordingResultChannel) closeCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.closes
 }
 
 func (r *recordingResultChannel) sendCount() int {
@@ -254,4 +277,26 @@ func TestAppendOp_FastFail_SkipsChannelsTheirReaderRetired(t *testing.T) {
 	assert.Equal(t, 0, retired.sendCount(), "a retired channel has no waiter left to wake")
 	assert.Equal(t, 1, live.sendCount(), "a live waiter must still be stopped, and told why")
 	assert.True(t, live.IsClosed(), "FastFail still closes what it woke")
+}
+
+// TestAppendOp_receivedAckCallback_CloseFailureDoesNotStopTheAck pins that
+// retiring the channel is best-effort: a close that fails is logged and the
+// replica's ack still reaches the quorum bookkeeping. Nothing in the repo has a
+// Close that can fail, so a double is the only way to exercise the handling.
+func TestAppendOp_receivedAckCallback_CloseFailureDoesNotStopTheAck(t *testing.T) {
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(3)).Return().Once()
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"),
+		func(int64, int64, error) {}, nil, mockHandle,
+		&proto.QuorumInfo{Wq: 1, Aq: 1, Es: 1, Nodes: []string{"n1"}}, nil)
+
+	resultChan := newRecordingChannel(op.Identifier())
+	resultChan.closeErr = werr.ErrInternalError
+	resultChan.seed(t, &channel.AppendResult{SyncedId: 3})
+	op.resultChannels = []channel.ResultChannel{resultChan}
+
+	op.receivedAckCallback(context.Background(), time.Now(), 3, resultChan, nil, 0, "n1")
+
+	assert.True(t, op.completed.Load(), "a failed close must not stop the ack from reaching quorum")
+	assert.Equal(t, 1, resultChan.closeCount(), "the retire is attempted exactly once, not retried")
 }

--- a/woodpecker/segment/append_op_replica_lifetime_test.go
+++ b/woodpecker/segment/append_op_replica_lifetime_test.go
@@ -423,3 +423,55 @@ func TestReplicaOutcome_ClassifiesTheSameWayTheAckPathsDo(t *testing.T) {
 	assert.Equal(t, "", replicaOutcome(&channel.AppendResult{SyncedId: entryId - 1}, entryId),
 		"a replica still catching up has not answered for this entry")
 }
+
+// remoteAnswerChannel is a RemoteResultChannel whose stream answers "sync
+// failed" - the shape a server-reported write failure actually reaches the
+// client in on the service-mode path, where ReadResult returns a non-nil result
+// AND a non-nil error. A local channel reports the same answer with no error, so
+// keying the post-quorum recording on the error rather than the result would
+// count it in embedded mode and drop it in service mode.
+func remoteAnswerChannel(t *testing.T, identifier string, entryId int64) *channel.RemoteResultChannel {
+	t.Helper()
+	resultChan := channel.NewRemoteResultChannel(identifier)
+	streamCtx, streamCancel := context.WithCancel(context.Background())
+	t.Cleanup(streamCancel)
+	resultChan.InitResponseStream(&failedAckStream{
+		streamCtx: streamCtx,
+		response: &proto.AddEntryResponse{
+			EntryId: entryId,
+			State:   proto.AddEntryState_Failed,
+			Status:  &proto.Status{Code: 500},
+		},
+	}, streamCtx, streamCancel)
+	return resultChan
+}
+
+type failedAckStream struct {
+	streamCtx context.Context
+	response  *proto.AddEntryResponse
+}
+
+func (s *failedAckStream) Recv() (*proto.AddEntryResponse, error) { return s.response, nil }
+func (s *failedAckStream) CloseSend() error                       { return nil }
+func (s *failedAckStream) Header() (metadata.MD, error)           { return nil, nil }
+func (s *failedAckStream) Trailer() metadata.MD                   { return nil }
+func (s *failedAckStream) Context() context.Context               { return s.streamCtx }
+func (s *failedAckStream) SendMsg(m any) error                    { return nil }
+func (s *failedAckStream) RecvMsg(m any) error                    { return nil }
+
+// TestAppendOp_RemoteReplicaAnsweringWithAFailureAfterQuorumIsCounted is the
+// service-mode form of the post-quorum rule: a replica that answered is counted
+// even though its answer arrives alongside an error.
+func TestAppendOp_RemoteReplicaAnsweringWithAFailureAfterQuorumIsCounted(t *testing.T) {
+	op, _ := answeringOp(t, 909005, 3, 3)
+	op.fastCalled.Store(true)
+	before := replicaOutcomeCount(op, "error")
+
+	answered := remoteAnswerChannel(t, op.Identifier(), 3)
+	op.resultChannels[0] = answered
+	op.receivedAckCallback(context.Background(), time.Now(), 3, answered, nil, 0, "n0")
+
+	assert.Equal(t, float64(1), replicaOutcomeCount(op, "error")-before,
+		"a remote replica that answered with a write failure is a real failure, "+
+			"even though ReadResult reports it as an error as well as a result")
+}

--- a/woodpecker/segment/append_op_replica_lifetime_test.go
+++ b/woodpecker/segment/append_op_replica_lifetime_test.go
@@ -18,17 +18,21 @@ package segment
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
 	"github.com/zilliztech/woodpecker/common/channel"
+	"github.com/zilliztech/woodpecker/common/metrics"
+	"github.com/zilliztech/woodpecker/common/topology"
 	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_segment_handle"
 	"github.com/zilliztech/woodpecker/proto"
@@ -299,4 +303,123 @@ func TestAppendOp_receivedAckCallback_CloseFailureDoesNotStopTheAck(t *testing.T
 
 	assert.True(t, op.completed.Load(), "a failed close must not stop the ack from reaching quorum")
 	assert.Equal(t, 1, resultChan.closeCount(), "the retire is attempted exactly once, not retried")
+}
+
+// replicaOutcomeCount reads the per-replica counter for one op's log. The tests
+// below use a distinct logId each so they do not see one another's counts.
+func replicaOutcomeCount(op *AppendOp, status string) float64 {
+	return testutil.ToFloat64(metrics.WpClientReplicaAppendTotal.WithLabelValues(
+		op.logNs, strconv.FormatInt(op.logId, 10), topology.ScopeUnknown, status))
+}
+
+// answeringOp builds an op whose replicas all have an answer waiting, and a
+// handle that runs the real FastSuccess the moment the quorum is reached - the
+// way SendAppendSuccessCallbacks drives it in production.
+func answeringOp(t *testing.T, logId int64, replicas int32, ackQuorum int32) (*AppendOp, []channel.ResultChannel) {
+	t.Helper()
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	nodes := make([]string, replicas)
+	for i := range nodes {
+		nodes[i] = "n" + strconv.Itoa(i)
+	}
+	op := NewAppendOp("a-bucket", "files", logId, 2, 3, []byte("0123456789"),
+		func(int64, int64, error) {}, nil, mockHandle,
+		&proto.QuorumInfo{Wq: replicas, Aq: ackQuorum, Es: replicas, Nodes: nodes}, nil)
+
+	mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(3)).
+		Run(func(ctx context.Context, _ int64) { op.FastSuccess(ctx) }).Return().Maybe()
+
+	channels := make([]channel.ResultChannel, replicas)
+	for i := range channels {
+		local := channel.NewLocalResultChannel(op.Identifier())
+		require.NoError(t, local.SendResult(context.Background(), &channel.AppendResult{SyncedId: 3}))
+		channels[i] = local
+	}
+	op.resultChannels = channels
+	return op, channels
+}
+
+// TestAppendOp_ReplicaAnsweringAfterQuorumIsStillCounted pins what the
+// per-replica counters measure. With Es=3/Aq=2 the third replica answers after
+// the quorum has already completed the op, and its answer used to be dropped by
+// the fast-completed guard - so a cluster writing three copies reported about
+// two outcomes per entry, and replica_append_bytes_total understated cross-AZ
+// write traffic by the same proportion.
+func TestAppendOp_ReplicaAnsweringAfterQuorumIsStillCounted(t *testing.T) {
+	op, channels := answeringOp(t, 909001, 3, 2)
+	before := replicaOutcomeCount(op, "success")
+
+	for i, resultChan := range channels {
+		op.receivedAckCallback(context.Background(), time.Now(), 3, resultChan, nil, i, "n"+strconv.Itoa(i))
+	}
+
+	require.True(t, op.fastCalled.Load(), "the quorum must have completed the op")
+	assert.Equal(t, float64(3), replicaOutcomeCount(op, "success")-before,
+		"every replica that answered must be counted, not just the ack quorum")
+}
+
+// TestApplyNodeAck_ReplicaAnsweringAfterQuorumIsStillCounted is the same
+// property on the batch drain, which applies acks through applyNodeAck.
+func TestApplyNodeAck_ReplicaAnsweringAfterQuorumIsStillCounted(t *testing.T) {
+	op, _ := answeringOp(t, 909002, 3, 2)
+	before := replicaOutcomeCount(op, "success")
+
+	for i := 0; i < 3; i++ {
+		op.applyNodeAck(context.Background(), time.Now(), &channel.AppendResult{SyncedId: 3}, nil, i, "n"+strconv.Itoa(i))
+	}
+
+	require.True(t, op.fastCalled.Load(), "the quorum must have completed the op")
+	assert.Equal(t, float64(3), replicaOutcomeCount(op, "success")-before,
+		"every replica that answered must be counted, not just the ack quorum")
+}
+
+// TestAppendOp_ReplicaFailingAfterCompletionIsNotCounted is the other half of
+// the rule. Once the op has completed, a read that FAILED may be our own doing -
+// FastFail cancels every replica still in flight - so it must not land in the
+// error series. Only an answer counts.
+func TestAppendOp_ReplicaFailingAfterCompletionIsNotCounted(t *testing.T) {
+	op, _ := answeringOp(t, 909003, 3, 3)
+	op.fastCalled.Store(true) // as FastFail leaves it
+	beforeErr := replicaOutcomeCount(op, "error")
+	beforeOK := replicaOutcomeCount(op, "success")
+
+	// A replica that had not answered when FastFail closed its channel: the read
+	// fails, and the failure is the close we performed.
+	cancelled := channel.NewLocalResultChannel(op.Identifier())
+	require.NoError(t, cancelled.Close(context.Background()))
+	op.resultChannels[0] = cancelled
+	op.receivedAckCallback(context.Background(), time.Now(), 3, cancelled, nil, 0, "n0")
+
+	assert.Equal(t, float64(0), replicaOutcomeCount(op, "error")-beforeErr,
+		"a cancellation we caused is not the replica's failure")
+	assert.Equal(t, float64(0), replicaOutcomeCount(op, "success")-beforeOK)
+}
+
+// TestAppendOp_ReplicaAnsweringWithAnErrorAfterQuorumIsCounted keeps the
+// post-quorum classification honest: an answer that reports a failure is a real
+// failure and belongs in the error series, unlike the cancellation above.
+func TestAppendOp_ReplicaAnsweringWithAnErrorAfterQuorumIsCounted(t *testing.T) {
+	op, _ := answeringOp(t, 909004, 3, 3)
+	op.fastCalled.Store(true)
+	before := replicaOutcomeCount(op, "error")
+
+	op.applyNodeAck(context.Background(), time.Now(),
+		&channel.AppendResult{SyncedId: -1, Err: werr.ErrFileWriterSyncFailed}, nil, 0, "n0")
+
+	assert.Equal(t, float64(1), replicaOutcomeCount(op, "error")-before,
+		"a replica that answered with a failure is a real failure")
+}
+
+// TestReplicaOutcome_ClassifiesTheSameWayTheAckPathsDo guards the one duplication
+// left: replicaOutcome mirrors the branches receivedAckCallback and applyNodeAck
+// take when the op has NOT completed, and the two must not drift.
+func TestReplicaOutcome_ClassifiesTheSameWayTheAckPathsDo(t *testing.T) {
+	const entryId = int64(7)
+	assert.Equal(t, "success", replicaOutcome(&channel.AppendResult{SyncedId: entryId}, entryId))
+	assert.Equal(t, "success", replicaOutcome(&channel.AppendResult{SyncedId: entryId + 1}, entryId))
+	assert.Equal(t, "error", replicaOutcome(&channel.AppendResult{SyncedId: -1}, entryId))
+	assert.Equal(t, "error", replicaOutcome(&channel.AppendResult{SyncedId: entryId, Err: werr.ErrFileWriterSyncFailed}, entryId))
+	assert.Equal(t, "error", replicaOutcome(nil, entryId))
+	assert.Equal(t, "", replicaOutcome(&channel.AppendResult{SyncedId: entryId - 1}, entryId),
+		"a replica still catching up has not answered for this entry")
 }

--- a/woodpecker/segment/append_op_retry_sequence_test.go
+++ b/woodpecker/segment/append_op_retry_sequence_test.go
@@ -1,0 +1,251 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package segment
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/woodpecker/common/channel"
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/common/werr"
+	"github.com/zilliztech/woodpecker/meta"
+	"github.com/zilliztech/woodpecker/mocks/mocks_meta"
+	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_logstore_client"
+	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_segment_handle"
+	"github.com/zilliztech/woodpecker/proto"
+)
+
+// The tests above cover each piece of the ack path on its own. These cover the
+// sequences the pieces exist for: a replica that accepts an entry and then goes
+// quiet, and what the retry machinery does with it.
+
+// shrinkAppendAckReadTimeout makes the single-entry ack wait finish in test time.
+func shrinkAppendAckReadTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	previous := appendAckReadTimeout
+	appendAckReadTimeout = d
+	t.Cleanup(func() { appendAckReadTimeout = previous })
+}
+
+// TestAppendOp_AckReadTimeout_IsReportedAsRetryable covers a replica that
+// accepted the entry and never sent its durability ack.
+//
+// The read has to give up on its own - Recv observes only the stream's context -
+// and how it reports that decides everything downstream. A bare gRPC status
+// would be classified as neither a timeout nor retryable, so the entry would go
+// terminal with none of its retries spent.
+func TestAppendOp_AckReadTimeout_IsReportedAsRetryable(t *testing.T) {
+	shrinkAppendAckReadTimeout(t, 150*time.Millisecond)
+
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"),
+		func(int64, int64, error) {}, nil, mockHandle,
+		&proto.QuorumInfo{Wq: 3, Aq: 2, Es: 3, Nodes: []string{"n1", "n2", "n3"}}, nil)
+
+	reported := make(chan error, 1)
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, int64(3), mock.Anything, 0, "n1").
+		Run(func(_ context.Context, _ int64, failure error, _ int, _ string) { reported <- failure }).
+		Return().Once()
+
+	silent, _ := inFlightReplicas(t, op, 1)
+	op.receivedAckCallback(context.Background(), time.Now(), 3, silent[0], nil, 0, "n1")
+
+	var failure error
+	select {
+	case failure = <-reported:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a read that ran out of its budget must be reported, not swallowed")
+	}
+
+	require.Error(t, failure)
+	assert.True(t, werr.IsRetryableErr(failure),
+		"a timeout is not a terminal failure: the entry must keep its retries")
+	assert.ErrorIs(t, failure, context.DeadlineExceeded,
+		"the read-timeout log branch tests for this")
+	assert.True(t, werr.IsRetryableErr(op.channelErrors[0]),
+		"the error kept for the retry decision must be the same one")
+}
+
+// TestAppendOp_Retry_SecondAttemptSucceeds covers the sequence a fresh channel
+// per attempt exists for: the first attempt's goroutine retires its own channel
+// while the retry is already opening the next one. Sharing the slot let that
+// close land on the retry's stream, failing an attempt that had just started.
+func TestAppendOp_Retry_SecondAttemptSucceeds(t *testing.T) {
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}}
+
+	op := NewAppendOp("bucket", "root", 1, 2, 10, []byte("v"),
+		func(int64, int64, error) {}, mockPool, mockHandle, quorumInfo, nil)
+	op.resultChannels = make([]channel.ResultChannel, 1)
+
+	mockClient.EXPECT().IsRemoteClient().Return(false).Maybe()
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node1").Return(mockClient, nil)
+
+	var mu sync.Mutex
+	handedOut := make([]channel.ResultChannel, 0, 2)
+	firstFailed := make(chan struct{})
+	mockClient.EXPECT().
+		AppendEntry(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ string, _ int64, _ *proto.LogEntry, ch channel.ResultChannel) (int64, error) {
+			mu.Lock()
+			attempt := len(handedOut)
+			handedOut = append(handedOut, ch)
+			mu.Unlock()
+			if attempt == 0 {
+				// A retryable send failure: no ack will ever arrive on this one.
+				return -1, werr.ErrSegmentHandleSegmentRolling
+			}
+			// The retry's replica answers.
+			require.NoError(t, ch.SendResult(context.Background(), &channel.AppendResult{SyncedId: 10}))
+			return 10, nil
+		})
+
+	// The first attempt's failure is what schedules the retry; run it inline so
+	// the two attempts interleave the way the executor makes them.
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, int64(10), mock.Anything, 0, "node1").
+		Run(func(context.Context, int64, error, int, string) { close(firstFailed) }).Return().Once()
+	acked := make(chan struct{})
+	mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(10)).
+		Run(func(context.Context, int64) { close(acked) }).Return().Once()
+
+	op.Execute()
+	select {
+	case <-firstFailed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the first attempt should have failed")
+	}
+
+	NewAppendRequestRetryOp(context.Background(), 0, op).Execute()
+	select {
+	case <-acked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the retry's ack never reached the quorum: an earlier attempt's close took its channel")
+	}
+
+	// Reaching the ack at all is the proof: the first attempt's goroutine retired
+	// its channel while the retry was opening the next one, and the retry's ack
+	// still landed. Sharing the slot is what used to make that close reach the
+	// retry's stream instead.
+	assert.True(t, op.completed.Load(), "the op completes on the retry")
+	waitAckGoroutinesDone(t, op)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, handedOut, 2)
+	assert.NotSame(t, handedOut[0], handedOut[1], "each attempt gets its own channel")
+	// Each attempt's own goroutine retires the channel it was handed, so both end
+	// closed - the point is that they were never the same object.
+	assert.True(t, handedOut[0].IsClosed())
+	assert.True(t, handedOut[1].IsClosed())
+}
+
+// TestSegmentHandle_AckReadTimeout_FailsTheEntryAfterItsRetries drives the whole
+// sequence through a real segment handle: a replica accepts every attempt and
+// answers none, so each attempt costs one ack budget and the entry is given up
+// on once its retries are spent.
+//
+// This is what the caller experiences from an unresponsive replica. Before the
+// read had a budget it experienced nothing at all - the ack goroutine blocked
+// for as long as the connection survived and the append never came back.
+func TestSegmentHandle_AckReadTimeout_FailsTheEntryAfterItsRetries(t *testing.T) {
+	shrinkAppendAckReadTimeout(t, 150*time.Millisecond)
+
+	mockMetadata := mocks_meta.NewMetadataProvider(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	mockClient.EXPECT().IsRemoteClient().Return(true).Maybe()
+	mockClient.EXPECT().UpdateLastAddConfirmed(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil).Maybe()
+	// Giving up on an entry puts the segment into rolling, which fences and
+	// completes it; that is the existing failure path, not what this test is
+	// about, so it only needs to be allowed to happen.
+	mockClient.EXPECT().FenceSegment(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
+	mockClient.EXPECT().CompleteSegment(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
+	mockMetadata.EXPECT().UpdateSegmentMetadata(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockMetadata.EXPECT().GetSegmentMetadata(mock.Anything, mock.Anything, mock.Anything).Return(&meta.SegmentMeta{
+		Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Completed, LastEntryId: -1},
+		Revision: 2,
+	}, nil).Maybe()
+
+	// Every attempt is accepted and then never answered, which is what a peer
+	// that buffers the entry and stops responding looks like from here.
+	var mu sync.Mutex
+	attempts := 0
+	mockClient.EXPECT().
+		AppendEntry(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ string, _ int64, entry *proto.LogEntry, ch channel.ResultChannel) (int64, error) {
+			mu.Lock()
+			attempts++
+			mu.Unlock()
+			return entry.EntryId, nil // buffered; no durability ack will follow
+		})
+
+	const maxRetries = 2
+	cfg := &config.Configuration{
+		Woodpecker: config.WoodpeckerConfig{
+			Client: config.ClientConfig{
+				SegmentAppend: config.SegmentAppendConfig{QueueSize: 10, MaxRetries: maxRetries},
+			},
+		},
+	}
+	segmentMeta := &meta.SegmentMeta{
+		Metadata: &proto.SegmentMetadata{
+			SegNo: 1, State: proto.SegmentState_Active, LastEntryId: -1,
+			Quorum: &proto.QuorumInfo{Id: 1, Aq: 1, Es: 1, Wq: 1, Nodes: []string{"127.0.0.1"}},
+		},
+		Revision: 1,
+	}
+	segmentHandle := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockPool, cfg, true, nil)
+
+	failed := make(chan error, 1)
+	segmentHandle.AppendAsync(context.Background(), []byte("stalled"), func(_ int64, _ int64, err error) {
+		failed <- err
+	})
+
+	select {
+	case err := <-failed:
+		require.Error(t, err, "an entry no replica ever acknowledged must come back as a failure")
+	case <-time.After(30 * time.Second):
+		t.Fatal("the entry never came back: an unanswered ack must not block the caller forever")
+	}
+
+	mu.Lock()
+	attemptsMade := attempts
+	mu.Unlock()
+	assert.Equal(t, maxRetries, attemptsMade,
+		"the entry spends every retry it has before being given up on, one ack budget each")
+
+	// The give-up rolls the segment on a background goroutine; let it finish so
+	// the mocks are not exercised after the test returns.
+	assert.Eventually(t, func() bool {
+		segImpl := segmentHandle.(*segmentHandleImpl)
+		segImpl.RLock()
+		defer segImpl.RUnlock()
+		return segImpl.appendOpsQueue.Len() == 0
+	}, 10*time.Second, 10*time.Millisecond)
+}

--- a/woodpecker/segment/append_op_test.go
+++ b/woodpecker/segment/append_op_test.go
@@ -533,25 +533,16 @@ func TestAppendOp_FastSuccess(t *testing.T) {
 	// Execute FastSuccess
 	op.FastSuccess(context.Background())
 
-	// Verify channels received success signal
-	ctx1, cancel1 := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel1()
-	result1, err1 := rc1.ReadResult(ctx1)
-	assert.NoError(t, err1)
-	assert.Equal(t, int64(3), result1.SyncedId)
-
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel2()
-	result2, err2 := rc2.ReadResult(ctx2)
-	assert.NoError(t, err2)
-	assert.Equal(t, int64(3), result2.SyncedId)
-
-	// Channels must stay OPEN. Quorum is satisfied, but the replicas outside it
-	// are still answering, and closing a RemoteResultChannel cancels the
-	// replica's stream mid-answer. Each channel is closed by its own
-	// receivedAckCallback once that replica has actually answered.
+	// FastSuccess leaves every replica channel exactly as it found it: open, and
+	// carrying nothing. The replicas outside the quorum are still answering, and
+	// a synthetic success would be read instead of the real answer - or, on the
+	// batch path, fill the one-slot buffer so the real ack is dropped.
 	assert.False(t, rc1.IsClosed(), "FastSuccess must not close a replica's channel")
 	assert.False(t, rc2.IsClosed(), "FastSuccess must not close a replica's channel")
+	_, ok1 := rc1.TryReadResult()
+	_, ok2 := rc2.TryReadResult()
+	assert.False(t, ok1, "FastSuccess must not write into a replica's channel")
+	assert.False(t, ok2, "FastSuccess must not write into a replica's channel")
 
 	// Verify fastCalled flag is set
 	assert.True(t, op.fastCalled.Load())
@@ -567,15 +558,11 @@ func TestAppendOp_FastSuccess_Idempotent(t *testing.T) {
 	op.FastSuccess(context.Background())
 	op.FastSuccess(context.Background()) // Should be no-op
 
-	// Verify only one signal was sent
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	result, err := rc.ReadResult(ctx)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(3), result.SyncedId)
-
-	// Still open: FastSuccess never closes, however many times it is called.
+	assert.True(t, op.fastCalled.Load())
+	// Untouched, however many times it is called.
 	assert.False(t, rc.IsClosed())
+	_, ok := rc.TryReadResult()
+	assert.False(t, ok)
 }
 
 func TestAppendOp_FastFail_WithClosedChannel(t *testing.T) {
@@ -644,21 +631,16 @@ func TestAppendOp_ConcurrentFastCalls(t *testing.T) {
 	assert.True(t, op.fastCalled.Load())
 	assert.Equal(t, 10, callCount) // All calls completed
 
-	// Verify channel received exactly one signal
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	result, err := rc.ReadResult(ctx)
-	assert.NoError(t, err)
-	assert.True(t, result.SyncedId == -1 || result.SyncedId == 3) // Either success or failure
-
 	// Exactly one of the ten calls won the CAS, and the two endings differ on
-	// purpose: FastFail closes so the waiters stop at once, FastSuccess leaves
-	// the channel for the replica's own ack goroutine to close. The close state
-	// must therefore agree with whichever result landed.
-	if result.SyncedId == -1 {
+	// purpose: FastFail stops the waiters at once, with the reason; FastSuccess
+	// leaves the channel entirely to the replica's own ack goroutine. So either
+	// the channel is closed and carries the failure, or it is untouched.
+	result, ok := rc.TryReadResult()
+	if ok {
+		assert.Equal(t, int64(-1), result.SyncedId, "only FastFail writes a result")
 		assert.True(t, rc.IsClosed(), "FastFail won the race: it closes the channel")
 	} else {
-		assert.False(t, rc.IsClosed(), "FastSuccess won the race: it leaves the channel open")
+		assert.False(t, rc.IsClosed(), "FastSuccess won the race: it leaves the channel alone")
 	}
 }
 

--- a/woodpecker/segment/append_op_test.go
+++ b/woodpecker/segment/append_op_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/zilliztech/woodpecker/common/channel"
 	"github.com/zilliztech/woodpecker/common/werr"
@@ -38,6 +39,27 @@ import (
 // cleanupAppendOp stops background goroutines spawned by Execute().
 // It sets fastCalled to make goroutines exit early after ReadResult returns,
 // then closes all result channels to unblock them.
+// waitAckGoroutinesDone waits until every result channel the op holds has been
+// closed by the goroutine that was reading it.
+//
+// Tests normally observe "the ack was processed" through a mock call made from
+// inside receivedAckCallback - SendAppendSuccessCallbacks or
+// HandleAppendRequestFailure - and both of those run BEFORE its deferred close.
+// Returning at that point leaves the goroutine still writing to the channel while
+// the mock's AssertExpectations cleanup reflects over that same object without
+// holding its lock, which the race detector reports.
+func waitAckGoroutinesDone(t *testing.T, op *AppendOp) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		for _, resultChan := range op.resultChannels {
+			if resultChan != nil && !resultChan.IsClosed() {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 2*time.Millisecond, "an ack goroutine is still holding a result channel")
+}
+
 func cleanupAppendOp(t *testing.T, op *AppendOp) {
 	t.Helper()
 	op.fastCalled.Store(true)
@@ -100,9 +122,14 @@ func TestAppendOp_Retry_RebuildsResultChannelForRemoteClient(t *testing.T) {
 		t.Fatal("receivedAckCallback did not complete")
 	}
 
-	_, isRemote := captured.(*channel.RemoteResultChannel)
-	assert.True(t, isRemote,
+	remoteChannel, isRemote := captured.(*channel.RemoteResultChannel)
+	require.True(t, isRemote,
 		"retry must rebuild a RemoteResultChannel for a remote client, not reuse the batch's LocalResultChannel")
+
+	// done is signalled from inside HandleAppendRequestFailure, which runs before
+	// receivedAckCallback's deferred close.
+	waitAckGoroutinesDone(t, op)
+	assert.True(t, remoteChannel.IsClosed(), "the ack goroutine must close the channel it was handed")
 }
 
 // newApplyNodeAckOp builds an AppendOp wired only for applyNodeAck unit tests
@@ -231,7 +258,7 @@ func TestAppendOp_RetryChannelRebuild_RacesWithFastFail(t *testing.T) {
 		close(start)
 		wg.Wait()
 		// Let the retry's spawned receivedAckCallback finish before mock teardown.
-		time.Sleep(5 * time.Millisecond)
+		waitAckGoroutinesDone(t, op)
 	}
 }
 
@@ -323,6 +350,11 @@ func TestAppendOp_Execute_Success(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for goroutine to complete")
 	}
+
+	// Not every replica's outcome is awaited above (a failing replica's
+	// HandleAppendRequestFailure is mocked but never joined), so wait for the
+	// goroutines themselves before the mocks are asserted.
+	waitAckGoroutinesDone(t, op)
 }
 
 func TestAppendOp_Execute_GetClientError(t *testing.T) {
@@ -349,6 +381,11 @@ func TestAppendOp_Execute_GetClientError(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	assert.Equal(t, expectedErr, op.channelErrors[0])
+
+	// Not every replica's outcome is awaited above (a failing replica's
+	// HandleAppendRequestFailure is mocked but never joined), so wait for the
+	// goroutines themselves before the mocks are asserted.
+	waitAckGoroutinesDone(t, op)
 }
 
 func TestAppendOp_receivedAckCallback_Success(t *testing.T) {
@@ -455,7 +492,8 @@ func TestAppendOp_FastFail(t *testing.T) {
 	assert.NoError(t, err2)
 	assert.Equal(t, int64(-1), result2.SyncedId)
 
-	// Verify channels are closed
+	// FastFail still closes, deliberately: the entry is abandoned, so every
+	// waiter should stop at once instead of sitting out its read budget.
 	assert.True(t, rc1.IsClosed())
 	assert.True(t, rc2.IsClosed())
 
@@ -508,9 +546,12 @@ func TestAppendOp_FastSuccess(t *testing.T) {
 	assert.NoError(t, err2)
 	assert.Equal(t, int64(3), result2.SyncedId)
 
-	// Verify channels are closed
-	assert.True(t, rc1.IsClosed())
-	assert.True(t, rc2.IsClosed())
+	// Channels must stay OPEN. Quorum is satisfied, but the replicas outside it
+	// are still answering, and closing a RemoteResultChannel cancels the
+	// replica's stream mid-answer. Each channel is closed by its own
+	// receivedAckCallback once that replica has actually answered.
+	assert.False(t, rc1.IsClosed(), "FastSuccess must not close a replica's channel")
+	assert.False(t, rc2.IsClosed(), "FastSuccess must not close a replica's channel")
 
 	// Verify fastCalled flag is set
 	assert.True(t, op.fastCalled.Load())
@@ -533,8 +574,8 @@ func TestAppendOp_FastSuccess_Idempotent(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int64(3), result.SyncedId)
 
-	// Channel should be closed
-	assert.True(t, rc.IsClosed())
+	// Still open: FastSuccess never closes, however many times it is called.
+	assert.False(t, rc.IsClosed())
 }
 
 func TestAppendOp_FastFail_WithClosedChannel(t *testing.T) {
@@ -610,8 +651,15 @@ func TestAppendOp_ConcurrentFastCalls(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, result.SyncedId == -1 || result.SyncedId == 3) // Either success or failure
 
-	// Channel should be closed
-	assert.True(t, rc.IsClosed())
+	// Exactly one of the ten calls won the CAS, and the two endings differ on
+	// purpose: FastFail closes so the waiters stop at once, FastSuccess leaves
+	// the channel for the replica's own ack goroutine to close. The close state
+	// must therefore agree with whichever result landed.
+	if result.SyncedId == -1 {
+		assert.True(t, rc.IsClosed(), "FastFail won the race: it closes the channel")
+	} else {
+		assert.False(t, rc.IsClosed(), "FastSuccess won the race: it leaves the channel open")
+	}
 }
 
 func TestAppendOp_toSegmentEntry(t *testing.T) {
@@ -651,9 +699,18 @@ func TestAppendOp_receivedAckCallback_Timeout(t *testing.T) {
 	assert.True(t, elapsed < 200*time.Millisecond) // Ensure test doesn't hang
 }
 
-// TestAppendOp_Execute_RetryIdempotency tests that retry operations are idempotent
-// by verifying that result channels are reused across multiple Execute calls
-func TestAppendOp_Execute_RetryIdempotency(t *testing.T) {
+// TestAppendOp_Retry_UsesAFreshResultChannelPerAttempt pins the ownership rule
+// that lets receivedAckCallback close the channel it was handed: every attempt
+// gets its own.
+//
+// Reuse used to be asserted here as "retry idempotency", but it never carried
+// any idempotency - the entry id does that, server-side. What reuse actually did
+// was let two attempts share one container while InitResponseStream replaced the
+// stream, context and cancel inside it, dropping the previous attempt's cancel
+// and leaving any recorded result in place for the next read to return. With the
+// ack goroutine now closing its own channel (outside op.mu), a shared container
+// would also let one attempt's close cancel the next attempt's stream.
+func TestAppendOp_Retry_UsesAFreshResultChannelPerAttempt(t *testing.T) {
 	// Setup mocks
 	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
 	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
@@ -685,30 +742,37 @@ func TestAppendOp_Execute_RetryIdempotency(t *testing.T) {
 	assert.NotNil(t, op.resultChannels[0])
 	assert.NotNil(t, op.resultChannels[1])
 
-	// Store references to original channels
-	originalChannel0 := op.resultChannels[0]
-	originalChannel1 := op.resultChannels[1]
+	// Store references to the first attempt's channels
+	firstChannel0 := op.resultChannels[0]
+	firstChannel1 := op.resultChannels[1]
 
 	// Second execution (simulating retry)
 	op.Execute()
 
-	// Verify channels are reused (idempotent)
 	assert.Equal(t, 2, len(op.resultChannels))
-	assert.Same(t, originalChannel0, op.resultChannels[0], "Channel 0 should be reused on retry")
-	assert.Same(t, originalChannel1, op.resultChannels[1], "Channel 1 should be reused on retry")
+	assert.NotSame(t, firstChannel0, op.resultChannels[0], "retry must build its own channel")
+	assert.NotSame(t, firstChannel1, op.resultChannels[1], "retry must build its own channel")
+
+	secondChannel0 := op.resultChannels[0]
 
 	// Third execution (simulating another retry)
 	op.Execute()
 
-	// Verify channels are still the same
 	assert.Equal(t, 2, len(op.resultChannels))
-	assert.Same(t, originalChannel0, op.resultChannels[0], "Channel 0 should be reused on multiple retries")
-	assert.Same(t, originalChannel1, op.resultChannels[1], "Channel 1 should be reused on multiple retries")
+	assert.NotSame(t, firstChannel0, op.resultChannels[0], "every attempt gets a new channel")
+	assert.NotSame(t, secondChannel0, op.resultChannels[0], "every attempt gets a new channel")
+
+	// The decisive property: retiring an earlier attempt's channel must not
+	// touch the live one. This is what a shared container would have broken -
+	// the earlier ack goroutine's close would have cancelled the newest stream.
+	_ = firstChannel0.Close(context.Background())
+	assert.False(t, op.resultChannels[0].IsClosed(),
+		"closing an earlier attempt's channel must leave the current attempt alone")
 }
 
-// TestAppendOp_Execute_RetryIdempotency_WithSameQuorumSize tests idempotency
-// when quorum info is refreshed but maintains the same size
-func TestAppendOp_Execute_RetryIdempotency_WithSameQuorumSize(t *testing.T) {
+// TestAppendOp_Retry_BuildsFreshChannelsAcrossQuorumRefresh covers the same rule
+// when the quorum is refreshed to the same size, so the slice is not reallocated.
+func TestAppendOp_Retry_BuildsFreshChannelsAcrossQuorumRefresh(t *testing.T) {
 	// Setup mocks
 	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
 	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
@@ -740,22 +804,22 @@ func TestAppendOp_Execute_RetryIdempotency_WithSameQuorumSize(t *testing.T) {
 	assert.NotNil(t, op.resultChannels[0])
 	assert.NotNil(t, op.resultChannels[1])
 
-	// Store references to original channels
-	originalChannel0 := op.resultChannels[0]
-	originalChannel1 := op.resultChannels[1]
+	// Store references to the first attempt's channels
+	firstChannel0 := op.resultChannels[0]
+	firstChannel1 := op.resultChannels[1]
 
 	// Second execution with same quorum size (simulating retry with refreshed quorum info)
 	op.Execute()
 
-	// Verify that existing channels are preserved
 	assert.Equal(t, 2, len(op.resultChannels))
-	assert.Same(t, originalChannel0, op.resultChannels[0], "Channel 0 should be preserved")
-	assert.Same(t, originalChannel1, op.resultChannels[1], "Channel 1 should be preserved")
+	assert.NotSame(t, firstChannel0, op.resultChannels[0], "retry must build its own channel")
+	assert.NotSame(t, firstChannel1, op.resultChannels[1], "retry must build its own channel")
 }
 
-// TestAppendOp_sendWriteRequest_ChannelReuse tests that sendWriteRequest
-// creates channels only once per server
-func TestAppendOp_sendWriteRequest_ChannelReuse(t *testing.T) {
+// TestAppendOp_sendWriteRequest_BuildsANewChannelEachCall pins the rule at its
+// source: sendWriteRequest builds the channel, one per send, never reusing the
+// slot it is about to overwrite.
+func TestAppendOp_sendWriteRequest_BuildsANewChannelEachCall(t *testing.T) {
 	// Setup mocks
 	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
 	mockClient := mocks_logstore_client.NewLogStoreClient(t)
@@ -782,18 +846,18 @@ func TestAppendOp_sendWriteRequest_ChannelReuse(t *testing.T) {
 
 	// Verify channel was created
 	assert.NotNil(t, op.resultChannels[0])
-	originalChannel := op.resultChannels[0]
+	firstChannel := op.resultChannels[0]
 
 	// Second call to sendWriteRequest for the same server
 	op.sendWriteRequest(context.Background(), mockClient, 0, "node0")
 
-	// Verify the same channel is reused
-	assert.Same(t, originalChannel, op.resultChannels[0], "Channel should be reused for the same server")
+	assert.NotSame(t, firstChannel, op.resultChannels[0],
+		"each send must own its channel, so the previous send's close cannot reach this one")
 }
 
 // TestAppendOp_Execute_RetryIdempotency_WithNilChannels tests behavior when
 // some channels are nil during retry
-func TestAppendOp_Execute_RetryIdempotency_WithNilChannels(t *testing.T) {
+func TestAppendOp_Execute_ReplacesBothExistingAndNilChannels(t *testing.T) {
 	// Setup mocks
 	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
 	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
@@ -816,28 +880,26 @@ func TestAppendOp_Execute_RetryIdempotency_WithNilChannels(t *testing.T) {
 	op := NewAppendOp("a-bucket", "files", 1, 2, 3, []byte("test"), func(int64, int64, error) {}, mockClientPool, mockHandle, quorumInfo, nil)
 	t.Cleanup(func() { cleanupAppendOp(t, op) })
 
-	// Manually set up result channels with one nil channel (simulating partial failure).
-	// The existing channel must match the client type (remote here) — a matching
-	// channel is reused, whereas a mismatched one is rebuilt (see the retry
-	// channel-type regression test).
+	// One slot already holds a channel of the right type, the other is nil. Both
+	// are replaced: a slot's previous contents are never carried into a send.
 	op.resultChannels = make([]channel.ResultChannel, 2)
 	op.resultChannels[0] = channel.NewRemoteResultChannel("test-channel-0")
-	op.resultChannels[1] = nil // This should be recreated
+	op.resultChannels[1] = nil
 
-	originalChannel0 := op.resultChannels[0]
+	preExistingChannel0 := op.resultChannels[0]
 
 	// Execute should handle nil channels correctly
 	op.Execute()
 
-	// Verify that existing non-nil channel is preserved and nil channel is created
 	assert.Equal(t, 2, len(op.resultChannels))
-	assert.Same(t, originalChannel0, op.resultChannels[0], "Existing matching channel should be preserved")
+	assert.NotSame(t, preExistingChannel0, op.resultChannels[0], "an existing channel is replaced, not adopted")
 	assert.NotNil(t, op.resultChannels[1], "Nil channel should be created")
 }
 
-// TestAppendOp_Execute_RetryIdempotency_ChannelIdentifier tests that
-// channels created for retry use the same identifier
-func TestAppendOp_Execute_RetryIdempotency_ChannelIdentifier(t *testing.T) {
+// TestAppendOp_Retry_ChannelKeepsTheOpIdentifier checks that a rebuilt channel
+// still carries the op's identifier, so a retry stays traceable in logs even
+// though the channel object behind it is new.
+func TestAppendOp_Retry_ChannelKeepsTheOpIdentifier(t *testing.T) {
 	// Setup mocks
 	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
 	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
@@ -866,16 +928,15 @@ func TestAppendOp_Execute_RetryIdempotency_ChannelIdentifier(t *testing.T) {
 	assert.Equal(t, 1, len(op.resultChannels))
 	assert.NotNil(t, op.resultChannels[0])
 
-	// We can't directly access the channel's identifier, but we can verify
-	// that the channel is properly created and reused
-	// The identifier should be consistent with the operation's identifier: "1/2/3"
-	originalChannel := op.resultChannels[0]
+	assert.Equal(t, op.Identifier(), op.resultChannels[0].GetIdentifier())
+	firstChannel := op.resultChannels[0]
 
 	// Second execution (retry)
 	op.Execute()
 
-	// Verify the same channel is reused
-	assert.Same(t, originalChannel, op.resultChannels[0], "Channel should be reused with same identifier")
+	assert.NotSame(t, firstChannel, op.resultChannels[0], "retry builds a new channel")
+	assert.Equal(t, op.Identifier(), op.resultChannels[0].GetIdentifier(),
+		"the new channel must still identify itself as this op")
 }
 
 // TestAppendOp_QuorumWrite_Case1_AllNodesSuccess tests quorum write with es=3,wq=3,aq=2
@@ -963,6 +1024,11 @@ func TestAppendOp_QuorumWrite_Case1_AllNodesSuccess(t *testing.T) {
 	assert.Equal(t, int64(2), callbackSegmentId)
 	assert.Equal(t, int64(3), callbackEntryId)
 	assert.NoError(t, callbackErr)
+
+	// Not every replica's outcome is awaited above (a failing replica's
+	// HandleAppendRequestFailure is mocked but never joined), so wait for the
+	// goroutines themselves before the mocks are asserted.
+	waitAckGoroutinesDone(t, op)
 }
 
 // TestAppendOp_QuorumWrite_Case2_TwoSuccessOneFail tests quorum write with es=3,wq=3,aq=2
@@ -1068,6 +1134,11 @@ func TestAppendOp_QuorumWrite_Case2_TwoSuccessOneFail(t *testing.T) {
 	assert.Equal(t, int64(2), callbackSegmentId)
 	assert.Equal(t, int64(3), callbackEntryId)
 	assert.NoError(t, callbackErr, "Should succeed despite 1 node failure")
+
+	// Not every replica's outcome is awaited above (a failing replica's
+	// HandleAppendRequestFailure is mocked but never joined), so wait for the
+	// goroutines themselves before the mocks are asserted.
+	waitAckGoroutinesDone(t, op)
 }
 
 // TestAppendOp_QuorumWrite_Case3_SingleNodeSuccess tests quorum write with es=1,wq=1,aq=1
@@ -1143,6 +1214,11 @@ func TestAppendOp_QuorumWrite_Case3_SingleNodeSuccess(t *testing.T) {
 	assert.Equal(t, int64(2), callbackSegmentId)
 	assert.Equal(t, int64(3), callbackEntryId)
 	assert.NoError(t, callbackErr)
+
+	// Not every replica's outcome is awaited above (a failing replica's
+	// HandleAppendRequestFailure is mocked but never joined), so wait for the
+	// goroutines themselves before the mocks are asserted.
+	waitAckGoroutinesDone(t, op)
 }
 
 // TestAppendOp_QuorumWrite_Case4_SingleNodeFailure tests quorum write with es=1,wq=1,aq=1
@@ -1198,6 +1274,11 @@ func TestAppendOp_QuorumWrite_Case4_SingleNodeFailure(t *testing.T) {
 	// Verify that operation did not complete successfully
 	assert.False(t, op.completed.Load(), "Operation should not be completed")
 	assert.Equal(t, 0, op.ackSet.Count(), "No nodes should have acked")
+
+	// Not every replica's outcome is awaited above (a failing replica's
+	// HandleAppendRequestFailure is mocked but never joined), so wait for the
+	// goroutines themselves before the mocks are asserted.
+	waitAckGoroutinesDone(t, op)
 }
 
 // TestAppendOp_QuorumWrite_Case5_SimpleQuorumTest tests basic quorum behavior
@@ -1345,6 +1426,11 @@ func testSimpleQuorum(t *testing.T, nodeCount, ackQuorum, successCount int, expe
 		assert.False(t, op.completed.Load(), "Operation should not be completed")
 		assert.Less(t, op.ackSet.Count(), ackQuorum, fmt.Sprintf("Less than %d nodes should have acked (insufficient for quorum)", ackQuorum))
 	}
+
+	// Not every replica's outcome is awaited above (a failing replica's
+	// HandleAppendRequestFailure is mocked but never joined), so wait for the
+	// goroutines themselves before the mocks are asserted.
+	waitAckGoroutinesDone(t, op)
 }
 
 // TestAppendOp_Execute_ParallelFanout verifies that Execute() issues the

--- a/woodpecker/segment/batch_append_op.go
+++ b/woodpecker/segment/batch_append_op.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/zilliztech/woodpecker/common/channel"
 	"github.com/zilliztech/woodpecker/common/logger"
 	"github.com/zilliztech/woodpecker/proto"
@@ -144,6 +146,18 @@ func (b *BatchAppendOp) sendBatchToNode(ctx context.Context, entries []*proto.Lo
 	// per op. For a batch of N entries this is 1 goroutine per node instead of N.
 	go func() {
 		defer streamCancel()
+		// This goroutine is the only reader of these channels, so it owns retiring
+		// them - the same rule the single-entry path follows. Without an owner a
+		// late send from the client's demux lands in a one-slot buffer nobody will
+		// drain; with one it takes the closed path instead.
+		defer func() {
+			for _, resultCh := range resultChs {
+				if closeErr := resultCh.Close(ctx); closeErr != nil {
+					logger.Ctx(ctx).Warn("failed to close batch result channel",
+						zap.String("serverAddr", serverAddr), zap.Error(closeErr))
+				}
+			}
+		}()
 		for i, op := range b.ops {
 			// Per-entry deadline: a slow early entry must not shrink a later
 			// (still-arriving) entry's budget into a false timeout.

--- a/woodpecker/segment/batch_append_op.go
+++ b/woodpecker/segment/batch_append_op.go
@@ -22,8 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap"
-
 	"github.com/zilliztech/woodpecker/common/channel"
 	"github.com/zilliztech/woodpecker/common/logger"
 	"github.com/zilliztech/woodpecker/proto"
@@ -147,15 +145,14 @@ func (b *BatchAppendOp) sendBatchToNode(ctx context.Context, entries []*proto.Lo
 	go func() {
 		defer streamCancel()
 		// This goroutine is the only reader of these channels, so it owns retiring
-		// them - the same rule the single-entry path follows. Without an owner a
-		// late send from the client's demux lands in a one-slot buffer nobody will
-		// drain; with one it takes the closed path instead.
+		// them - the same rule the single-entry path follows, through the same
+		// helper. Without an owner a late send from the client's demux lands in a
+		// one-slot buffer nobody will drain; with one it takes the closed path
+		// instead. Entries the drain gives up on are retired here too: it abandons
+		// them without reading, so nothing else ever will.
 		defer func() {
-			for _, resultCh := range resultChs {
-				if closeErr := resultCh.Close(ctx); closeErr != nil {
-					logger.Ctx(ctx).Warn("failed to close batch result channel",
-						zap.String("serverAddr", serverAddr), zap.Error(closeErr))
-				}
+			for i, op := range b.ops {
+				op.retireResultChannel(ctx, resultChs[i], serverAddr)
 			}
 		}()
 		for i, op := range b.ops {
@@ -185,6 +182,25 @@ func (b *BatchAppendOp) failNode(ctx context.Context, nodeIdx int, serverAddr st
 	for _, op := range b.ops {
 		op.channelErrors[nodeIdx] = err
 		op.recordReplicaResult(nodeIdx, "error")
-		go op.handle.HandleAppendRequestFailure(ctx, op.entryId, err, nodeIdx, serverAddr)
 	}
+	// Report off this goroutine, and in entry order.
+	//
+	// Off, because Execute waits for sendBatchToNode while AppendAsync holds the
+	// segment handle's lock across a Submit that blocks on a full queue: taking
+	// that lock here would deadlock the executor. sendWriteRequestRetry reports
+	// asynchronously for the same reason.
+	//
+	// In order, because HandleAppendRequestFailure sweeps out every queued entry
+	// above the one that failed. Reporting the batch out of order lets an entry be
+	// resubmitted for retry and then swept by a sibling's later report, so the
+	// retry is sent for an entry that is already abandoned.
+	//
+	// One goroutine for the batch, not one per entry: a full batch failing on
+	// every replica would otherwise spawn MaxBatchEntries x Es goroutines onto one
+	// lock, at the moment the system is least able to absorb it.
+	go func() {
+		for _, op := range b.ops {
+			op.handle.HandleAppendRequestFailure(ctx, op.entryId, err, nodeIdx, serverAddr)
+		}
+	}()
 }

--- a/woodpecker/segment/batch_append_op_test.go
+++ b/woodpecker/segment/batch_append_op_test.go
@@ -244,6 +244,19 @@ func TestBatchAppendOp_InstallsLocalResultChannelInOpSlot(t *testing.T) {
 		_, isLocal := op.resultChannels[0].(*channel.LocalResultChannel)
 		assert.True(t, isLocal, "op %d slot should hold a LocalResultChannel after batch send", i)
 	}
+
+	// The drain goroutine is the only reader of these channels, so it owns
+	// retiring them - the same rule the single-entry path follows. Without an
+	// owner, a late send from the client's demux lands in a one-slot buffer that
+	// nobody will ever drain.
+	assert.Eventually(t, func() bool {
+		for _, op := range ops {
+			if !op.resultChannels[0].IsClosed() {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 5*time.Millisecond, "the batch drain must retire the channels it read")
 }
 
 // TestBatchAppendOp_GetClientFails_AllOpsRoutedToFailure covers the send-side

--- a/woodpecker/segment/batch_append_op_test.go
+++ b/woodpecker/segment/batch_append_op_test.go
@@ -269,7 +269,9 @@ func TestBatchAppendOp_GetClientFails_AllOpsRoutedToFailure(t *testing.T) {
 	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
 	quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}}
 
-	const batchN = 3
+	// Deliberately wider than the other batch tests: the order assertion below is
+	// only as strong as the number of ways the batch could come back out of order.
+	const batchN = 8
 	ops := newBatchOps(t, batchN, mockPool, mockHandle, quorumInfo)
 
 	clientErr := errors.New("no client available")
@@ -277,9 +279,16 @@ func TestBatchAppendOp_GetClientFails_AllOpsRoutedToFailure(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(batchN)
+	var reportedMu sync.Mutex
+	reported := make([]int64, 0, batchN)
 	mockHandle.EXPECT().
 		HandleAppendRequestFailure(mock.Anything, mock.Anything, clientErr, 0, "node1").
-		Run(func(context.Context, int64, error, int, string) { wg.Done() }).Return().Times(batchN)
+		Run(func(_ context.Context, entryId int64, _ error, _ int, _ string) {
+			reportedMu.Lock()
+			reported = append(reported, entryId)
+			reportedMu.Unlock()
+			wg.Done()
+		}).Return().Times(batchN)
 
 	NewBatchAppendOp(ops).Execute()
 	waitWG(t, &wg, 5*time.Second)
@@ -287,6 +296,17 @@ func TestBatchAppendOp_GetClientFails_AllOpsRoutedToFailure(t *testing.T) {
 	for i, op := range ops {
 		assert.Equal(t, clientErr, op.channelErrors[0], "op %d should record the client error", i)
 	}
+	// In entry order, not arbitrary. HandleAppendRequestFailure sweeps out every
+	// queued entry above the one that failed, so reporting a batch out of order lets
+	// an entry be resubmitted for retry and then swept by a sibling's later report -
+	// a retry sent for an entry that is already abandoned.
+	reportedMu.Lock()
+	defer reportedMu.Unlock()
+	expected := make([]int64, batchN)
+	for i := range expected {
+		expected[i] = int64(10 + i)
+	}
+	assert.Equal(t, expected, reported, "a whole-batch failure must be reported in entry order")
 }
 
 // TestBatchAppendOp_AppendEntriesError_AllOpsRoutedToFailure covers the batch RPC

--- a/woodpecker/segment/batch_append_op_test.go
+++ b/woodpecker/segment/batch_append_op_test.go
@@ -377,6 +377,19 @@ func TestBatchAppendOp_StalledNode_FailsRemainingAndCancelsStream(t *testing.T) 
 	assert.Eventually(t, func() bool { return capturedCtx != nil && capturedCtx.Err() != nil },
 		2*time.Second, 10*time.Millisecond,
 		"stream context should be cancelled after the drain gives up on the stalled node")
+
+	// The drain abandons the entries after the stall without ever reading their
+	// channels, so those channels have no other owner: it must retire all of them,
+	// not only the ones it read. Otherwise a late send from the client's demux lands
+	// in a one-slot buffer nobody will drain.
+	assert.Eventually(t, func() bool {
+		for _, op := range ops {
+			if !op.resultChannels[0].IsClosed() {
+				return false
+			}
+		}
+		return true
+	}, 5*time.Second, 5*time.Millisecond, "channels the drain abandoned must still be retired")
 }
 
 // TestBatchAppendOp_PerEntryTimeout_NoFalseFailOnSlowEarlyEntry is a regression
@@ -438,4 +451,205 @@ func TestBatchAppendOp_PerEntryTimeout_NoFalseFailOnSlowEarlyEntry(t *testing.T)
 	for i, op := range ops {
 		assert.True(t, op.completed.Load(), "op %d should be acknowledged, not false-failed", i)
 	}
+}
+
+// TestBatchAppendOp_OneReplicaSendFails_QuorumStillCompletes pins the invariant the
+// other failure tests structurally cannot see: they all run at Es=1/Aq=1, where "this
+// replica failed" and "this entry failed" are the same event, so they cannot tell a
+// per-replica failure route apart from one that fails the whole op. Here one replica
+// never yields a client while the other two ack, so the entries must still complete on
+// quorum - with the failed replica's entries routed to the retry path all the same, and
+// the error recorded against that replica's slot only.
+func TestBatchAppendOp_OneReplicaSendFails_QuorumStillCompletes(t *testing.T) {
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	healthy := mocks_logstore_client.NewLogStoreClient(t)
+	quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 3, Aq: 2, Es: 3, Nodes: []string{"node1", "node2", "node3"}}
+
+	const batchN = 3
+	ops := newBatchOps(t, batchN, mockPool, mockHandle, quorumInfo) // entryIds 10, 11, 12
+
+	// The failing replica is node2 (index 1), not index 0, so a slot index that is
+	// hardcoded rather than derived from the replica cannot pass unnoticed.
+	clientErr := errors.New("no client available")
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node1").Return(healthy, nil)
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node2").Return(nil, clientErr)
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node3").Return(healthy, nil)
+
+	healthy.EXPECT().
+		AppendEntries(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ string, _ int64, entries []*proto.LogEntry, chs []channel.ResultChannel) ([]int64, error) {
+			ids := make([]int64, len(entries))
+			for i, e := range entries {
+				ids[i] = e.EntryId
+				ch, eid := chs[i], e.EntryId
+				go func() { _ = ch.SendResult(context.Background(), &channel.AppendResult{SyncedId: eid}) }()
+			}
+			return ids, nil
+		})
+
+	var acked sync.WaitGroup
+	acked.Add(batchN)
+	for i := 0; i < batchN; i++ {
+		mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(10+i)).
+			Run(func(context.Context, int64) { acked.Done() }).Return().Once()
+	}
+	var routed sync.WaitGroup
+	routed.Add(batchN)
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, mock.Anything, clientErr, 1, "node2").
+		Run(func(context.Context, int64, error, int, string) { routed.Done() }).Return().Times(batchN)
+
+	NewBatchAppendOp(ops).Execute()
+	waitWG(t, &acked, 5*time.Second)
+	waitWG(t, &routed, 5*time.Second)
+
+	for i, op := range ops {
+		assert.True(t, op.completed.Load(), "op %d must reach quorum on the two healthy replicas", i)
+		assert.Equal(t, clientErr, op.channelErrors[1], "op %d must record the failure against node2", i)
+		assert.NoError(t, op.channelErrors[0], "op %d must not record an error against node1", i)
+		assert.NoError(t, op.channelErrors[2], "op %d must not record an error against node3", i)
+	}
+}
+
+// TestBatchAppendOp_OneReplicaStalls_QuorumStillCompletes is the ack-side half of the
+// test above: one replica acks the first entry and then goes silent while the other two
+// ack everything. The stalled replica's drain must fail only its own entries on its own
+// slot - the entries themselves are already durable on quorum and must not be dragged
+// down with it.
+func TestBatchAppendOp_OneReplicaStalls_QuorumStillCompletes(t *testing.T) {
+	oldTimeout := batchAckReadTimeout
+	batchAckReadTimeout = 200 * time.Millisecond
+	defer func() { batchAckReadTimeout = oldTimeout }()
+
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	healthy := mocks_logstore_client.NewLogStoreClient(t)
+	stalling := mocks_logstore_client.NewLogStoreClient(t)
+	quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 3, Aq: 2, Es: 3, Nodes: []string{"node1", "node2", "node3"}}
+
+	const batchN = 3
+	ops := newBatchOps(t, batchN, mockPool, mockHandle, quorumInfo) // entryIds 10, 11, 12
+
+	// The stalled replica is node2 (index 1), not index 0, so a slot index that is
+	// hardcoded rather than derived from the replica cannot pass unnoticed.
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node1").Return(healthy, nil)
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node2").Return(stalling, nil)
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node3").Return(healthy, nil)
+
+	stalling.EXPECT().
+		AppendEntries(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ string, _ int64, entries []*proto.LogEntry, chs []channel.ResultChannel) ([]int64, error) {
+			ids := make([]int64, len(entries))
+			for i, e := range entries {
+				ids[i] = e.EntryId
+			}
+			// Acks the first entry, then stalls: entries 11 and 12 never get an answer.
+			_ = chs[0].SendResult(context.Background(), &channel.AppendResult{SyncedId: entries[0].EntryId})
+			return ids, nil
+		})
+	healthy.EXPECT().
+		AppendEntries(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ string, _ int64, entries []*proto.LogEntry, chs []channel.ResultChannel) ([]int64, error) {
+			ids := make([]int64, len(entries))
+			for i, e := range entries {
+				ids[i] = e.EntryId
+				ch, eid := chs[i], e.EntryId
+				go func() { _ = ch.SendResult(context.Background(), &channel.AppendResult{SyncedId: eid}) }()
+			}
+			return ids, nil
+		})
+
+	var acked sync.WaitGroup
+	acked.Add(batchN)
+	for i := 0; i < batchN; i++ {
+		mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(10+i)).
+			Run(func(context.Context, int64) { acked.Done() }).Return().Once()
+	}
+	var routed sync.WaitGroup
+	routed.Add(2) // entries 11 and 12, on node2 only
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, mock.Anything, mock.Anything, 1, "node2").
+		Run(func(_ context.Context, entryId int64, failure error, _ int, _ string) {
+			assert.True(t, werr.IsRetryableErr(failure),
+				"entry %d: a stalled replica is a timeout, not a terminal failure", entryId)
+			routed.Done()
+		}).Return().Times(2)
+
+	NewBatchAppendOp(ops).Execute()
+	waitWG(t, &acked, 5*time.Second)
+	waitWG(t, &routed, 5*time.Second)
+
+	for i, op := range ops {
+		assert.True(t, op.completed.Load(), "op %d must reach quorum on the two healthy replicas", i)
+		assert.NoError(t, op.channelErrors[0], "op %d must not record an error against node1", i)
+		assert.NoError(t, op.channelErrors[2], "op %d must not record an error against node3", i)
+	}
+	assert.NoError(t, ops[0].channelErrors[1], "entry 10 was acked before the replica went silent")
+	assert.Error(t, ops[1].channelErrors[1], "entry 11 must record node2's timeout")
+	assert.Error(t, ops[2].channelErrors[1], "entry 12 must record node2's timeout")
+}
+
+// TestBatchAppendOp_EntryFails_PrefixAckedSuffixRoutedToRetry covers the shape a real
+// mid-batch failure takes on the wire. Per AddEntriesResponse (proto/logstore.proto:132)
+// a Failed frame names "the single entry that failed (fails the whole RPC)", so it is
+// never an isolated event: the entries before it are already Synced, and the entries
+// after it never get an answer of their own - the stream ends and the client demux hands
+// every still-waiting sink the Recv error. This exercises BatchAppendOp's central claim,
+// that partial success falls out of the existing ordered-LAC machinery with no
+// out-of-order bookkeeping of its own. Single replica keeps the focus on the response
+// shape; quorum across replicas is covered by the two tests above.
+func TestBatchAppendOp_EntryFails_PrefixAckedSuffixRoutedToRetry(t *testing.T) {
+	mockHandle := mocks_segment_handle.NewSegmentHandle(t)
+	mockPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	mockClient := mocks_logstore_client.NewLogStoreClient(t)
+	quorumInfo := &proto.QuorumInfo{Id: 1, Wq: 1, Aq: 1, Es: 1, Nodes: []string{"node1"}}
+
+	const batchN = 4
+	ops := newBatchOps(t, batchN, mockPool, mockHandle, quorumInfo) // entryIds 10, 11, 12, 13
+
+	entryErr := errors.New("entry rejected by the server")
+	streamErr := errors.New("stream ended after the failure")
+
+	mockPool.EXPECT().GetLogStoreClient(mock.Anything, "node1").Return(mockClient, nil)
+	mockClient.EXPECT().
+		AppendEntries(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, _ string, _ string, _ int64, entries []*proto.LogEntry, chs []channel.ResultChannel) ([]int64, error) {
+			ids := make([]int64, len(entries))
+			for i, e := range entries {
+				ids[i] = e.EntryId
+			}
+			_ = chs[0].SendResult(context.Background(), &channel.AppendResult{SyncedId: entries[0].EntryId})
+			_ = chs[1].SendResult(context.Background(), &channel.AppendResult{SyncedId: -1, Err: entryErr})
+			for _, ch := range chs[2:] {
+				_ = ch.SendResult(context.Background(), &channel.AppendResult{SyncedId: -1, Err: streamErr})
+			}
+			return ids, nil
+		})
+
+	var acked sync.WaitGroup
+	acked.Add(1)
+	mockHandle.EXPECT().SendAppendSuccessCallbacks(mock.Anything, int64(10)).
+		Run(func(context.Context, int64) { acked.Done() }).Return().Once()
+
+	var routed sync.WaitGroup
+	routed.Add(3)
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, int64(11), entryErr, 0, "node1").
+		Run(func(context.Context, int64, error, int, string) { routed.Done() }).Return().Once()
+	mockHandle.EXPECT().
+		HandleAppendRequestFailure(mock.Anything, mock.Anything, streamErr, 0, "node1").
+		Run(func(context.Context, int64, error, int, string) { routed.Done() }).Return().Times(2)
+
+	NewBatchAppendOp(ops).Execute()
+	waitWG(t, &acked, 5*time.Second)
+	waitWG(t, &routed, 5*time.Second)
+
+	assert.True(t, ops[0].completed.Load(), "the committed prefix must still be acknowledged")
+	for i := 1; i < batchN; i++ {
+		assert.False(t, ops[i].completed.Load(), "entry %d must not be acknowledged", 10+i)
+	}
+	assert.Equal(t, entryErr, ops[1].channelErrors[0], "the failed entry keeps the server's reason")
+	assert.Equal(t, streamErr, ops[2].channelErrors[0], "the suffix keeps the stream's reason")
+	assert.Equal(t, streamErr, ops[3].channelErrors[0], "the suffix keeps the stream's reason")
 }

--- a/woodpecker/segment/batch_append_op_test.go
+++ b/woodpecker/segment/batch_append_op_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/zilliztech/woodpecker/common/channel"
+	"github.com/zilliztech/woodpecker/common/werr"
 	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_logstore_client"
 	"github.com/zilliztech/woodpecker/mocks/mocks_woodpecker/mocks_segment_handle"
 	"github.com/zilliztech/woodpecker/proto"
@@ -358,8 +359,14 @@ func TestBatchAppendOp_StalledNode_FailsRemainingAndCancelsStream(t *testing.T) 
 	failures.Add(2) // entries 11 and 12
 	mockHandle.EXPECT().
 		HandleAppendRequestFailure(mock.Anything, mock.Anything, mock.Anything, 0, "node1").
-		Run(func(_ context.Context, entryId int64, _ error, _ int, _ string) {
+		Run(func(_ context.Context, entryId int64, failure error, _ int, _ string) {
 			if entryId == 11 || entryId == 12 {
+				// The drain read a LocalResultChannel that ran out of its budget. A
+				// stalled peer is a timeout, not a terminal failure: reported as a bare
+				// context.DeadlineExceeded the entry is unclassifiable downstream and
+				// gives up without spending any of its retries.
+				assert.True(t, werr.IsRetryableErr(failure),
+					"entry %d: a stalled node must be reported as retryable", entryId)
 				failures.Done()
 			}
 		}).Return().Times(2)

--- a/woodpecker/segment/segment_handle_test.go
+++ b/woodpecker/segment/segment_handle_test.go
@@ -430,11 +430,14 @@ func TestAppendAsync_TimeoutBug(t *testing.T) {
 
 	// Entry 2 will succeed with AppendEntry but we won't send result to channel (timeout simulation)
 	// This will cause multiple retries due to timeout - expect initial attempt + 2 retries = 3 total
+	// Entry 2 is accepted and never answered, so it costs one ack budget per
+	// attempt and spends its whole retry allowance: MaxRetries below is 2, and
+	// the retry test is attempts+1 < MaxRetries, so two attempts in total.
 	mockClient.EXPECT().AppendEntry(mock.Anything, mock.Anything, mock.Anything, int64(1), &proto.LogEntry{
 		SegId:   1,
 		EntryId: int64(2),
 		Values:  []byte("test_2"),
-	}, mock.MatchedBy(func(ch channel.ResultChannel) bool { return ch != nil })).Return(int64(2), nil).Times(1)
+	}, mock.MatchedBy(func(ch channel.ResultChannel) bool { return ch != nil })).Return(int64(2), nil).Times(2)
 
 	cfg := &config.Configuration{
 		Woodpecker: config.WoodpeckerConfig{
@@ -575,11 +578,10 @@ func TestAppendAsync_TimeoutBug(t *testing.T) {
 
 	// Wait long enough for the complete timeout and retry cycle:
 	// 1. Entries 0,1 to complete successfully (immediate)
-	// 2. Entry 2 first attempt: 30s timeout
-	// 3. Entry 2 retry 1: 30s timeout
-	// 4. Entry 2 retry 2: 30s timeout
-	// 5. Final FastFail callback with bug (nil error)
-	// Total: ~90 seconds for 3 attempts, we wait 2 minutes to be safe
+	// 2. Entry 2 first attempt: 30s ack budget, no answer
+	// 3. Entry 2 retry: another 30s, no answer, retries now spent
+	// 4. Final FastFail callback carrying the timeout
+	// Total: ~60 seconds for 2 attempts, we wait 2 minutes to be safe
 	t.Logf("Waiting 2 minutes for complete timeout and retry cycle...")
 	t.Logf("This will demonstrate the real-world timeout behavior")
 	time.Sleep(2 * time.Minute)


### PR DESCRIPTION
Closes #287.

`FastSuccess` closed **every** entry in `op.resultChannels`, and in service mode
`RemoteResultChannel.Close()` cancels the stream context. So the replica outside
the ack quorum — with `Es=3, Aq=2` there is normally exactly one — had its `Recv()`
aborted while it was answering perfectly normally, and its completion came back as
`rpc error: code = Canceled`.

**4,879,009 WARN lines in 24h on one instance (~2.8 GB), against 295 from the
genuine failure paths.** 99.994% of them describe a replica that was finishing
fine.

No data was ever at risk: the server buffers the entry before the client can
cancel and does not retain the request context, so cancelling the result stream
only ends the goroutine that was waiting to report the ack. The logstore side is
silent throughout.

**This is drift, not a decision.** `d6f4a5e` (2025-06-04) added the `Close` loop
when result channels were plain Go channels and `Close` was local cleanup.
`61c5efa` (2026-01-08) rewrote `RemoteResultChannel` around a gRPC stream and gave
`Close` the new meaning *"cancel the peer RPC"* — without revisiting this call site.

## The change

The channel belongs to the goroutine reading it. `receivedAckCallback` closes it
on every exit path, **after** the replica has actually answered.

`FastFail` is unchanged and still closes early, deliberately: there the entry is
abandoned, so every waiter should stop at once rather than sit out its budget.
`Close` is idempotent, so the early close and the goroutine's own close cannot
conflict.

`FastSuccess` keeps its `SendResult` — only the `Close` goes.

The channel is retired **as soon as the replica's answer is in**, not only on the
way out: the stream is dead weight the moment the ack arrives, and the bookkeeping
that follows takes the segment handle's lock. The deferred call stays as the
catch-all for every other exit path.

## Two things the issue's plan did not account for

### 1. The read budget was decorative

`receivedAckCallback` wraps the read in a 30s context. **`ReadResult` ignores it**
once a stream is attached:

```go
	resultResponse, readErr := ch.Recv()   // ctx unused on this path
```

`Recv` observes only the stream's own context, which is `context.WithCancel` with
no deadline, and `newConnection` sets no keepalive. So `FastSuccess`'s cancel was
**the only thing that ever unblocked a replica that accepted an entry and then went
silent**. Removing it without a real bound would have leaked the goroutine and the
stream for as long as the connection survived.

`ReadResult` now enforces the caller's deadline by cancelling the stream when it
expires — the same device `AppendEntry` already uses to bound the first response,
not a new mechanism.

This is a standalone bug, but it cannot be separated from the fix: the fix is
unsafe without it. It has its own tests and this section is the record.

### 2. Retries reused the channel object

`sendWriteRequest` reused the slot when the type matched, asserted in four tests as
*"retry idempotency"*. It carries none — the entry id is what makes an append
idempotent, server-side. What reuse actually did:

* every attempt opens its **own** stream, context and cancel;
* `InitResponseStream` **overwrites all three without cancelling the previous ones**,
  so the earlier attempt's cancel is dropped and can never be called;
* it also **does not clear `r.result`**, so a recorded result can be returned to the
  next attempt's read instead of its new stream's.

Splitting by where the failure came from:

| retry trigger | attempt 1's channel | reuse vs fresh |
| --- | --- | --- |
| `GetLogStoreClient` fails | never touched | identical |
| `AddEntry` fails / first `Recv` errors / first-response timeout / first response is a failure | `AppendEntry` cancelled the stream itself and never called `InitResponseStream`, so `ch`/`cancel` are still nil | identical |
| server's second frame reports failure; connection drops | stream handed over, `cancel` never called | reuse orphans that cancel permanently |
| **server accepts, then never sends the ack** | stream handed over and live | **reuse breaks the retry** |

That last row is the decisive one, and only after this PR's other changes:

```
G1(attempt 1): ReadResult exhausts its budget
G1:            HandleAppendRequestFailure  → submits the retry   (synchronous, in-body)
                       G2(attempt 2): sendWriteRequest reuses the same channel
                       G2:            AppendEntry → InitResponseStream(stream2, cancel2)
G1:            returns → deferred Close() → r.cancel() is now cancel2
                       ← attempt 2's brand-new stream is killed by attempt 1's cleanup
```

`maxRetries: 3`, and the interleaving can repeat every round. Budget gone ⇒ the
entry `FastFail`s ⇒ `minRemoveId` fast-fails every queued entry behind it in the
segment.

**Why this is new**: today the only `Close` is in `FastSuccess`/`FastFail`, which hold
`op.mu`, as does `AppendRequestRetryOp.Execute` — they are mutually exclusive. The
deferred close added here runs **outside** `op.mu`, so reuse becomes unsafe the
moment the goroutine owns the channel.

I considered keeping reuse with a compare-and-close (`op.mu` + "close only if the
slot still points at me") and rejected it: `AppendOp.Execute` holds `op.mu` across
the whole parallel fan-out including `wg.Wait()`, so every ack's cleanup would
queue behind the send path — and it would still leave the orphaned cancel and the
stale `r.result`. A fresh channel per attempt costs one small object and loses
nothing, because nothing worth carrying survives an attempt.

## Tests

Every changed and added test was confirmed to **fail against the previous code**
before being kept:

```
--- FAIL: TestAppendOp_FastSuccess_DoesNotCancelInFlightReplicaStreams
        replica 0: FastSuccess must not close the channel
        replica 0: FastSuccess must not cancel the stream
--- FAIL: TestAppendOp_receivedAckCallback_ClosesItsOwnChannel/after_a_normal_ack
--- FAIL: TestAppendOp_receivedAckCallback_ClosesItsOwnChannel/after_a_send_error
--- FAIL: TestAppendOp_Retry_UsesAFreshResultChannelPerAttempt
--- FAIL: TestRemoteResultChannel_ReadResult_ViaStream_HonoursCallerDeadline
        ReadResult ignored the caller's deadline: a silent peer blocks it indefinitely
```

New:

* `TestAppendOp_FastSuccess_DoesNotCancelInFlightReplicaStreams` — three replicas
  holding streams that have not answered; after `FastSuccess` none may be closed
  **or cancelled**. This is the defect itself.
* `TestAppendOp_FastFail_CancelsInFlightReplicaStreams` — the deliberate contrast.
  It passes on the old code too: it guards behaviour this PR must *not* change.
* `TestAppendOp_receivedAckCallback_ClosesItsOwnChannel` — the other half of the
  exchange, on both the normal-ack and the early-return path.
* `TestRemoteResultChannel_ReadResult_ViaStream_HonoursCallerDeadline` — a silent
  peer must not block the read forever. Fails cleanly rather than hanging.
* `TestRemoteResultChannel_ReadResult_ViaStream_DeadlineNotReached` — the budget
  fires only when exhausted; an in-budget ack is returned and its stream left alone.

Rewritten, with the reason recorded in each: the four `RetryIdempotency` /
`ChannelReuse` tests now assert a fresh channel per attempt, and one of them adds
the property that matters — closing an earlier attempt's channel must leave the
current one alone. `TestAppendOp_Retry_ChannelKeepsTheOpIdentifier` now actually
checks the identifier it was named for (`GetIdentifier()` is on the interface; the
old comment said it was unreachable).

`TestAppendOp_FastSuccess`, `_Idempotent` and `_ConcurrentFastCalls` had their
close assertions inverted; the last now asserts the close state **agrees with
whichever of FastFail/FastSuccess won the CAS**, which is stronger than what it
checked before.

### A test-hygiene problem this surfaced

Several append tests observed "the ack was processed" through a mock call made
from **inside** `receivedAckCallback` (`SendAppendSuccessCallbacks`,
`HandleAppendRequestFailure`) and returned there — leaving the goroutine still
writing to the result channel while testify's `AssertExpectations` cleanup
reflects over that same object **without holding its lock**. `-race` reports it.

Retiring the channel before those calls fixes most of it, because the callback
then really is a join point. The remainder needed `waitAckGoroutinesDone`: in the
quorum tests a *failing* replica's `HandleAppendRequestFailure` is mocked but
never awaited, so nothing ever joined that goroutine. Two consecutive
`go test -race ./woodpecker/segment/` runs are clean.

## Out of scope

`recordReplicaResult` sits after the `fastCalled` guard, so a post-quorum replica's
outcome is still not counted in `woodpecker_client_replica_append_total` (measured
at 2.01 outcomes per entry where `Es=3` predicts ~3.0). That is the guard's own
behaviour and removing the cancel does not change it, as the issue notes.

The `ReadResult` WARN stays at WARN. After this change it fires on genuine stream
failures and on `FastFail` — rare, and downgrading it would hide the real ones.

## Verification

- `gofmt` clean, `go vet ./common/channel/ ./woodpecker/segment/ ./woodpecker/client/` clean, `go build ./...` ok
- `go test -race ./woodpecker/segment/` ok, twice in a row
- `go test -race ./common/channel/ ./woodpecker/client/ ./woodpecker/log/` ok

One unrelated local failure: `TestNewEmbedClientFromConfig_MinioObjectStorageError`
fails the same way on `master` in a clean worktree (427s, `https://.blob./` → EOF).
It is environment-dependent and green on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNe2heiUwYkqt67PosjiXi
