### PR TITLE
enhance(config): expose the two settings missing from woodpecker.yaml

### DIFF
--- a/common/config/configuration_test.go
+++ b/common/config/configuration_test.go
@@ -75,6 +75,7 @@ func TestNewConfiguration(t *testing.T) {
 	assert.Equal(t, int64(2000000), config.Woodpecker.Logstore.SegmentCompactionPolicy.MaxBytes.Int64())
 	assert.Equal(t, 4, config.Woodpecker.Logstore.SegmentCompactionPolicy.MaxParallelUploads)
 	assert.Equal(t, 8, config.Woodpecker.Logstore.SegmentCompactionPolicy.MaxParallelReads)
+	assert.Equal(t, 300, config.Woodpecker.Logstore.SegmentCompactionPolicy.Timeout.Seconds())
 	assert.Equal(t, int64(2000000), config.Woodpecker.Logstore.SegmentReadPolicy.MaxBatchSize.Int64())
 	assert.Equal(t, 32, config.Woodpecker.Logstore.SegmentReadPolicy.MaxFetchThreads)
 	assert.Equal(t, 259200, config.Woodpecker.Logstore.RetentionPolicy.TTL) // 72h = 259200s
@@ -92,6 +93,8 @@ func TestNewConfiguration(t *testing.T) {
 	assert.Equal(t, 1800, config.Woodpecker.Logstore.MaintenanceStrategy.ReconcileMinDataLogAge.Seconds())    // pull reconcile footer-HEAD age gate (30m)
 	assert.Equal(t, "minio", config.Woodpecker.Storage.Type)
 	assert.Equal(t, "/var/lib/woodpecker", config.Woodpecker.Storage.RootPath)
+	assert.Equal(t, 1024, config.Woodpecker.Runtime.OpRegistry.Capacity)
+	assert.Equal(t, 30, config.Woodpecker.Runtime.OpRegistry.WarnAge.Seconds())
 	assert.Equal(t, "info", config.Log.Level)
 	assert.Equal(t, "text", config.Log.Format)
 	assert.True(t, config.Log.Stdout)
@@ -178,6 +181,7 @@ func TestNewConfiguration(t *testing.T) {
 	assert.Equal(t, int64(32000000), defaultConfig.Woodpecker.Logstore.SegmentCompactionPolicy.MaxBytes.Int64())
 	assert.Equal(t, 4, defaultConfig.Woodpecker.Logstore.SegmentCompactionPolicy.MaxParallelUploads)
 	assert.Equal(t, 8, defaultConfig.Woodpecker.Logstore.SegmentCompactionPolicy.MaxParallelReads)
+	assert.Equal(t, 300, defaultConfig.Woodpecker.Logstore.SegmentCompactionPolicy.Timeout.Seconds())
 	assert.Equal(t, int64(16000000), defaultConfig.Woodpecker.Logstore.SegmentReadPolicy.MaxBatchSize.Int64())
 	assert.Equal(t, 32, defaultConfig.Woodpecker.Logstore.SegmentReadPolicy.MaxFetchThreads)
 	assert.Equal(t, 259200, defaultConfig.Woodpecker.Logstore.RetentionPolicy.TTL) // 72h = 259200s
@@ -195,6 +199,8 @@ func TestNewConfiguration(t *testing.T) {
 	assert.Equal(t, 1800, defaultConfig.Woodpecker.Logstore.MaintenanceStrategy.ReconcileMinDataLogAge.Seconds())    // pull reconcile footer-HEAD age gate (30m)
 	assert.Equal(t, "default", defaultConfig.Woodpecker.Storage.Type)
 	assert.Equal(t, "/tmp/woodpecker", defaultConfig.Woodpecker.Storage.RootPath)
+	assert.Equal(t, 1024, defaultConfig.Woodpecker.Runtime.OpRegistry.Capacity)
+	assert.Equal(t, 30, defaultConfig.Woodpecker.Runtime.OpRegistry.WarnAge.Seconds())
 	assert.Equal(t, "info", defaultConfig.Log.Level)
 	assert.Equal(t, "text", defaultConfig.Log.Format)
 	assert.True(t, defaultConfig.Log.Stdout)

--- a/config/woodpecker.yaml
+++ b/config/woodpecker.yaml
@@ -29,7 +29,7 @@ woodpecker:
       maxBatchEntries: 1000 # Client-side group commit: max consecutive appends coalesced into one AddEntries request. Opportunistic (only batches already-queued ops, adds no latency at low load). Set to 1 to disable batching.
       maxBatchBytes: 2000000 # Max total payload (bytes) of a coalesced batch, default 2MB; whichever of maxBatchEntries/maxBatchBytes is hit first bounds the batch. Ignored when maxBatchEntries <= 1.
     segmentRollingPolicy:
-      maxSize: 256000000 # Maximum segment size in bytes, default is 2GB. Increase this value for high write throughput scenarios to minimize frequent segment rolling.
+      maxSize: 256000000 # Maximum segment size in bytes, default is 256MB. Increase this value for high write throughput scenarios to minimize frequent segment rolling.
       maxInterval: 600 # Maximum interval between two segments in seconds, default is 10 minutes
       maxBlocks: 1000 # Maximum number of blocks in a segment, default is 1000
     auditor:
@@ -103,6 +103,7 @@ woodpecker:
       maxBytes: 2000000 # Maximum size of a merged block in bytes after compact, default is 2M
       maxParallelUploads: 4 # Maximum number of parallel upload threads for compaction, default is 4
       maxParallelReads: 8 # Maximum number of parallel read threads for compaction, default is 8
+      timeout: 300 # Deadline for compacting one segment in seconds, default is 300s. Covers the whole read/merge/upload pass; on expiry the compaction is aborted and the auditor retries it on a later cycle.
     segmentReadPolicy:
       maxBatchSize: 2000000 # Maximum size of a batch in bytes, default is 2MB
       maxFetchThreads: 32 # Maximum number of threads to fetch data, default is 32
@@ -145,6 +146,12 @@ woodpecker:
     # Valid values: [default, minio, local, service]
     type: minio
     rootPath: /var/lib/woodpecker # Root path to the log data files.
+  # Configuration of Woodpecker runtime subsystems.
+  runtime:
+    # In-flight operation registry backing `wp ops stats` and the operation metrics.
+    opRegistry:
+      capacity: 1024 # Maximum number of in-flight operations tracked, default is 1024
+      warnAge: 30 # Seconds after which a still-running operation is reported as stalled, default is 30s
 
 # Configures the system log output.
 log:


### PR DESCRIPTION
## Problem

`config/woodpecker.yaml` is what an operator reads to learn what is tunable. Two enforced settings
never appeared in it, and one comment stated a value roughly 8x off.

Fixes #316

## Changes

**`logstore.segmentCompactionPolicy.timeout`** — defined at `common/config/configuration.go:196`,
validated at `:812`, and enforced at `server/processor/segment_processor.go:641`, where it wraps the
entire `writer.Compact()` call:

```go
timeout := time.Duration(cfg.Woodpecker.Logstore.SegmentCompactionPolicy.Timeout.Seconds()) * time.Second
ctx, cancel := context.WithTimeout(ctx, timeout)
defer cancel()
```

Nothing in the shipped config revealed that a 5-minute compaction deadline exists, let alone how to
change it.

**`woodpecker.runtime`** — the whole section was absent. `opRegistry.capacity` and
`opRegistry.warnAge` are read at `cmd/main.go:203-204` to build the in-flight operation registry
that backs `wp ops stats` and the operation metrics, so in practice they were untunable. Placed
after `storage` to match the field order in `WoodpeckerConfig`.

**`segmentRollingPolicy.maxSize` comment** — the value is 256,000,000 bytes and the comment said
2GB. The file writes sizes in decimal units throughout (`2000000` is commented as "2MB"), so by its
own convention this reads 256MB.

Both new keys carry their existing in-code defaults, so no behaviour changes.

## Verification

Because the added keys carry the same values as their in-code defaults, a wrong indentation or
nesting level would be invisible: the key would be ignored, the default would apply, and every
assertion would still pass. Checked explicitly with a throwaway config setting them to 777 / 4242 /
99 — all three came through, confirming the keys are really parsed rather than falling back.

`TestNewConfiguration` now pins all three on both paths (YAML-loaded and defaults-only), matching
how it already covers every other field; without that the new YAML values would be the only
unpinned ones in the file.

- `go build ./...`: ok
- `go test ./common/config/...`: ok
- `golangci-lint run ./common/config/...` with the CI-pinned v2.11.4: 0 issues
- `gofmt -l .`: clean
- `go mod tidy`: no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
