### PR TITLE
fix(ci): pass the rerun comment body through the environment instead of the script

### DIFF
--- a/.github/workflows/rerun-ci.yaml
+++ b/.github/workflows/rerun-ci.yaml
@@ -22,10 +22,18 @@ jobs:
       - name: Rerun workflows
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A ${{ }} expression is substituted into the script before bash parses
+          # it, so anything interpolated straight into `run:` is executed as shell
+          # source. A comment body is written by whoever comments -- it has to
+          # arrive as an environment variable, which bash reads as data. Only the
+          # first word of it is ever a command; the rest is prose.
+          # (issue.number and github.repository below are supplied by GitHub, not
+          # by the commenter, so they are not attacker-controlled.)
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           PR=${{ github.event.issue.number }}
           REPO=${{ github.repository }}
-          COMMENT="${{ github.event.comment.body }}"
+          COMMENT="$COMMENT_BODY"
 
           # Map comment keywords to workflow file names
           declare -A WORKFLOW_MAP


### PR DESCRIPTION
## Problem

`rerun-ci.yaml` built its script with the comment body spliced in:

```yaml
run: |
  COMMENT="${{ github.event.comment.body }}"
```

A `${{ }}` expression is substituted **before bash parses the script**, so the comment body arrived as shell *source*, not as a value. Anyone who can comment on an issue — on a public repository, anyone — could therefore have text of their choosing evaluated by the job. The trigger guard does not help: a body that begins with `/rerun` satisfies `startsWith(...)` and then continues into whatever follows it.

The job runs with:

```yaml
permissions:
  actions: write
  pull-requests: write
  issues: write
```

and `GH_TOKEN` in its environment. There is no `contents: write`, so this could not push code, but it could act on workflow runs, issues and pull requests, and the token itself was reachable.

## Change

Deliver the body as an environment variable. `env:` values are set by the runner as process environment, so bash reads them at runtime as data and never parses them as code.

```diff
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           PR=${{ github.event.issue.number }}
           REPO=${{ github.repository }}
-          COMMENT="${{ github.event.comment.body }}"
+          COMMENT="$COMMENT_BODY"
```

Nothing else changes. Command extraction, the keyword map, and every use of `CMD` are untouched — `CMD` was already quoted at each site (`[ "$CMD" = ... ]`, an associative-array subscript, `gh` arguments) and only ever used as a value.

`issue.number` and `github.repository` stay interpolated: GitHub supplies both, and neither is written by the commenter. A comment above the `env:` block records that distinction so the next reader does not have to re-derive it.

## What this does not change

Who may trigger a rerun is unchanged — the workflow has no author check today and this PR does not add one, so any commenter can still run `/rerun` on any PR. That is a separate product question; this PR only stops the surrounding text from being executed.

## Verification

The extraction logic was exercised in isolation:

| comment body | resulting `CMD` |
| --- | --- |
| `/rerun-chaos` | `/rerun-chaos` |
| `/rerun` + free-form prose | `/rerun` |
| body containing quotes | `/rerun` |
| body shaped to close the quote | an unrecognised string → falls through to the "Unknown command" branch, nothing executed |

`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
