### PR TITLE
enhance(test): cover empty-segment recovery on every backend and scope the shared footer validator

### DIFF
--- a/server/storage/codec/index_section.go
+++ b/server/storage/codec/index_section.go
@@ -1,18 +1,19 @@
-// Licensed to the LF AI & Data foundation under one
-// or more contributor license agreements. See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership. The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License. You may obtain a copy of the License at
+// Copyright (C) 2025 Zilliz. All rights reserved.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// This file is part of the Woodpecker project.
+//
+// Woodpecker is dual-licensed under the GNU Affero General Public License v3.0
+// (AGPLv3) and the Server Side Public License v1 (SSPLv1). You may use this
+// file under either license, at your option.
+//
+// AGPLv3 License: https://www.gnu.org/licenses/agpl-3.0.html
+// SSPLv1 License: https://www.mongodb.com/licensing/server-side-public-license
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under these licenses is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// See the license texts for specific language governing permissions and
+// limitations under the licenses.
 
 package codec
 
@@ -22,8 +23,17 @@ import (
 )
 
 // ValidateIndexSection checks that a parsed footer describes a readable index
-// section. It is the single definition of which footers are acceptable, shared
-// by every storage backend that recovers a finalized segment from its footer.
+// section of a segment file that stores its index inline -- the local-file
+// backends, disk and stagedstorage, whose data.log is
+// header | blocks | index records | footer.
+//
+// It is NOT valid for footers whose index lives in a separate object. In
+// objectstorage, and for stagedstorage's compacted footer, the index records
+// start at offset 0 of footer.blk, so those footers carry IndexOffset = 0 as
+// their normal value and the readers never consult IndexOffset at all
+// (objectstorage.recoverFromFooter and stagedstorage's parseIndexDataUnsafe
+// slice the object instead). Routing them through this function would reject
+// every object-storage segment as corrupt.
 //
 // A segment that was finalized with zero blocks is valid: Finalize writes the
 // header and the footer with nothing in between, so IndexOffset equals the
@@ -35,8 +45,9 @@ func ValidateIndexSection(footer *FooterRecord) error {
 		return fmt.Errorf("invalid footer record: nil")
 	}
 	if footer.IndexOffset == 0 {
-		// Every finalized file starts with a header record, so the index
-		// section can never begin at offset 0.
+		// An inline index always follows the header record, so it can never
+		// begin at offset 0. (A footer describing a separate index object may
+		// legitimately say 0 -- such footers do not belong here, see above.)
 		return fmt.Errorf("invalid footer record: IndexOffset=%d, IndexLength=%d",
 			footer.IndexOffset, footer.IndexLength)
 	}

--- a/server/storage/codec/index_section_test.go
+++ b/server/storage/codec/index_section_test.go
@@ -1,18 +1,19 @@
-// Licensed to the LF AI & Data foundation under one
-// or more contributor license agreements. See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership. The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License. You may obtain a copy of the License at
+// Copyright (C) 2025 Zilliz. All rights reserved.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// This file is part of the Woodpecker project.
+//
+// Woodpecker is dual-licensed under the GNU Affero General Public License v3.0
+// (AGPLv3) and the Server Side Public License v1 (SSPLv1). You may use this
+// file under either license, at your option.
+//
+// AGPLv3 License: https://www.gnu.org/licenses/agpl-3.0.html
+// SSPLv1 License: https://www.mongodb.com/licensing/server-side-public-license
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under these licenses is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// See the license texts for specific language governing permissions and
+// limitations under the licenses.
 
 package codec
 

--- a/server/storage/disk/writer_recover_empty_test.go
+++ b/server/storage/disk/writer_recover_empty_test.go
@@ -1,18 +1,19 @@
-// Licensed to the LF AI & Data foundation under one
-// or more contributor license agreements. See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership. The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License. You may obtain a copy of the License at
+// Copyright (C) 2025 Zilliz. All rights reserved.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// This file is part of the Woodpecker project.
+//
+// Woodpecker is dual-licensed under the GNU Affero General Public License v3.0
+// (AGPLv3) and the Server Side Public License v1 (SSPLv1). You may use this
+// file under either license, at your option.
+//
+// AGPLv3 License: https://www.gnu.org/licenses/agpl-3.0.html
+// SSPLv1 License: https://www.mongodb.com/licensing/server-side-public-license
 //
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
+// distributed under these licenses is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// See the license texts for specific language governing permissions and
+// limitations under the licenses.
 
 package disk
 

--- a/server/storage/objectstorage/writer_recover_empty_test.go
+++ b/server/storage/objectstorage/writer_recover_empty_test.go
@@ -1,0 +1,84 @@
+// Copyright (C) 2025 Zilliz. All rights reserved.
+//
+// This file is part of the Woodpecker project.
+//
+// Woodpecker is dual-licensed under the GNU Affero General Public License v3.0
+// (AGPLv3) and the Server Side Public License v1 (SSPLv1). You may use this
+// file under either license, at your option.
+//
+// AGPLv3 License: https://www.gnu.org/licenses/agpl-3.0.html
+// SSPLv1 License: https://www.mongodb.com/licensing/server-side-public-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under these licenses is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the license texts for specific language governing permissions and
+// limitations under the licenses.
+
+package objectstorage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/woodpecker/mocks/mocks_objectstorage"
+	"github.com/zilliztech/woodpecker/server/storage/codec"
+)
+
+// A segment finalized with zero blocks uploads a footer.blk that carries only
+// the footer record: TotalBlocks=0, IndexLength=0. Recovery has to accept it,
+// or the segment can never be fenced -- the failure that left a local-storage
+// WAL unopenable in #306. This backend was never affected, and had no test
+// saying so.
+func TestMinioFileWriter_RecoverFromFooter_EmptyFinalizedSegment(t *testing.T) {
+	ctx := context.Background()
+	mockClient := mocks_objectstorage.NewObjectStorage(t)
+	w := newTestMinioFileWriter()
+	w.client = mockClient
+
+	footerData, footer := serializeFooterAndIndexes(ctx, nil)
+	require.EqualValues(t, 0, footer.TotalBlocks)
+	require.EqualValues(t, 0, footer.IndexLength)
+	require.Len(t, footerData, codec.RecordHeaderSize+codec.GetFooterRecordSize(footer.Version),
+		"an empty finalized segment uploads the footer record and nothing else")
+
+	footerBlockKey := "test-base/1/0/footer.blk"
+	mockReader := &writerMockFileReader{data: footerData}
+	mockClient.EXPECT().GetObject(mock.Anything, "test-bucket", footerBlockKey, int64(0), int64(len(footerData)), mock.Anything, mock.Anything).
+		Return(mockReader, nil).Once()
+
+	err := w.recoverFromFooter(ctx, footerBlockKey, int64(len(footerData)))
+	require.NoError(t, err, "recovery of a finalized empty segment")
+	assert.True(t, w.finalized.Load(), "a footer means the segment is finalized")
+	assert.False(t, w.storageWritable.Load())
+	assert.Empty(t, w.blockIndexes)
+	assert.EqualValues(t, -1, w.lastEntryID.Load())
+}
+
+// This backend keeps its index at offset 0 of a separate footer.blk, so
+// IndexOffset=0 is its normal value -- the opposite of the local-file backends,
+// where it marks a corrupt footer. codec.ValidateIndexSection encodes the
+// local-file rule, so object-storage footers must never be routed through it.
+// If someone ever "unifies" recoverFromFooter onto the shared codec helper,
+// this fails instead of every object-storage segment being declared corrupt.
+func TestObjectStorageFooterIsNotValidatedAsInlineIndex(t *testing.T) {
+	ctx := context.Background()
+
+	_, empty := serializeFooterAndIndexes(ctx, nil)
+	_, populated := serializeFooterAndIndexes(ctx, []*codec.IndexRecord{
+		{BlockNumber: 0, StartOffset: 0, BlockSize: 100, FirstEntryID: 0, LastEntryID: 9},
+	})
+
+	for name, footer := range map[string]*codec.FooterRecord{"empty": empty, "populated": populated} {
+		t.Run(name, func(t *testing.T) {
+			require.EqualValues(t, 0, footer.IndexOffset,
+				"index records start at offset 0 of footer.blk")
+			assert.Error(t, codec.ValidateIndexSection(footer),
+				"the inline-index validator rejects this backend's footers by design")
+		})
+	}
+}

--- a/server/storage/stagedstorage/writer_recover_empty_test.go
+++ b/server/storage/stagedstorage/writer_recover_empty_test.go
@@ -1,0 +1,118 @@
+// Copyright (C) 2025 Zilliz. All rights reserved.
+//
+// This file is part of the Woodpecker project.
+//
+// Woodpecker is dual-licensed under the GNU Affero General Public License v3.0
+// (AGPLv3) and the Server Side Public License v1 (SSPLv1). You may use this
+// file under either license, at your option.
+//
+// AGPLv3 License: https://www.gnu.org/licenses/agpl-3.0.html
+// SSPLv1 License: https://www.mongodb.com/licensing/server-side-public-license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under these licenses is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the license texts for specific language governing permissions and
+// limitations under the licenses.
+
+package stagedstorage
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zilliztech/woodpecker/server/storage/codec"
+)
+
+// The staged mirror of disk's TestLocalFileWriter_RecoverFinalizedEmptySegment.
+//
+// TestRecoverBlocksFromFooter_EmptyIndexLength already covers reopening a
+// finalized empty segment, but it stops at inspecting the recovered state. The
+// sequence that made a WAL unopenable in #306 goes one step further: Fence
+// reopens the writer in recovery mode and then fences it. That combination was
+// never exercised on this backend, which is how the same defect survived in
+// disk until #307.
+func TestStagedFileWriter_RecoverFinalizedEmptySegment_ThenFence(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+
+	w, err := NewStagedFileWriter(ctx, "test-bucket", "test-root", dir, 1, 77, nil, cfg)
+	require.NoError(t, err)
+	last, err := w.Finalize(ctx, -1)
+	require.NoError(t, err)
+	assert.EqualValues(t, -1, last)
+	require.NoError(t, w.Close(ctx))
+
+	rw, err := NewStagedFileWriterWithMode(ctx, "test-bucket", "test-root", dir, 1, 77, nil, cfg, true)
+	require.NoError(t, err, "recovery of a finalized empty segment")
+	defer rw.Close(ctx)
+	assert.True(t, rw.finalized.Load(), "recovered as finalized")
+	assert.Empty(t, rw.blockIndexes)
+
+	fenced, err := rw.Fence(ctx)
+	require.NoError(t, err, "fence after reopen")
+	assert.EqualValues(t, -1, fenced)
+
+	_, err = rw.Finalize(ctx, -1)
+	assert.NoError(t, err, "finalize is idempotent on an already finalized segment")
+}
+
+// writeFinalizedFileWithFooter lays down header + footer at the path the staged
+// writer reads, so recovery sees a well-formed file carrying exactly this footer.
+func writeFinalizedFileWithFooter(t *testing.T, dir string, logId, segId int64, footer *codec.FooterRecord) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(getSegmentDir(dir, logId, segId), 0o755))
+
+	header := codec.EncodeRecord(&codec.HeaderRecord{Version: codec.FormatVersion, Flags: 0, FirstEntryID: 0})
+	data := append(append([]byte{}, header...), codec.EncodeRecord(footer)...)
+	require.NoError(t, os.WriteFile(getSegmentFilePath(dir, logId, segId), data, 0o644))
+}
+
+// #307 routed this backend through codec.ValidateIndexSection, which rejects
+// IndexOffset == 0. The fast path it replaced accepted any footer with
+// IndexLength == 0 regardless of IndexOffset, so this is a real tightening of
+// staged's contract and needs a test of its own -- the codec package tests the
+// rule, not that this backend applies it.
+func TestStagedFileWriter_RecoverFromFooter_RejectsZeroIndexOffset(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+
+	writeFinalizedFileWithFooter(t, dir, 2, 10, &codec.FooterRecord{
+		TotalBlocks: 0,
+		TotalSize:   0,
+		IndexOffset: 0,
+		IndexLength: 0,
+		Version:     codec.FormatVersion,
+		LAC:         -1,
+	})
+
+	_, err := NewStagedFileWriterWithMode(ctx, "test-bucket", "test-root", dir, 2, 10, nil, cfg, true)
+	require.Error(t, err, "an inline-index footer can never start at offset 0")
+	assert.ErrorContains(t, err, "IndexOffset=0")
+}
+
+// The other half of the tightening: a zero-length index cannot describe blocks.
+func TestStagedFileWriter_RecoverFromFooter_RejectsIndexLengthZeroWithBlocks(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+
+	writeFinalizedFileWithFooter(t, dir, 2, 11, &codec.FooterRecord{
+		TotalBlocks: 3,
+		TotalSize:   uint64(codec.RecordHeaderSize + codec.HeaderRecordSize),
+		IndexOffset: uint64(codec.RecordHeaderSize + codec.HeaderRecordSize),
+		IndexLength: 0,
+		Version:     codec.FormatVersion,
+		LAC:         -1,
+	})
+
+	_, err := NewStagedFileWriterWithMode(ctx, "test-bucket", "test-root", dir, 2, 11, nil, cfg, true)
+	require.Error(t, err, "IndexLength=0 cannot describe 3 blocks")
+	assert.ErrorContains(t, err, "TotalBlocks=3")
+}

--- a/tests/integration/local_empty_segment_fence_test.go
+++ b/tests/integration/local_empty_segment_fence_test.go
@@ -105,6 +105,16 @@ func TestLocalReopenFencesFinalizedEmptySegment(t *testing.T) {
 
 	writer, err := lh2.OpenLogWriter(ctx)
 	require.NoError(t, err, "fencing a finalized empty segment on reopen must succeed")
+
+	// The fence has to have landed on the file this test wrote. disk.Fence drops
+	// a write.fence flag next to data.log, so its presence proves the log store
+	// resolved the same path the test guessed. Without this the test would still
+	// pass if that layout ever drifted: the finalized empty file would sit where
+	// nobody looks, recoverFromExistingFileUnsafe would take its os.IsNotExist
+	// fast path, and the fence would trivially succeed with the bug intact.
+	require.FileExists(t, path.Join(baseDir, fmt.Sprintf("%d/%d/write.fence", logId, segId)),
+		"fence flag must sit beside the segment file this test finalized")
+
 	res := writer.Write(ctx, &log.WriteMessage{Payload: []byte("first write after reopen")})
 	require.NoError(t, res.Err)
 	require.NoError(t, writer.Close(ctx))


### PR DESCRIPTION
Follow-up to #307.

## Why

#307 fixed the disk backend rejecting a finalized empty segment. The coverage that should have caught it existed — but in the wrong package.

`stagedstorage` has had `TestRecoverBlocksFromFooter_EmptyIndexLength` for a while: finalize an empty segment, reopen in recovery mode, assert the recovered state. That is exactly the #306 case. It lives on the one local backend that already handled it, while `disk` — byte-for-byte the same function apart from that one branch — never got a mirror.

Running that same test against `disk` on the pre-#307 code reproduces the production error verbatim:

```
recover from existing file: invalid footer record: IndexOffset=25, IndexLength=0
```

So the failure mode was not "nobody thought of empty segments". It was that coverage is organised per package rather than per path, and a shared behaviour drifted between two copies of it. This PR closes the same gap on the other two backends and on the fence path.

## Tests added

**`objectstorage`** — had no test that finalized an empty segment and recovered it.

- `TestMinioFileWriter_RecoverFromFooter_EmptyFinalizedSegment` — a footer.blk holding only the footer record recovers to zero blocks, finalized, not writable.
- `TestObjectStorageFooterIsNotValidatedAsInlineIndex` — this backend keeps its index at offset 0 of a separate `footer.blk`, so `IndexOffset=0` is its **normal** value, the opposite of the local-file backends where it marks corruption. The test pins that `codec.ValidateIndexSection` rejects these footers *by design*, so a future attempt to "unify" `recoverFromFooter` onto the shared helper fails a test instead of declaring every object-storage segment corrupt.

**`stagedstorage`** — `TestRecoverBlocksFromFooter_EmptyIndexLength` stops at inspecting recovered state; the #306 sequence continues into `Fence`, which reopens the writer in recovery mode. That combination was never exercised here — the same shape of gap that let the defect survive in `disk`. Its existing `Fence` tests all fence a fresh or written-to writer, never a recovered finalized empty one.

- `TestStagedFileWriter_RecoverFinalizedEmptySegment_ThenFence` — the mirror of disk's `TestLocalFileWriter_RecoverFinalizedEmptySegment`: finalize empty → reopen in recovery mode → `Fence` → idempotent `Finalize`.
- `TestStagedFileWriter_RecoverFromFooter_RejectsZeroIndexOffset` and `..._RejectsIndexLengthZeroWithBlocks` — #307 routed this backend through `codec.ValidateIndexSection`, replacing a fast path that accepted **any** footer with `IndexLength == 0` regardless of `IndexOffset`. That is a real tightening of staged's contract, and the codec package tests the rule, not that this backend applies it.

**`tests/integration`** — `local_empty_segment_fence_test.go` hard-codes the on-disk layout it writes the finalized empty file to. If that layout ever drifts, the file lands where the log store never looks, `recoverFromExistingFileUnsafe` takes its `os.IsNotExist` fast path, `OpenLogWriter` trivially succeeds, and the test passes **with the bug fully present**. It now asserts the `write.fence` flag that `disk.Fence` drops beside `data.log`, which can only exist if the log store resolved the same path.

## Comment fix

`ValidateIndexSection` claimed to be "the single definition of which footers are acceptable, shared by every storage backend that recovers a finalized segment from its footer". Two footer flavours in this repository legitimately carry `IndexOffset = 0`:

| footer | IndexOffset | reader |
| --- | --- | --- |
| disk / staged `data.log` (index inline) | `>= 25` | `codec.ReadIndexSection` |
| objectstorage `footer.blk` | `0` | `recoverFromFooter` slices the object |
| staged compacted `footer.blk` | `0` | `parseIndexDataUnsafe` starts at 0 |

The comment now states which backends the rule covers and which it must not be used for, so the invitation to unify the remaining two is no longer sitting in the code.

## License headers

The three files added by #307 carry the LF AI & Data / Apache-2.0 header, while every other file in `server/storage/codec` and `server/storage/disk` uses the Zilliz AGPLv3/SSPLv1 header — 45 files to 2 across `server/`. In a dual-licensed repository that is a licensing statement, not formatting, so they are restored to the surrounding convention. (`tests/integration` genuinely uses the LF AI header, 22 files to 2, so that file is left alone.)

## Verification

- `server/storage/{codec,disk,stagedstorage,objectstorage}` all pass.
- `gofmt`, `gofumpt` and `gci` clean on every changed file.
- The integration assertion was exercised locally: the `write.fence` check passes, and the test then fails at the following write on `logstore local disk above hard watermark` — a local disk-space condition on my machine, not the test. CI runs it on a clean runner.

## Still open

The error path in `recoverBlocksFromFooterUnsafe` still emits no metric — `recover_footer` is only recorded with `status="success"`, so during an outage of exactly this kind the dashboards show the success counter going flat with no error series to alert on. Left out here to keep this to tests and comments; happy to send it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
