### PR TITLE
enhance(log): stop the auditor re-logging a no-op compaction pass on local storage

### DIFF
--- a/woodpecker/log/internal_log_writer.go
+++ b/woodpecker/log/internal_log_writer.go
@@ -265,10 +265,16 @@ func (l *internalLogWriterImpl) runAuditor() {
 	ticker := time.NewTicker(time.Duration(l.auditorMaxInterval * int(time.Second)))
 	defer ticker.Stop()
 
+	// Storage mode is fixed for the writer's lifetime; read it once here rather than per
+	// segment. localMode disables the compaction pass (see compactCompletedSegments), so
+	// report it here instead of logging the skip for every segment on every cycle.
+	localMode := l.cfg.Woodpecker.Storage.IsStorageLocal()
+
 	logger.Ctx(context.Background()).Info("Log auditor started",
 		zap.String("logName", l.logHandle.GetName()),
 		zap.Int64("logId", l.logHandle.GetId()),
-		zap.Int("intervalSeconds", l.auditorMaxInterval))
+		zap.Int("intervalSeconds", l.auditorMaxInterval),
+		zap.Bool("localStorageCompactionDisabled", localMode))
 
 	auditCycle := uint64(0)
 	for {
@@ -319,7 +325,7 @@ func (l *internalLogWriterImpl) runAuditor() {
 			markTruncatedSegmentsReaped(l.notifyManager, truncatedSegmentExists)
 			publishSegmentsSnapshot(l.notifySegsCh, segmentMetaList)
 
-			cs := compactCompletedSegments(ctx, l.logHandle, segmentMetaList)
+			cs := compactCompletedSegments(ctx, l.logHandle, segmentMetaList, localMode)
 			if ctx.Err() != nil {
 				sp.End()
 				return
@@ -463,7 +469,9 @@ func (l *internalLogWriterImpl) cleanupTruncatedSegmentsIfNecessary(ctx context.
 	// Process segments in ascending order by segment ID
 	var segmentIdsToClean []int64
 	truncatedSegmentCount := 0
-	protectedSegmentCount := 0
+	readerProtectedCount := 0
+	ttlProtectedCount := 0
+	ttlCutoffMs := time.Now().UnixMilli() - int64(l.cfg.Woodpecker.Logstore.RetentionPolicy.TTL*1000)
 
 	for segId, segMeta := range segments {
 		// Only consider segments that are truncated
@@ -473,13 +481,12 @@ func (l *internalLogWriterImpl) cleanupTruncatedSegmentsIfNecessary(ctx context.
 
 		truncatedSegmentCount++
 
-		// Skip segments that are at or after the minTruncatedSegmentId point
+		// Skip segments that are at or after the minTruncatedSegmentId point.
+		// Counted, not logged: a protected segment stays protected across cycles, so a per-segment
+		// line re-reports the same segments every cycle at O(segments) volume. The eligibility
+		// summary below carries the counts and the cutoffs needed to explain any single decision.
 		if segId >= minTruncatedSegmentId {
-			logger.Ctx(ctx).Debug("Skipping truncated segment still in use by readers",
-				zap.String("logName", logName),
-				zap.Int64("logId", logId),
-				zap.Int64("segmentId", segId))
-			protectedSegmentCount++
+			readerProtectedCount++
 			continue
 		}
 
@@ -491,12 +498,8 @@ func (l *internalLogWriterImpl) cleanupTruncatedSegmentsIfNecessary(ctx context.
 		if segMeta.Metadata.SealedTime > lastActiveTime {
 			lastActiveTime = segMeta.Metadata.SealedTime
 		}
-		if lastActiveTime+int64(l.cfg.Woodpecker.Logstore.RetentionPolicy.TTL*1000) > time.Now().UnixMilli() {
-			logger.Ctx(ctx).Debug("Skipping truncated segment still within ttl protection",
-				zap.String("logName", logName),
-				zap.Int64("logId", logId),
-				zap.Int64("segmentId", segId))
-			protectedSegmentCount++
+		if lastActiveTime > ttlCutoffMs {
+			ttlProtectedCount++
 			continue
 		}
 
@@ -513,7 +516,10 @@ func (l *internalLogWriterImpl) cleanupTruncatedSegmentsIfNecessary(ctx context.
 		zap.Int64("logId", logId),
 		zap.Int("totalTruncatedSegments", truncatedSegmentCount),
 		zap.Int("segmentsEligibleForCleanup", len(segmentIdsToClean)),
-		zap.Int("segmentsProtectedByReaders", protectedSegmentCount))
+		zap.Int("segmentsProtectedByReaders", readerProtectedCount),
+		zap.Int("segmentsProtectedByTTL", ttlProtectedCount),
+		zap.Int64("minSegmentIdInUse", minTruncatedSegmentId),
+		zap.Int64("ttlCutoffMs", ttlCutoffMs))
 
 	if len(segmentIdsToClean) == 0 {
 		logger.Ctx(ctx).Info("No truncated segments eligible for cleanup",

--- a/woodpecker/log/log_auditor.go
+++ b/woodpecker/log/log_auditor.go
@@ -52,8 +52,18 @@ type compactStats struct {
 // compactCompletedSegments compacts every Completed segment in the snapshot, sequentially by
 // design (to keep each log's background work light, since a cluster may host many logs). A
 // per-segment failure is logged and skipped; writer-lifecycle cancellation stops the pass.
-func compactCompletedSegments(ctx context.Context, logHandle LogHandle, segs map[int64]*meta.SegmentMeta) compactStats {
+//
+// Gated on localMode: on local storage a segment is already a single file, so SegmentHandle.Compact
+// is a no-op that returns without advancing the segment out of Completed. Running the pass anyway
+// re-walks the same Completed set every cycle and, per segment, takes the log handle's write lock
+// (GetRecoverableSegmentHandle), opens a tracing span and emits handle metrics -- all to do nothing.
+// The set only grows with uptime, so the per-cycle cost grows with it. This mirrors the serviceMode
+// gate on distributeCompactedMarks. The mode is reported once in the "Log auditor started" line.
+func compactCompletedSegments(ctx context.Context, logHandle LogHandle, segs map[int64]*meta.SegmentMeta, localMode bool) compactStats {
 	var st compactStats
+	if localMode {
+		return st
+	}
 	for _, seg := range segs {
 		if ctx.Err() != nil {
 			break
@@ -74,7 +84,10 @@ func compactCompletedSegments(ctx context.Context, logHandle LogHandle, segs map
 			continue
 		}
 		st.compacted++
-		logger.Ctx(ctx).Info("Successfully compacted segment",
+		// Debug, not Info: the auditor's cycle summary already reports segmentsProcessed /
+		// segmentsCompacted / segmentsFailed, so an Info line per segment only duplicates it
+		// at O(segments) volume.
+		logger.Ctx(ctx).Debug("Successfully compacted segment",
 			zap.String("logName", logHandle.GetName()),
 			zap.Int64("logId", logHandle.GetId()),
 			zap.Int64("segmentId", seg.Metadata.SegNo))

--- a/woodpecker/log/log_auditor_test.go
+++ b/woodpecker/log/log_auditor_test.go
@@ -251,7 +251,7 @@ func TestCompactCompletedSegments_CountsAndSkips(t *testing.T) {
 		2: segMeta(2, proto.SegmentState_Sealed),    // ignored by this pass
 		3: segMeta(3, proto.SegmentState_Truncated), // ignored by this pass
 	}
-	st := compactCompletedSegments(context.Background(), lh, segs)
+	st := compactCompletedSegments(context.Background(), lh, segs, false)
 	require.Equal(t, 1, st.processed)
 	assert.Equal(t, 0, st.compacted)
 	assert.Equal(t, 1, st.failed)
@@ -264,7 +264,25 @@ func TestCompactCompletedSegments_CanceledWriterDoesNotStartCompaction(t *testin
 
 	st := compactCompletedSegments(ctx, lh, map[int64]*meta.SegmentMeta{
 		1: segMeta(1, proto.SegmentState_Completed),
-	})
+	}, false)
+
+	assert.Equal(t, compactStats{}, st)
+	lh.AssertNotCalled(t, "GetRecoverableSegmentHandle", mock.Anything, mock.Anything)
+}
+
+// TestCompactCompletedSegments_LocalModeSkipsPass verifies the compaction pass does no per-segment
+// work on local storage: Compact() is a no-op there that never advances a segment out of Completed,
+// so running the pass would re-walk the same set every auditor cycle -- taking the log handle's
+// write lock and emitting a log line per segment -- forever.
+func TestCompactCompletedSegments_LocalModeSkipsPass(t *testing.T) {
+	lh := &testLogHandleMock{}
+	lh.On("GetName").Return("test-log").Maybe()
+	lh.On("GetId").Return(int64(1)).Maybe()
+
+	st := compactCompletedSegments(context.Background(), lh, map[int64]*meta.SegmentMeta{
+		1: segMeta(1, proto.SegmentState_Completed),
+		2: segMeta(2, proto.SegmentState_Completed),
+	}, true)
 
 	assert.Equal(t, compactStats{}, st)
 	lh.AssertNotCalled(t, "GetRecoverableSegmentHandle", mock.Anything, mock.Anything)

--- a/woodpecker/log/log_writer.go
+++ b/woodpecker/log/log_writer.go
@@ -342,10 +342,16 @@ func (l *logWriterImpl) runAuditor() {
 	ticker := time.NewTicker(time.Duration(l.auditorMaxInterval * int(time.Second)))
 	defer ticker.Stop()
 
+	// Storage mode is fixed for the writer's lifetime; read it once here rather than per
+	// segment. localMode disables the compaction pass (see compactCompletedSegments), so
+	// report it here instead of logging the skip for every segment on every cycle.
+	localMode := l.cfg.Woodpecker.Storage.IsStorageLocal()
+
 	logger.Ctx(context.Background()).Info("Log auditor started",
 		zap.String("logName", l.logHandle.GetName()),
 		zap.Int64("logId", l.logHandle.GetId()),
-		zap.Int("intervalSeconds", l.auditorMaxInterval))
+		zap.Int("intervalSeconds", l.auditorMaxInterval),
+		zap.Bool("localStorageCompactionDisabled", localMode))
 
 	auditCycle := uint64(0)
 	for {
@@ -395,7 +401,7 @@ func (l *logWriterImpl) runAuditor() {
 			markTruncatedSegmentsReaped(l.notifyManager, truncatedSegmentExists)
 			publishSegmentsSnapshot(l.notifySegsCh, segmentMetaList)
 
-			cs := compactCompletedSegments(ctx, l.logHandle, segmentMetaList)
+			cs := compactCompletedSegments(ctx, l.logHandle, segmentMetaList, localMode)
 			if ctx.Err() != nil {
 				sp.End()
 				return
@@ -551,12 +557,11 @@ func (l *logWriterImpl) cleanupTruncatedSegmentsIfNecessary(ctx context.Context)
 
 		truncatedSegmentCount++
 
-		// Skip segments that are at or after the minTruncatedSegmentId point
+		// Skip segments that are at or after the minTruncatedSegmentId point.
+		// Counted, not logged: a protected segment stays protected across cycles, so a per-segment
+		// line re-reports the same segments every cycle at O(segments) volume. The eligibility
+		// summary below carries the counts and the cutoffs needed to explain any single decision.
 		if segId >= minTruncatedSegmentId {
-			logger.Ctx(ctx).Debug("Skipping truncated segment still in use by readers",
-				zap.String("logName", logName),
-				zap.Int64("logId", logId),
-				zap.Int64("segmentId", segId))
 			readerProtectedCount++
 			continue
 		}
@@ -570,10 +575,6 @@ func (l *logWriterImpl) cleanupTruncatedSegmentsIfNecessary(ctx context.Context)
 			lastActiveTime = segMeta.Metadata.SealedTime
 		}
 		if lastActiveTime > ttlCutoffMs {
-			logger.Ctx(ctx).Debug("Skipping truncated segment still within ttl protection",
-				zap.String("logName", logName),
-				zap.Int64("logId", logId),
-				zap.Int64("segmentId", segId))
 			ttlProtectedCount++
 			continue
 		}

--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -1915,7 +1915,11 @@ func (s *segmentHandleImpl) Compact(ctx context.Context) error {
 	defer sp.End()
 	s.updateAccessTime()
 	if s.cfg.Woodpecker.Storage.IsStorageLocal() {
-		logger.Ctx(ctx).Info("Local storage detected, skipping compaction (not yet implemented)",
+		// Defensive: the auditor already skips the whole compaction pass on local storage
+		// (see compactCompletedSegments), so reaching here means a caller bypassed that gate.
+		// Debug, not Info -- at Info this fires once per Completed segment per auditor cycle,
+		// which is O(segments) lines every cycle for work that does nothing.
+		logger.Ctx(ctx).Debug("Local storage detected, skipping compaction (not yet implemented)",
 			zap.String("logName", s.logName),
 			zap.Int64("logId", s.logId),
 			zap.Int64("segmentId", s.segmentId))


### PR DESCRIPTION
## Problem

`SegmentHandle.Compact` returns early on local storage — a segment there is already a single
file, so there is nothing to compact. The early return happens **before** the code that moves
the segment `Completed -> Sealed`, so the segment never leaves `Completed`.

`compactCompletedSegments` walks every `Completed` segment in the snapshot on every auditor
cycle. Since nothing advances, the same set is re-walked forever, and per segment it:

- takes the log handle's **write lock** via `GetRecoverableSegmentHandle` (the same lock the
  append path uses),
- opens a tracing span and emits two handle metrics,
- logs two Info lines.

The Completed set only grows with uptime, so the per-cycle cost grows with it.

## Measurements

Milvus standalone, `storage.type=local`, 16 vchannels, ~850 Completed segments per channel,
`woodpecker.client.auditor.maxInterval=10s`. Sampled 200 MB of stdout over a 5-minute window:

| lines/s | share | level | call site |
|---|---|---|---|
| 1038.9 | 42.57% | Info | `log/log_auditor.go:77` `Successfully compacted segment` |
| 1038.9 | 42.57% | Info | `segment/segment_handle.go:1918` `Local storage detected, skipping compaction` |
| 348.7 | 14.29% | Debug | `log/internal_log_writer.go:494` `Skipping truncated segment ... ttl protection` |
| 13.8 | 0.57% | — | all 20 other call sites combined |

Three call sites account for **99.43%** of the volume. Only 23 of 1406 logger call sites in
the tree fired at all during the window.

End to end, same instance, before and after this change:

```
before   2243 MB/h
after      44.5 MB/h     -98.02%
```

What remains is per-cycle, not per-segment, so it scales with vchannel count (16) instead of
segment count (13,600) and no longer grows with uptime.

## Changes

- Gate `compactCompletedSegments` on local storage, mirroring the existing `serviceMode` gate
  on `distributeCompactedMarks` in the same file, and report the mode once in the
  `Log auditor started` line instead of once per segment per cycle.
- Demote the per-segment `Successfully compacted segment` to Debug. The auditor's cycle summary
  already reports `segmentsProcessed` / `segmentsCompacted` / `segmentsFailed`.
- Drop the per-segment `Skipping truncated segment ...` lines in both writer implementations.
  A protected segment stays protected across cycles, so these re-reported the same segments
  every cycle indefinitely; the eligibility summary already carries the counts.
- `internal_log_writer` counted TTL-protected segments into `protectedSegmentCount` but reported
  that number as `segmentsProtectedByReaders`. Split the counters and report the cutoffs, matching
  what `log_writer` already did, and hoist `time.Now()` out of the loop.

## Segment handle cache leak (same root cause)

`Compact` calls `updateAccessTime()` before the local-storage early return, on every Completed
segment every cycle. That kept every handle young enough to escape idle-handle cleanup, which
therefore never reclaimed anything on local storage. Measured: `totalHandles=848..850` per log,
with zero handles reaped over the sample window (~13,600 handles pinned across 16 logs). The
pass-level gate fixes this as well.

## Relation to previous log-volume work

Same defect class as #189 (idle-spin writer logging) and #190 (read-path verbosity + idle
tail-read poll spin), but a different shape and a different code path: those are
O(polls) and independent of data, this one is O(segments) inside a periodic full-snapshot scan
and grows with uptime. Not covered by either fix.

## Verification

- `go build ./...`, `golangci-lint run` with the CI-pinned v2.11.4 and `.golangci.yml`: 0 issues.
- `golangci-lint fmt --diff`: clean. `go mod tidy`: no diff.
- `go test ./woodpecker/log/... ./woodpecker/segment/...` passes, and matches a baseline run of
  the same packages on an unmodified `upstream/master` worktree — no new failures.
- New test `TestCompactCompletedSegments_LocalModeSkipsPass` asserts the pass does no per-segment
  work on local storage (`GetRecoverableSegmentHandle` is never called).



Fixes #315
