### PR TITLE
fix(ci): resolve the PR from open pull requests when the head commit is not local

### DIFF
--- a/.github/workflows/pr-ci-label.yaml
+++ b/.github/workflows/pr-ci-label.yaml
@@ -57,8 +57,16 @@ jobs:
           set -euo pipefail
 
           # `workflow_run.pull_requests` is empty for pull requests from forks,
-          # so resolve the PR from the head SHA instead.
+          # so the PR has to be resolved from the head SHA. `commits/{sha}/pulls`
+          # only covers commits that live in this repository, which a fork's head
+          # commit does not, so fall back to matching the SHA against open PRs.
           PR=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" --jq '.[0].number // empty')
+          if [ -z "$PR" ]; then
+            # shellcheck disable=SC2016  # $ENV.HEAD_SHA is jq, not shell
+            MATCHES=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate \
+                        --jq '.[] | select(.head.sha == $ENV.HEAD_SHA) | .number')
+            PR=$(printf '%s\n' "$MATCHES" | head -n 1)
+          fi
           if [ -z "$PR" ]; then
             echo "No pull request found for ${HEAD_SHA}; nothing to do."
             exit 0


### PR DESCRIPTION
Follow-up to #309.

## Problem

`PR CI Label` never labels a fork pull request — the case it was written for.

It resolved the PR with:

```bash
PR=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" --jq '.[0].number // empty')
```

"List pull requests associated with a commit" only reports commits that live in **this** repository. A fork PR's head commit does not, so the call returns `[]` and the job exits early.

Observed on #307 right after #309 merged ([run 34318783993](https://github.com/zilliztech/woodpecker/actions/runs/34318783993)):

```
RUN_ID: 34287397814
RUN_CONCLUSION: success
No pull request found for baab3207e5cb13dd316f9743b1b905f8cd56961c; nothing to do.
```

Confirmed directly against the API for `baab320` (#307, `czs007:fix/disk-recover-empty-finalized-segment`):

| Lookup | Result |
| --- | --- |
| `repos/zilliztech/woodpecker/commits/{sha}/pulls` | `0` entries |
| open PRs filtered by `head.sha` | `307` |

The `workflow_run` plumbing itself works — the workflow fires and reaches the script. Only the lookup was wrong.

## Change

Keep `commits/{sha}/pulls` as the cheap path for same-repository PRs, and fall back to matching the head SHA against the open pull requests when it returns nothing:

```bash
if [ -z "$PR" ]; then
  # shellcheck disable=SC2016  # $ENV.HEAD_SHA is jq, not shell
  MATCHES=$(gh api "repos/${REPO}/pulls?state=open&per_page=100" --paginate \
              --jq '.[] | select(.head.sha == $ENV.HEAD_SHA) | .number')
  PR=$(printf '%s\n' "$MATCHES" | head -n 1)
fi
```

The SHA reaches jq through `$ENV`, not string interpolation, so nothing PR-controlled is spliced into the shell or the filter. `MATCHES` is captured before `head` so `set -o pipefail` cannot trip on SIGPIPE.

## Verification

- Both lookups exercised against the live API for #307: the old one returns nothing, the new one returns `307`.
- `actionlint` clean; the script body passes `bash -n`.

Full end-to-end confirmation again needs this on `master`, since `workflow_run` only executes from the default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
