### PR TITLE
fix(test): stamp the "created after task start" file's mtime instead of relying on creation order

### DIFF
--- a/server/compacted_file_cleanup_test.go
+++ b/server/compacted_file_cleanup_test.go
@@ -755,8 +755,12 @@ func TestCompactedFileCleanup_StartupWalkSeedsStoredGauges(t *testing.T) {
 	task := newCompactedFileCleanupTask(store) // startTime = now: oldDir predates it
 
 	// Created AFTER the task started: this process's writer accounted for it (create
-	// branch), so the mtime guard must skip it.
-	makeSegmentDir(t, root, bucket, rp, freshLogId, 22)
+	// branch), so the mtime guard must skip it. Stamp the mtime forward instead of
+	// relying on creation order: a file's mtime comes from the kernel's coarse clock,
+	// which on Linux lags the time.Now() behind startTime by up to a timer tick, so a
+	// file created here can otherwise carry an mtime that predates the task.
+	freshDir := makeSegmentDir(t, root, bucket, rp, freshLogId, 22)
+	ageDataLog(t, freshDir, -time.Second)
 
 	logNs := bucket + "/" + rp
 	oldBytesBefore := testutil.ToFloat64(metrics.WpFileStoredBytes.WithLabelValues(metrics.NodeID, logNs, "29"))


### PR DESCRIPTION
Fixes #302

## Problem

`TestCompactedFileCleanup_StartupWalkSeedsStoredGauges` went red on an unrelated PR's Unit Test job:

```
--- FAIL: TestCompactedFileCleanup_StartupWalkSeedsStoredGauges (0.00s)
    compacted_file_cleanup_test.go:773:
        Error:    Not equal:  expected: 0   actual: 11
        Messages: a file created after task start was counted by the writer; seeding it would double-count
```

The defect is in the test's setup, not in `seedStoredGauges`. It builds two preconditions for that function's mtime guard and only establishes one of them:

```go
oldDir := makeSegmentDir(t, root, bucket, rp, oldLogId, 21)
ageDataLog(t, oldDir, 10*time.Minute)                // "predates the task"  — stamped explicitly

task := newCompactedFileCleanupTask(store)           // startTime = time.Now()

makeSegmentDir(t, root, bucket, rp, freshLogId, 22)  // "postdates the task" — creation order only
```

The guard is `!info.ModTime().Before(t.startTime)`, and those two values come from different clocks: `startTime` is Go's fine-grained `time.Now()`, while the mtime is stamped from the kernel's **coarse** realtime clock, which advances only once per timer tick. Creating the file afterwards does not give it a later mtime, so the test never establishes the relationship it asserts and `seedStoredGauges` sees an input the test did not intend.

## Fix

Stamp the fresh file's mtime explicitly, the way the sibling precondition already does — one line, test-only:

```go
freshDir := makeSegmentDir(t, root, bucket, rp, freshLogId, 22)
ageDataLog(t, freshDir, -time.Second)
```

## Verification

The bare sequence (`time.Now()` → `MkdirAll` + `WriteFile` → `Stat`), 2000 iterations in a `golang:1.25-alpine` container:

```
mtime < startTime (would wrongly seed): 1997/2000 = 99.85%   worst lag: 1.841959ms
```

| | before | after |
| --- | --- | --- |
| unmodified `origin/master`, Linux container | fails every run, verbatim CI error | — |
| this branch, Linux container, `-count=20` | — | `ok  github.com/zilliztech/woodpecker/server` |
| this branch, macOS `./server/ -run TestCompactedFileCleanup` | — | `ok` |
| `golangci-lint run --config .golangci.yml ./server/...` | — | `0 issues` |

It passes on APFS and on GitHub's runners most of the time because both clock sources are fine-grained there, which is why this surfaced as a rare flake rather than a permanent red.

## Not addressed here

The same zero-margin comparison exists in production: a `data.log` created by this process within ~2 ms of `startTime` and then reached by the first reconcile walk would be seeded on top of the writer's own count. It needs both the sub-tick window at process start and the walk arriving at that exact segment, so it is recorded in #302 rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DNe2heiUwYkqt67PosjiXi
