### PR TITLE
fix(disk): accept a finalized empty segment on recovery; share footer index parsing across local backends

### DIFF
--- a/server/storage/codec/index_section.go
+++ b/server/storage/codec/index_section.go
@@ -1,0 +1,101 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codec
+
+import (
+	"fmt"
+	"io"
+)
+
+// ValidateIndexSection checks that a parsed footer describes a readable index
+// section. It is the single definition of which footers are acceptable, shared
+// by every storage backend that recovers a finalized segment from its footer.
+//
+// A segment that was finalized with zero blocks is valid: Finalize writes the
+// header and the footer with nothing in between, so IndexOffset equals the
+// header size and IndexLength is 0. Such a file is complete, it just carries no
+// entries; it must not be reported as corrupt, or the segment can never be
+// fenced or read again.
+func ValidateIndexSection(footer *FooterRecord) error {
+	if footer == nil {
+		return fmt.Errorf("invalid footer record: nil")
+	}
+	if footer.IndexOffset == 0 {
+		// Every finalized file starts with a header record, so the index
+		// section can never begin at offset 0.
+		return fmt.Errorf("invalid footer record: IndexOffset=%d, IndexLength=%d",
+			footer.IndexOffset, footer.IndexLength)
+	}
+	if footer.IndexLength == 0 && footer.TotalBlocks != 0 {
+		return fmt.Errorf("invalid footer record: IndexLength=0 but TotalBlocks=%d", footer.TotalBlocks)
+	}
+	return nil
+}
+
+// ParseIndexRecords parses the index section of a finalized segment. indexData
+// is exactly the IndexLength bytes starting at IndexOffset. Every record must be
+// a well-formed IndexRecord; a trailing fragment shorter than a record header is
+// ignored. For an empty index section (a segment finalized with zero blocks)
+// the result is an empty, non-nil slice.
+func ParseIndexRecords(indexData []byte, footer *FooterRecord) ([]*IndexRecord, error) {
+	if err := ValidateIndexSection(footer); err != nil {
+		return nil, err
+	}
+	records := make([]*IndexRecord, 0, footer.TotalBlocks)
+	if footer.IndexLength == 0 {
+		return records, nil
+	}
+	if len(indexData) != int(footer.IndexLength) {
+		return nil, fmt.Errorf("index section is %d bytes, footer says %d", len(indexData), footer.IndexLength)
+	}
+
+	recordSize := RecordHeaderSize + IndexRecordSize
+	offset := 0
+	for offset < len(indexData) {
+		if offset+RecordHeaderSize > len(indexData) {
+			break
+		}
+		record, err := DecodeRecord(indexData[offset:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode index record at offset %d: %w", offset, err)
+		}
+		if record.Type() != IndexRecordType {
+			return nil, fmt.Errorf("expected index record type %d, got %d at offset %d",
+				IndexRecordType, record.Type(), offset)
+		}
+		records = append(records, record.(*IndexRecord))
+		offset += recordSize
+	}
+	return records, nil
+}
+
+// ReadIndexSection reads the index section described by footer from r and
+// parses it with ParseIndexRecords. It is what a local-file backend calls when
+// it reopens a finalized segment for recovery.
+func ReadIndexSection(r io.ReaderAt, footer *FooterRecord) ([]*IndexRecord, error) {
+	if err := ValidateIndexSection(footer); err != nil {
+		return nil, err
+	}
+	if footer.IndexLength == 0 {
+		return make([]*IndexRecord, 0), nil
+	}
+	indexData := make([]byte, footer.IndexLength)
+	if _, err := r.ReadAt(indexData, int64(footer.IndexOffset)); err != nil {
+		return nil, fmt.Errorf("failed to read index section: %w", err)
+	}
+	return ParseIndexRecords(indexData, footer)
+}

--- a/server/storage/codec/index_section_test.go
+++ b/server/storage/codec/index_section_test.go
@@ -1,0 +1,147 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codec
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func indexRecords(n int) []*IndexRecord {
+	out := make([]*IndexRecord, 0, n)
+	for i := 0; i < n; i++ {
+		out = append(out, &IndexRecord{
+			BlockNumber: int32(i), StartOffset: int64(100 * (i + 1)), BlockSize: 100,
+			FirstEntryID: int64(10 * i), LastEntryID: int64(10*i + 9),
+		})
+	}
+	return out
+}
+
+func encodeIndex(records []*IndexRecord) []byte {
+	var buf bytes.Buffer
+	for _, r := range records {
+		buf.Write(EncodeRecord(r))
+	}
+	return buf.Bytes()
+}
+
+func TestValidateIndexSection(t *testing.T) {
+	headerSize := uint64(RecordHeaderSize + HeaderRecordSize)
+
+	assert.Error(t, ValidateIndexSection(nil))
+	assert.Error(t, ValidateIndexSection(&FooterRecord{IndexOffset: 0, IndexLength: 41, TotalBlocks: 1}), "index at offset 0 is impossible")
+	assert.Error(t, ValidateIndexSection(&FooterRecord{IndexOffset: headerSize, IndexLength: 0, TotalBlocks: 3}), "zero-length index cannot describe 3 blocks")
+
+	// The footer Finalize writes for a segment completed with zero blocks.
+	assert.NoError(t, ValidateIndexSection(&FooterRecord{IndexOffset: headerSize, IndexLength: 0, TotalBlocks: 0, TotalSize: headerSize}))
+	assert.NoError(t, ValidateIndexSection(&FooterRecord{IndexOffset: 500, IndexLength: 41, TotalBlocks: 1}))
+}
+
+func TestParseIndexRecords(t *testing.T) {
+	headerSize := uint64(RecordHeaderSize + HeaderRecordSize)
+
+	t.Run("empty finalized segment", func(t *testing.T) {
+		footer := &FooterRecord{IndexOffset: headerSize, IndexLength: 0, TotalBlocks: 0, TotalSize: headerSize}
+		records, err := ParseIndexRecords(nil, footer)
+		require.NoError(t, err)
+		require.NotNil(t, records)
+		assert.Empty(t, records)
+	})
+
+	t.Run("round trip", func(t *testing.T) {
+		want := indexRecords(3)
+		data := encodeIndex(want)
+		footer := &FooterRecord{IndexOffset: 1000, IndexLength: uint32(len(data)), TotalBlocks: 3}
+		got, err := ParseIndexRecords(data, footer)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+		for i := range want {
+			assert.Equal(t, want[i].BlockNumber, got[i].BlockNumber)
+			assert.Equal(t, want[i].StartOffset, got[i].StartOffset)
+			assert.Equal(t, want[i].BlockSize, got[i].BlockSize)
+			assert.Equal(t, want[i].FirstEntryID, got[i].FirstEntryID)
+			assert.Equal(t, want[i].LastEntryID, got[i].LastEntryID)
+		}
+	})
+
+	t.Run("length mismatch with footer", func(t *testing.T) {
+		data := encodeIndex(indexRecords(2))
+		footer := &FooterRecord{IndexOffset: 1000, IndexLength: uint32(len(data)) + 1, TotalBlocks: 2}
+		_, err := ParseIndexRecords(data, footer)
+		assert.Error(t, err)
+	})
+
+	t.Run("wrong record type", func(t *testing.T) {
+		data := EncodeRecord(&HeaderRecord{Version: FormatVersion, FirstEntryID: 0})
+		footer := &FooterRecord{IndexOffset: 1000, IndexLength: uint32(len(data)), TotalBlocks: 1}
+		_, err := ParseIndexRecords(data, footer)
+		assert.ErrorContains(t, err, "expected index record type")
+	})
+
+	t.Run("corrupt record", func(t *testing.T) {
+		data := encodeIndex(indexRecords(1))
+		data[len(data)-1] ^= 0xff // break the payload, CRC no longer matches
+		footer := &FooterRecord{IndexOffset: 1000, IndexLength: uint32(len(data)), TotalBlocks: 1}
+		_, err := ParseIndexRecords(data, footer)
+		assert.ErrorContains(t, err, "failed to decode index record")
+	})
+
+	t.Run("invalid footer is rejected before parsing", func(t *testing.T) {
+		_, err := ParseIndexRecords(encodeIndex(indexRecords(1)), &FooterRecord{IndexOffset: 0, IndexLength: 41, TotalBlocks: 1})
+		assert.Error(t, err)
+	})
+}
+
+func TestReadIndexSection(t *testing.T) {
+	headerSize := RecordHeaderSize + HeaderRecordSize
+	header := EncodeRecord(&HeaderRecord{Version: FormatVersion, FirstEntryID: 0})
+	require.Len(t, header, headerSize)
+
+	t.Run("empty finalized file: header + footer only", func(t *testing.T) {
+		footer := &FooterRecord{IndexOffset: uint64(headerSize), IndexLength: 0, TotalBlocks: 0, TotalSize: uint64(headerSize), Version: FormatVersion, LAC: -1}
+		file := append(append([]byte{}, header...), EncodeRecord(footer)...)
+		assert.Len(t, file, headerSize+RecordHeaderSize+FooterRecordSize)
+
+		records, err := ReadIndexSection(bytes.NewReader(file), footer)
+		require.NoError(t, err)
+		assert.Empty(t, records)
+	})
+
+	t.Run("file with blocks", func(t *testing.T) {
+		want := indexRecords(2)
+		fakeBlocks := bytes.Repeat([]byte{0xab}, 200)
+		index := encodeIndex(want)
+		indexOffset := uint64(len(header) + len(fakeBlocks))
+		footer := &FooterRecord{IndexOffset: indexOffset, IndexLength: uint32(len(index)), TotalBlocks: 2, Version: FormatVersion, LAC: want[1].LastEntryID}
+		file := bytes.Join([][]byte{header, fakeBlocks, index, EncodeRecord(footer)}, nil)
+
+		records, err := ReadIndexSection(bytes.NewReader(file), footer)
+		require.NoError(t, err)
+		require.Len(t, records, 2)
+		assert.Equal(t, want[1].LastEntryID, records[1].LastEntryID)
+	})
+
+	t.Run("short read", func(t *testing.T) {
+		footer := &FooterRecord{IndexOffset: 1000, IndexLength: 41, TotalBlocks: 1}
+		_, err := ReadIndexSection(bytes.NewReader(header), footer)
+		assert.ErrorContains(t, err, "failed to read index section")
+	})
+}

--- a/server/storage/disk/writer_impl.go
+++ b/server/storage/disk/writer_impl.go
@@ -1186,103 +1186,36 @@ func (w *LocalFileWriter) recoverBlocksFromFooterUnsafe(ctx context.Context, fil
 		zap.Uint32("indexLength", footerRecord.IndexLength),
 		zap.Int32("totalBlocks", footerRecord.TotalBlocks))
 
-	// Validate footer record
-	if footerRecord.IndexOffset == 0 || footerRecord.IndexLength == 0 {
-		return fmt.Errorf("invalid footer record: IndexOffset=%d, IndexLength=%d",
-			footerRecord.IndexOffset, footerRecord.IndexLength)
-	}
-
-	// Read index section from file
-	indexData := make([]byte, footerRecord.IndexLength)
-	_, err := file.ReadAt(indexData, int64(footerRecord.IndexOffset))
+	// The footer validation and index parsing are shared with the other
+	// local-file backend (codec.ReadIndexSection), so a segment that was
+	// finalized with zero blocks is accepted the same way everywhere.
+	blockIndexes, err := codec.ReadIndexSection(file, footerRecord)
 	if err != nil {
-		return fmt.Errorf("failed to read index section: %w", err)
+		return err
 	}
-
-	logger.Ctx(ctx).Debug("Read index section",
-		zap.Int("indexDataLength", len(indexData)),
-		zap.Uint64("indexOffset", footerRecord.IndexOffset))
-
-	// Parse index records sequentially
-	offset := 0
-	blockIndexes := make([]*codec.IndexRecord, 0, footerRecord.TotalBlocks)
-
-	for offset < len(indexData) {
-		if offset+codec.RecordHeaderSize > len(indexData) {
-			logger.Ctx(ctx).Warn("Not enough data for complete record header",
-				zap.Int("offset", offset),
-				zap.Int("remaining", len(indexData)-offset))
-			break
-		}
-
-		// Decode the record
-		record, err := codec.DecodeRecord(indexData[offset:])
-		if err != nil {
-			logger.Ctx(ctx).Warn("Failed to decode index record",
-				zap.Int("offset", offset),
-				zap.Error(err))
-			return fmt.Errorf("failed to decode index record at offset %d: %w", offset, err)
-		}
-
-		// Verify it's an index record
-		if record.Type() != codec.IndexRecordType {
-			logger.Ctx(ctx).Warn("Unexpected record type in index section",
-				zap.Int("offset", offset),
-				zap.Uint8("expectedType", codec.IndexRecordType),
-				zap.Uint8("actualType", record.Type()))
-			return fmt.Errorf("expected index record type %d, got %d at offset %d",
-				codec.IndexRecordType, record.Type(), offset)
-		}
-
-		indexRecord := record.(*codec.IndexRecord)
-		blockIndexes = append(blockIndexes, indexRecord)
-
-		logger.Ctx(ctx).Debug("Parsed index record",
-			zap.Int32("blockNumber", indexRecord.BlockNumber),
-			zap.Int64("startOffset", indexRecord.StartOffset),
-			zap.Int64("firstEntryID", indexRecord.FirstEntryID),
-			zap.Int64("lastEntryID", indexRecord.LastEntryID))
-
-		// Move to next record (header + IndexRecord payload size)
-		recordSize := codec.RecordHeaderSize + codec.IndexRecordSize // IndexRecord payload size
-		offset += recordSize
-	}
-
-	// Validate recovered blocks count
 	if len(blockIndexes) != int(footerRecord.TotalBlocks) {
-		logger.Ctx(ctx).Warn("Block count mismatch",
-			zap.Int("recoveredBlocks", len(blockIndexes)),
-			zap.Int32("expectedBlocks", footerRecord.TotalBlocks))
-		// Continue anyway, use what we recovered
+		logger.Ctx(ctx).Warn("Recovered index record count differs from footer, using recovered records",
+			zap.String("segmentFilePath", w.segmentFilePath),
+			zap.Int("recovered", len(blockIndexes)),
+			zap.Int32("footerTotalBlocks", footerRecord.TotalBlocks))
 	}
 
-	// Update writer state
 	w.blockIndexes = blockIndexes
-
-	// Update entry ID tracking
 	if len(blockIndexes) > 0 {
 		firstBlock := blockIndexes[0]
 		lastBlock := blockIndexes[len(blockIndexes)-1]
-
 		w.firstEntryID.Store(firstBlock.FirstEntryID)
 		w.lastEntryID.Store(lastBlock.LastEntryID)
 		w.currentBlockNumber.Store(int64(len(blockIndexes))) // Next block number
-
-		logger.Ctx(ctx).Info("Updated entry ID tracking from recovered blocks",
-			zap.Int64("firstEntryID", firstBlock.FirstEntryID),
-			zap.Int64("lastEntryID", lastBlock.LastEntryID),
-			zap.Int64("nextBlockNumber", int64(len(blockIndexes))))
 	}
 
-	logger.Ctx(ctx).Info("Successfully recovered blocks from footer",
+	logger.Ctx(ctx).Info("Recovered blocks from footer",
 		zap.String("segmentFilePath", w.segmentFilePath),
 		zap.Int("recoveredBlocks", len(blockIndexes)),
 		zap.Int64("firstEntryID", w.firstEntryID.Load()),
 		zap.Int64("lastEntryID", w.lastEntryID.Load()))
-
 	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_footer", "success").Inc()
 	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_footer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
-
 	w.recovered.Store(true)
 	return nil
 }

--- a/server/storage/disk/writer_recover_empty_test.go
+++ b/server/storage/disk/writer_recover_empty_test.go
@@ -1,0 +1,97 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/server/storage/codec"
+)
+
+// A segment finalized with zero blocks is header + footer only, with
+// IndexOffset = header size and IndexLength = 0. Reopening it in recovery
+// mode (what Fence does when another writer takes over the log) must succeed
+// and see an empty, finalized segment; rejecting it makes the segment
+// unfenceable and the log unopenable.
+func TestLocalFileWriter_RecoverFinalizedEmptySegment(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, err := config.NewConfiguration()
+	require.NoError(t, err)
+
+	w, err := NewLocalFileWriter(ctx, dir, 1, 7, cfg)
+	require.NoError(t, err)
+	last, err := w.Finalize(ctx, -1)
+	require.NoError(t, err)
+	assert.EqualValues(t, -1, last)
+	require.NoError(t, w.Close(ctx))
+
+	st, err := os.Stat(getSegmentFilePath(dir, 1, 7))
+	require.NoError(t, err)
+	assert.EqualValues(t, codec.RecordHeaderSize+codec.HeaderRecordSize+codec.RecordHeaderSize+codec.FooterRecordSize, st.Size(),
+		"header + footer only")
+
+	rw, err := NewLocalFileWriterWithMode(ctx, dir, 1, 7, cfg, true)
+	require.NoError(t, err, "recovery of a finalized empty segment")
+	assert.True(t, rw.finalized.Load(), "recovered as finalized")
+	assert.Empty(t, rw.blockIndexes)
+	assert.EqualValues(t, -1, rw.GetFirstEntryId(ctx))
+	assert.EqualValues(t, -1, rw.GetLastEntryId(ctx))
+
+	fenced, err := rw.Fence(ctx)
+	require.NoError(t, err, "fence after reopen")
+	assert.EqualValues(t, -1, fenced)
+
+	_, err = rw.Finalize(ctx, -1)
+	assert.NoError(t, err, "finalize is idempotent on an already finalized segment")
+	require.NoError(t, rw.Close(ctx))
+}
+
+// A finalized segment with data still recovers its index through the shared
+// codec path.
+func TestLocalFileWriter_RecoverFinalizedSegmentWithData(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg, err := config.NewConfiguration()
+	require.NoError(t, err)
+
+	w, err := NewLocalFileWriter(ctx, dir, 1, 8, cfg)
+	require.NoError(t, err)
+	for i := int64(0); i < 3; i++ {
+		_, err := w.WriteDataAsync(ctx, i, []byte("payload"), nil)
+		require.NoError(t, err)
+	}
+	// Finalize syncs the buffer and waits for every flush before writing the footer.
+	last, err := w.Finalize(ctx, 2)
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, last)
+	require.NoError(t, w.Close(ctx))
+
+	rw, err := NewLocalFileWriterWithMode(ctx, dir, 1, 8, cfg, true)
+	require.NoError(t, err)
+	assert.True(t, rw.finalized.Load())
+	assert.NotEmpty(t, rw.blockIndexes)
+	assert.EqualValues(t, 0, rw.GetFirstEntryId(ctx))
+	assert.EqualValues(t, 2, rw.GetLastEntryId(ctx))
+	require.NoError(t, rw.Close(ctx))
+}

--- a/server/storage/stagedstorage/writer_impl.go
+++ b/server/storage/stagedstorage/writer_impl.go
@@ -2207,107 +2207,37 @@ func (w *StagedFileWriter) recoverBlocksFromFooterUnsafe(ctx context.Context, fi
 		zap.Uint32("indexLength", footerRecord.IndexLength),
 		zap.Int32("totalBlocks", footerRecord.TotalBlocks))
 
-	if footerRecord.IndexLength == 0 {
-		// empty index length, no data blocks at all, fast return
-		w.blockIndexes = make([]*codec.IndexRecord, 0, footerRecord.TotalBlocks)
-		w.recoveredFooter = footerRecord
-		w.recovered.Store(true)
-		logger.Ctx(ctx).Info("Recovered no blocks from footer")
-		return nil
-	}
-
-	// Read index section from file
-	indexData := make([]byte, footerRecord.IndexLength)
-	_, err := file.ReadAt(indexData, int64(footerRecord.IndexOffset))
+	// The footer validation and index parsing are shared with the other
+	// local-file backend (codec.ReadIndexSection), so a segment that was
+	// finalized with zero blocks is accepted the same way everywhere.
+	blockIndexes, err := codec.ReadIndexSection(file, footerRecord)
 	if err != nil {
-		return fmt.Errorf("failed to read index section: %w", err)
+		return err
 	}
-
-	logger.Ctx(ctx).Debug("Read index section",
-		zap.Int("indexDataLength", len(indexData)),
-		zap.Uint64("indexOffset", footerRecord.IndexOffset))
-
-	// Parse index records sequentially
-	offset := 0
-	blockIndexes := make([]*codec.IndexRecord, 0, footerRecord.TotalBlocks)
-
-	for offset < len(indexData) {
-		if offset+codec.RecordHeaderSize > len(indexData) {
-			logger.Ctx(ctx).Warn("Not enough data for complete record header",
-				zap.Int("offset", offset),
-				zap.Int("remaining", len(indexData)-offset))
-			break
-		}
-
-		// Decode the record
-		record, err := codec.DecodeRecord(indexData[offset:])
-		if err != nil {
-			logger.Ctx(ctx).Warn("Failed to decode index record",
-				zap.Int("offset", offset),
-				zap.Error(err))
-			return fmt.Errorf("failed to decode index record at offset %d: %w", offset, err)
-		}
-
-		// Verify it's an index record
-		if record.Type() != codec.IndexRecordType {
-			logger.Ctx(ctx).Warn("Unexpected record type in index section",
-				zap.Int("offset", offset),
-				zap.Uint8("expectedType", codec.IndexRecordType),
-				zap.Uint8("actualType", record.Type()))
-			return fmt.Errorf("expected index record type %d, got %d at offset %d",
-				codec.IndexRecordType, record.Type(), offset)
-		}
-
-		indexRecord := record.(*codec.IndexRecord)
-		blockIndexes = append(blockIndexes, indexRecord)
-
-		logger.Ctx(ctx).Debug("Parsed index record",
-			zap.Int32("blockNumber", indexRecord.BlockNumber),
-			zap.Int64("startOffset", indexRecord.StartOffset),
-			zap.Int64("firstEntryID", indexRecord.FirstEntryID),
-			zap.Int64("lastEntryID", indexRecord.LastEntryID))
-
-		// Move to next record (header + IndexRecord payload size)
-		recordSize := codec.RecordHeaderSize + codec.IndexRecordSize // IndexRecord payload size
-		offset += recordSize
-	}
-
-	// Validate recovered blocks count
 	if len(blockIndexes) != int(footerRecord.TotalBlocks) {
-		logger.Ctx(ctx).Warn("Block count mismatch",
-			zap.Int("recoveredBlocks", len(blockIndexes)),
-			zap.Int32("expectedBlocks", footerRecord.TotalBlocks))
-		// Continue anyway, use what we recovered
+		logger.Ctx(ctx).Warn("Recovered index record count differs from footer, using recovered records",
+			zap.String("segmentFilePath", w.segmentFilePath),
+			zap.Int("recovered", len(blockIndexes)),
+			zap.Int32("footerTotalBlocks", footerRecord.TotalBlocks))
 	}
 
-	// Update writer state
 	w.blockIndexes = blockIndexes
 	w.recoveredFooter = footerRecord
-
-	// Update entry ID tracking
 	if len(blockIndexes) > 0 {
 		firstBlock := blockIndexes[0]
 		lastBlock := blockIndexes[len(blockIndexes)-1]
-
 		w.firstEntryID.Store(firstBlock.FirstEntryID)
 		w.lastEntryID.Store(lastBlock.LastEntryID)
 		w.currentBlockNumber.Store(int64(len(blockIndexes))) // Next block number
-
-		logger.Ctx(ctx).Info("Updated entry ID tracking from recovered blocks",
-			zap.Int64("firstEntryID", firstBlock.FirstEntryID),
-			zap.Int64("lastEntryID", lastBlock.LastEntryID),
-			zap.Int64("nextBlockNumber", int64(len(blockIndexes))))
 	}
 
-	logger.Ctx(ctx).Info("Successfully recovered blocks from footer",
+	logger.Ctx(ctx).Info("Recovered blocks from footer",
 		zap.String("segmentFilePath", w.segmentFilePath),
 		zap.Int("recoveredBlocks", len(blockIndexes)),
 		zap.Int64("firstEntryID", w.firstEntryID.Load()),
 		zap.Int64("lastEntryID", w.lastEntryID.Load()))
-
 	metrics.WpFileOperationsTotal.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_footer", "success").Inc()
 	metrics.WpFileOperationLatency.WithLabelValues(metrics.NodeID, w.logNs, w.logIdStr, "recover_footer", "success").Observe(float64(time.Since(startTime).Milliseconds()))
-
 	w.recovered.Store(true)
 	return nil
 }

--- a/tests/integration/local_empty_segment_fence_test.go
+++ b/tests/integration/local_empty_segment_fence_test.go
@@ -1,0 +1,111 @@
+// Licensed to the LF AI & Data foundation under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/woodpecker/common/config"
+	"github.com/zilliztech/woodpecker/proto"
+	"github.com/zilliztech/woodpecker/server/storage/codec"
+	"github.com/zilliztech/woodpecker/server/storage/disk"
+	"github.com/zilliztech/woodpecker/woodpecker"
+	"github.com/zilliztech/woodpecker/woodpecker/log"
+)
+
+// A segment that was finalized while empty (header + footer, zero blocks) is a
+// valid file: Finalize writes IndexOffset = header size and IndexLength = 0 for
+// it. If that segment's metadata is still Active when the next writer opens the
+// log -- the state left behind when the previous holder finished completion
+// phase 1 (finalize on the log store) but never wrote the metadata update --
+// OpenLogWriter fences the segment, which reopens the file in recovery mode.
+// The recovery path has to accept the empty finalized file; rejecting it makes
+// the log unopenable for every later writer.
+//
+// The local backend is the one that reopens the same file, so this runs with
+// storage type "local". It needs etcd only.
+func TestLocalReopenFencesFinalizedEmptySegment(t *testing.T) {
+	ctx := context.Background()
+	cfg, err := config.NewConfiguration("../../config/woodpecker.yaml")
+	require.NoError(t, err)
+	cfg.Woodpecker.Storage.Type = "local"
+	cfg.Woodpecker.Storage.RootPath = t.TempDir()
+	if ep := os.Getenv("WP_TEST_ETCD_ENDPOINTS"); ep != "" {
+		cfg.Etcd.Endpoints = strings.Split(ep, ",")
+	}
+	cfg.Etcd.RootPath = fmt.Sprintf("wp-empty-seg-%d", time.Now().UnixNano())
+	require.NoError(t, woodpecker.StopEmbedLogStore())
+	logName := fmt.Sprintf("empty_seg_%d", time.Now().UnixNano())
+
+	// --- previous holder: creates the segment and never writes to it
+	client1, err := woodpecker.NewEmbedClientFromConfig(ctx, cfg)
+	require.NoError(t, err)
+	require.NoError(t, client1.CreateLog(ctx, logName))
+	lh1, err := client1.OpenLog(ctx, logName)
+	require.NoError(t, err)
+	sh, err := lh1.GetOrCreateWritableSegmentHandle(ctx, func(context.Context, string) {})
+	require.NoError(t, err)
+	logId := lh1.GetId()
+	segId := sh.GetId(ctx)
+
+	// The holder is gone before completing the segment in metadata: drop the
+	// client and the in-memory log store (a new process has neither).
+	require.NoError(t, client1.Close(ctx))
+	require.NoError(t, woodpecker.StopEmbedLogStore())
+
+	// Its log store had finalized the segment file: header + footer, zero blocks.
+	// Write that state directly, at the path the local log store uses for
+	// storage type "local": <storage.rootPath>/<minio.rootPath>/<logId>/<segmentId>
+	// (see segmentProcessor.getOrCreateSegmentWriter, local branch).
+	baseDir := path.Join(cfg.Woodpecker.Storage.RootPath, cfg.Minio.RootPath)
+	w, err := disk.NewLocalFileWriter(ctx, baseDir, logId, segId, cfg)
+	require.NoError(t, err)
+	_, err = w.Finalize(ctx, -1)
+	require.NoError(t, err)
+	require.NoError(t, w.Close(ctx))
+	st, err := os.Stat(path.Join(baseDir, fmt.Sprintf("%d/%d/data.log", logId, segId)))
+	require.NoError(t, err)
+	require.EqualValues(t, codec.RecordHeaderSize+codec.HeaderRecordSize+codec.RecordHeaderSize+codec.FooterRecordSize, st.Size(),
+		"header + footer only: a finalized empty segment")
+
+	// --- next holder opens the log and must fence the still-Active empty segment
+	client2, err := woodpecker.NewEmbedClientFromConfig(ctx, cfg)
+	require.NoError(t, err)
+	defer func() {
+		_ = client2.Close(ctx)
+		_ = woodpecker.StopEmbedLogStore()
+	}()
+	lh2, err := client2.OpenLog(ctx, logName)
+	require.NoError(t, err)
+	segMeta, err := lh2.GetMetadataProvider().GetSegmentMetadata(ctx, logName, segId)
+	require.NoError(t, err)
+	require.Equal(t, proto.SegmentState_Active, segMeta.Metadata.State, "metadata still says Active")
+
+	writer, err := lh2.OpenLogWriter(ctx)
+	require.NoError(t, err, "fencing a finalized empty segment on reopen must succeed")
+	res := writer.Write(ctx, &log.WriteMessage{Payload: []byte("first write after reopen")})
+	require.NoError(t, res.Err)
+	require.NoError(t, writer.Close(ctx))
+}


### PR DESCRIPTION
Fixes #306

## Problem

`Finalize` on a segment with zero blocks writes a complete, valid file: header record, no blocks, no index records, footer. Its footer therefore says `IndexOffset = 25` (the header size) and `IndexLength = 0`. The disk backend's `recoverBlocksFromFooterUnsafe` rejected exactly that footer:

```go
if footerRecord.IndexOffset == 0 || footerRecord.IndexLength == 0 {
    return fmt.Errorf("invalid footer record: ...")
}
```

`segmentProcessor.Fence` always reopens the writer in recovery mode, so an empty segment that had been finalized on the log store but was still `Active` in metadata (completion phase 2 never landed) could never be fenced again, and `OpenLogWriter` → `fenceAllActiveSegments` failed on every attempt. From Milvus this is a WAL that never reopens after a restart (`failed to fence log: failed to fence segment N: recover from existing file: invalid footer record: IndexOffset=25, IndexLength=0`), with the balancer in backoff, the pchannel stuck in `ASSIGNING`, DDL blocked and `healthz` still OK.

A torn footer does not reach this branch: it fails CRC, does not parse, and goes to the full-scan recovery. Only the well-formed empty footer did.

## Change

- `codec`: new `ValidateIndexSection`, `ParseIndexRecords`, `ReadIndexSection`. One definition of which footers are acceptable: `IndexOffset == 0` is invalid; `IndexLength == 0 && TotalBlocks == 0` is an empty finalized segment (empty index, no entries); `IndexLength == 0 && TotalBlocks != 0` is invalid; otherwise the section is read and parsed strictly, as before.
- `disk` and `stagedstorage` writers: `recoverBlocksFromFooterUnsafe` now calls `codec.ReadIndexSection` and only applies the result to writer state. The two functions were line-for-line identical except that staged already accepted the empty case; the divergence is what let the disk backend keep the bug. Behavior for populated segments is unchanged (same strict parsing, same state updates including `currentBlockNumber`).
- `objectstorage` is untouched: it recovers from object listings and already parses an empty index section to zero records.

## Tests

- `codec/index_section_test.go`: validation rules, round trip, length mismatch, wrong record type, corrupt record (CRC), reading an empty finalized file and a populated one.
- `disk/writer_recover_empty_test.go`: finalize an empty segment → reopen in recovery mode → `Fence` → `Finalize` again (idempotent); and the same flow for a segment with data.
- `tests/integration/local_empty_segment_fence_test.go` (storage type `local`, needs etcd): a segment is created but never written, its file is finalized while its metadata stays `Active`, then a second client opens the log and writes.

Verified locally: the integration test **fails on `master` without the fix** with the exact production error above, and passes with it. `go test ./server/storage/codec/ ./server/storage/disk/ ./server/storage/stagedstorage/` pass; `gofumpt`/`gci` clean; `golangci-lint` (repo config) reports no issues on the touched packages.
