### PR TITLE
fix(chaos): point chaos-daemon at the node's actual container runtime

### DIFF
--- a/tests/chaos_mesh/run_network_chaos.sh
+++ b/tests/chaos_mesh/run_network_chaos.sh
@@ -8,12 +8,12 @@ export CLUSTER_NAME="wp-chaos"
 export CR_NAME="my-woodpecker"
 export NAMESPACE="default"
 export REPLICAS=3
-# Default to minikube's docker runtime: it uses built-in bridge networking and needs no
-# external CNI image. The containerd runtime forces a kindnet CNI whose image
-# (kindest/kindnetd:<ver>) frequently cannot be pulled on constrained/offline hosts, leaving
-# the cluster with no pod networking ("failed to find network info for sandbox"). Chaos Mesh
-# supports the docker runtime, and the injection smoke-check guards correctness either way.
-# Override with MK_RUNTIME=containerd only where the kindnet image is reachable.
+# Empty MK_RUNTIME leaves the choice to minikube's default, which is NOT a fixed value: it was
+# docker up to minikube v1.38.1 and is containerd from v1.39.0 on. Chaos Mesh supports both, and
+# install_chaos_mesh() reads the node's actual runtime rather than assuming one, so either is fine.
+# Pin MK_RUNTIME=docker on constrained/offline hosts: the containerd runtime forces a kindnet CNI
+# whose image (kindest/kindnetd:<ver>) frequently cannot be pulled there, leaving the cluster with
+# no pod networking ("failed to find network info for sandbox").
 export MK_CPUS="${MK_CPUS:-6}" MK_MEMORY="${MK_MEMORY:-8192}" MK_RUNTIME="${MK_RUNTIME:-}"
 export WP_IMG="zilliztech/woodpecker:v0.1.26"
 export CLIENT_POD="wp-client-test"
@@ -51,15 +51,22 @@ bringup() {
 }
 
 install_chaos_mesh() {
-  # chaos-daemon must point at the SAME container runtime minikube uses, else injection is a
-  # silent no-op (caught by injection_smoke_check). Empty MK_RUNTIME = minikube's docker runtime.
-  local daemon_runtime daemon_socket
-  if [ "${MK_RUNTIME:-}" = "containerd" ]; then
-    daemon_runtime=containerd; daemon_socket=/run/containerd/containerd.sock
-  else
-    daemon_runtime=docker; daemon_socket=/var/run/docker.sock
-  fi
-  log "installing chaos-mesh (chaosDaemon.runtime=$daemon_runtime socket=$daemon_socket)"
+  # chaos-daemon must point at the SAME container runtime the node actually runs: it bypasses the
+  # Kubernetes API and resolves container IDs through that socket to enter a pod's netns. Point it
+  # at the wrong one and injection fails ("unable to flush ip sets for pod ...") or is a silent
+  # no-op. Ask the node instead of deriving it from MK_RUNTIME — MK_RUNTIME is empty by default,
+  # which means "whatever minikube defaults to", and that default flipped from docker to containerd
+  # in minikube v1.39.0 and left this suite red on every nightly (#304).
+  local runtime_ver daemon_runtime daemon_socket
+  runtime_ver=$(kubectl get node "$CLUSTER_NAME" -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}')
+  case "$runtime_ver" in
+    containerd://*) daemon_runtime=containerd; daemon_socket=/run/containerd/containerd.sock ;;
+    docker://*)     daemon_runtime=docker;     daemon_socket=/var/run/docker.sock ;;
+    # Guessing a socket here buys nothing: a wrong one fails 5 minutes later with a message that
+    # points at chaos, not at the runtime. Say what we actually saw.
+    *) fail "unrecognized node container runtime '$runtime_ver' — cannot configure chaos-daemon" ;;
+  esac
+  log "installing chaos-mesh (node runtime=$runtime_ver -> chaosDaemon.runtime=$daemon_runtime socket=$daemon_socket)"
   helm repo add chaos-mesh https://charts.chaos-mesh.org 2>/dev/null || true
   helm repo update
   # Preload chaos-mesh images: the node can't reach ghcr.io through the host's loopback proxy.


### PR DESCRIPTION
Fixes #304.

## Problem

`Chaos Mesh Test` has been red on every nightly since 2026-09-03 (15/15). Not a product regression — the cluster comes up healthy and the suite dies on the first injection:

```
[20:28:49] installing chaos-mesh (chaosDaemon.runtime=docker socket=/var/run/docker.sock)
Warning  Failed  records  Failed to apply chaos: failed to apply for pod default/wp-client-test:
                          unable to flush ip sets for pod wp-client-test
[20:30:54] FAIL: chaos never reached AllInjected
```

The workflow installs minikube from `releases/latest`, and **minikube v1.39.0 (released 2026-09-02 21:09Z) changed its default container runtime to containerd** ([upstream #23562](https://github.com/kubernetes/minikube/pull/23562)). The last green nightly started 46 minutes before that release; the first red one picked up the new default.

`install_chaos_mesh()` derived chaos-daemon's runtime from `MK_RUNTIME`, treating "empty" as "docker". But empty means "whatever minikube defaults to" — `wp_minikube_start` omits `--container-runtime` in that case. So chaos-daemon got `/var/run/docker.sock` while the node ran containerd 2.3.4 and could no longer resolve `containerd://<id>` containers to enter their netns.

## Fix

Ask the node for its runtime instead of inferring it:

```bash
runtime_ver=$(kubectl get node "$CLUSTER_NAME" -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}')
case "$runtime_ver" in
  containerd://*) daemon_runtime=containerd; daemon_socket=/run/containerd/containerd.sock ;;
  docker://*)     daemon_runtime=docker;     daemon_socket=/var/run/docker.sock ;;
  *) fail "unrecognized node container runtime '$runtime_ver' — cannot configure chaos-daemon" ;;
esac
```

chaos-daemon now tracks whatever minikube actually started, so a future upstream default change cannot desync it again. `MK_RUNTIME` stays as the knob passed to `minikube start`; it just stops being the source of truth for what the node ended up running. An unrecognized runtime fails immediately with the value we read, rather than defaulting to a socket that would fail five minutes later with a message pointing at chaos instead of at the runtime.

The stale comments (file header and `install_chaos_mesh()`) are updated: the header's "default to minikube's docker runtime" is no longer true, and the kindnet/offline caveat is rewritten as the reason to pin `MK_RUNTIME=docker` rather than as a description of the default.

Script only — no product code, no workflow change.

## Verification

- `bash -n` clean; `shellcheck -S warning` reports only the pre-existing SC2034 at line 153.
- Ran throwaway local minikube clusters against both branches and confirmed the jsonpath returns the forms the new `case` matches:
  `--container-runtime=containerd` -> `containerd://1.7.27`, `--container-runtime=docker` -> `docker://28.1.1`.
- **Full suite run on this branch: green.** `nightly-chaos-mesh.yaml` dispatched against `fix/chaos-daemon-follow-node-runtime` — [run 34193307716](https://github.com/zilliztech/woodpecker/actions/runs/34193307716), `success` in 38m42s (vs ~9m to failure on every red nightly, and 36m43s on the last green one):

```
installing chaos-mesh (node runtime=containerd://2.3.4 -> chaosDaemon.runtime=containerd socket=/run/containerd/containerd.sock)
Injection smoke-check PASSED (1ms -> 359ms)
SCENARIO server-minio-delay PASSED
SCENARIO server-minio-loss PASSED
SCENARIO server-etcd-delay PASSED
SCENARIO client-server-delay PASSED
SCENARIO client-server-loss PASSED
SCENARIO server-minio-blip PASSED
SCENARIO server-etcd-blip PASSED
ALL SCENARIOS PASSED
```

  All 7 scenarios pass on a containerd node, with no `I6 VIOLATION` (no server container restarted). Note this had to be dispatched manually: PR workflows are path-filtered to `**.go`/`go.mod`/`config/**`, and `nightly-chaos-mesh.yaml` is `workflow_call`/`workflow_dispatch` only, so no PR CI exercises this suite.

## Impact

Unblocks all 7 chaos scenarios (`server-minio-delay`, `server-minio-loss`, `server-etcd-delay`, `client-server-delay`, `client-server-loss` and the two blip scenarios), which have not run since 2026-09-03. These cover the degraded-but-connected network faults — latency, packet loss, jitter — that the docker-compose `Chaos Test` suite cannot express, since its injection is `docker pause/stop/kill/network disconnect`, i.e. hard cuts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018gNuXNfcHNuqVTdnGEkZms