### PR TITLE
enhance(compaction): drop one payload copy and the pool around a contiguous read

### DIFF
--- a/server/storage/stagedstorage/writer_impl.go
+++ b/server/storage/stagedstorage/writer_impl.go
@@ -1599,13 +1599,6 @@ type mergeBlockTask struct {
 	nextEntryID int64                // Next entry ID after this merge block
 }
 
-// blockReadResult represents the result of reading a block from local file
-type blockReadResult struct {
-	blockIndex *codec.IndexRecord
-	blockData  []byte
-	error      error
-}
-
 // mergedBlockUploadResult represents the result of uploading a merged block
 type mergedBlockUploadResult struct {
 	blockIndex *codec.IndexRecord
@@ -1748,28 +1741,14 @@ func (w *StagedFileWriter) processMergeTask(ctx context.Context, task *mergeBloc
 		zap.Int64("mergedBlockID", mergedBlockID),
 		zap.Int("originalBlocks", len(task.blocks)))
 
-	// Create pool for concurrent block reading
-	maxConcurrentReads := w.compactPolicyConfig.MaxParallelReads
-	if maxConcurrentReads <= 0 {
-		maxConcurrentReads = min(8, len(task.blocks)) // Default to min(8, block count)
-	}
-
-	readPool := conc.NewPool[*blockReadResult](maxConcurrentReads, conc.WithPreAlloc(true))
-	defer readPool.Release()
-
-	// Submit all block read tasks to the pool
-	var readFutures []*conc.Future[*blockReadResult]
-	for _, blockIndex := range task.blocks {
-		if ctx.Err() != nil {
-			return &mergedBlockUploadResult{error: ctx.Err()}
-		}
-		// Capture variable for closure
-		blockIndexCopy := blockIndex
-
-		future := readPool.Submit(func() (*blockReadResult, error) {
-			return w.readBlockDataFromLocalFile(ctx, blockIndexCopy), nil
-		})
-		readFutures = append(readFutures, future)
+	// A merge task is planned from a consecutive run of blockIndexes, so its blocks occupy one
+	// contiguous range of the local file. Read that range once and view each block inside it,
+	// rather than issuing one ReadAt per block through a pool: the blocks are adjacent, the data
+	// was written by this same writer moments ago and is normally still in page cache, so the
+	// parallelism only fragmented a sequential read.
+	blockData, readErr := w.readMergeTaskBlocks(ctx, task)
+	if readErr != nil {
+		return &mergedBlockUploadResult{error: readErr}
 	}
 
 	// Collect block data and extract only DataRecords from each block
@@ -1781,21 +1760,15 @@ func (w *StagedFileWriter) processMergeTask(ctx context.Context, task *mergeBloc
 	firstEntryID := int64(-1)
 	lastEntryID := int64(-1)
 
-	for _, future := range readFutures {
+	for i, blockIndex := range task.blocks {
 		if ctx.Err() != nil {
 			return &mergedBlockUploadResult{error: ctx.Err()}
 		}
-		result := future.Value()
-		if result.error != nil {
-			return &mergedBlockUploadResult{
-				error: fmt.Errorf("failed to read block data: %w", result.error),
-			}
-		}
 
-		dataRecords, blockLastEntryID, extractErr := w.extractCompactedDataRecords(result.blockIndex, result.blockData, expectedLastEntryId)
+		dataRecords, blockLastEntryID, extractErr := w.extractCompactedDataRecords(blockIndex, blockData[i], expectedLastEntryId)
 		if extractErr != nil {
 			return &mergedBlockUploadResult{
-				error: fmt.Errorf("failed to extract data records from block %d: %w", result.blockIndex.BlockNumber, extractErr),
+				error: fmt.Errorf("failed to extract data records from block %d: %w", blockIndex.BlockNumber, extractErr),
 			}
 		}
 		if len(dataRecords) == 0 {
@@ -1803,13 +1776,13 @@ func (w *StagedFileWriter) processMergeTask(ctx context.Context, task *mergeBloc
 		}
 
 		allBlocks = append(allBlocks, extractedBlockData{
-			blockIndex:  result.blockIndex,
+			blockIndex:  blockIndex,
 			dataRecords: dataRecords,
 		})
 
 		// Track entry ID range
-		if firstEntryID == -1 || result.blockIndex.FirstEntryID < firstEntryID {
-			firstEntryID = result.blockIndex.FirstEntryID
+		if firstEntryID == -1 || blockIndex.FirstEntryID < firstEntryID {
+			firstEntryID = blockIndex.FirstEntryID
 		}
 		if lastEntryID == -1 || blockLastEntryID > lastEntryID {
 			lastEntryID = blockLastEntryID
@@ -1824,27 +1797,40 @@ func (w *StagedFileWriter) processMergeTask(ctx context.Context, task *mergeBloc
 		return allBlocks[i].blockIndex.BlockNumber < allBlocks[j].blockIndex.BlockNumber
 	})
 
-	// Merge all data records
-	var mergedDataRecords []byte
-	for _, blk := range allBlocks {
-		mergedDataRecords = append(mergedDataRecords, blk.dataRecords...)
-	}
-
 	// Build the complete merged block:
 	// Format: [HeaderRecord (if first)] + [BlockHeaderRecord] + [DataRecords]
 	// This matches objectstorage compaction format — one BlockHeader per merged block.
-	blockLength := uint32(len(mergedDataRecords))
-	blockCrc := crc32.ChecksumIEEE(mergedDataRecords)
+	//
+	// Both leading records are fixed width, so their space is reserved up front and the data
+	// records are merged straight into the same buffer. That keeps one copy of the payload
+	// rather than merging into an intermediate slice and concatenating again, while still
+	// handing PutObject a seekable reader so the object-storage client can retry a failed
+	// transfer without re-running the whole merge.
+	prefixLen := codec.RecordHeaderSize + codec.BlockHeaderRecordSize
+	if mergedBlockID == 0 {
+		prefixLen += codec.RecordHeaderSize + codec.HeaderRecordSize
+	}
+	dataLen := 0
+	for _, blk := range allBlocks {
+		dataLen += len(blk.dataRecords)
+	}
+
+	completeBlockData := make([]byte, prefixLen+dataLen)
+	off := prefixLen
+	for _, blk := range allBlocks {
+		off += copy(completeBlockData[off:], blk.dataRecords)
+	}
+	mergedDataRecords := completeBlockData[prefixLen:]
 
 	blockHeaderRecord := &codec.BlockHeaderRecord{
 		BlockNumber:  int32(mergedBlockID),
 		FirstEntryID: firstEntryID,
 		LastEntryID:  lastEntryID,
-		BlockLength:  blockLength,
-		BlockCrc:     blockCrc,
+		BlockLength:  uint32(len(mergedDataRecords)),
+		BlockCrc:     crc32.ChecksumIEEE(mergedDataRecords),
 	}
 
-	var completeBlockData []byte
+	prefix := 0
 	if mergedBlockID == 0 {
 		// First merged block: prepend HeaderRecord with compacted flag, preserving existing flags
 		headerRecord := &codec.HeaderRecord{
@@ -1852,10 +1838,16 @@ func (w *StagedFileWriter) processMergeTask(ctx context.Context, task *mergeBloc
 			Flags:        codec.SetCompacted(w.recoveredFooter.Flags),
 			FirstEntryID: firstEntryID,
 		}
-		completeBlockData = append(completeBlockData, codec.EncodeRecord(headerRecord)...)
+		prefix += copy(completeBlockData[prefix:], codec.EncodeRecord(headerRecord))
 	}
-	completeBlockData = append(completeBlockData, codec.EncodeRecord(blockHeaderRecord)...)
-	completeBlockData = append(completeBlockData, mergedDataRecords...)
+	prefix += copy(completeBlockData[prefix:], codec.EncodeRecord(blockHeaderRecord))
+	if prefix != prefixLen {
+		// The reserved width no longer matches what the codec emits; writing anyway would leave
+		// a gap of zero bytes between the headers and the payload.
+		return &mergedBlockUploadResult{
+			error: fmt.Errorf("merged block %d header width mismatch: reserved %d, encoded %d", mergedBlockID, prefixLen, prefix),
+		}
+	}
 
 	// Create block key for upload
 	blockKey := w.getCompactedBlockKey(mergedBlockID)
@@ -1991,36 +1983,48 @@ func strictDataRecordPrefix(dataRecords []byte, recordsToKeep int, requireEOF bo
 	return dataRecords[:offset], recordsToKeep, nil
 }
 
-// readBlockDataFromLocalFile reads data for a specific block from the local file
-func (w *StagedFileWriter) readBlockDataFromLocalFile(ctx context.Context, blockIndex *codec.IndexRecord) *blockReadResult {
-	_, sp := logger.NewIntentCtxWithParent(ctx, WriterScope, "readBlockDataFromLocalFile")
+// readMergeTaskBlocks reads the byte range spanned by a merge task's blocks in a single ReadAt and
+// returns a view of each block inside that buffer, in task.blocks order.
+//
+// planMergeBlockTasks groups a consecutive run of blockIndexes, so the range is contiguous; the
+// span is nonetheless derived from the blocks themselves, so were a gap ever to appear it would
+// only cost a few extra bytes read and would not affect what each view contains.
+func (w *StagedFileWriter) readMergeTaskBlocks(ctx context.Context, task *mergeBlockTask) ([][]byte, error) {
+	_, sp := logger.NewIntentCtxWithParent(ctx, WriterScope, "readMergeTaskBlocks")
 	defer sp.End()
 
-	// Open local file for reading
+	if len(task.blocks) == 0 {
+		return nil, nil
+	}
+
+	spanStart := task.blocks[0].StartOffset
+	spanEnd := spanStart
+	for _, blockIndex := range task.blocks {
+		if blockIndex.StartOffset < spanStart {
+			spanStart = blockIndex.StartOffset
+		}
+		if end := blockIndex.StartOffset + int64(blockIndex.BlockSize); end > spanEnd {
+			spanEnd = end
+		}
+	}
+
 	file, err := os.Open(w.segmentFilePath)
 	if err != nil {
-		return &blockReadResult{
-			blockIndex: blockIndex,
-			error:      fmt.Errorf("failed to open local file: %w", err),
-		}
+		return nil, fmt.Errorf("failed to open local file: %w", err)
 	}
 	defer file.Close()
 
-	// Read block data from file
-	blockData := make([]byte, blockIndex.BlockSize)
-	_, err = file.ReadAt(blockData, blockIndex.StartOffset)
-	if err != nil {
-		return &blockReadResult{
-			blockIndex: blockIndex,
-			error:      fmt.Errorf("failed to read block data: %w", err),
-		}
+	span := make([]byte, spanEnd-spanStart)
+	if _, err := file.ReadAt(span, spanStart); err != nil {
+		return nil, fmt.Errorf("failed to read block data: %w", err)
 	}
 
-	return &blockReadResult{
-		blockIndex: blockIndex,
-		blockData:  blockData,
-		error:      nil,
+	views := make([][]byte, len(task.blocks))
+	for i, blockIndex := range task.blocks {
+		offset := blockIndex.StartOffset - spanStart
+		views[i] = span[offset : offset+int64(blockIndex.BlockSize)]
 	}
+	return views, nil
 }
 
 // uploadCompactedFooter creates and uploads the footer for compacted segment

--- a/server/storage/stagedstorage/writer_impl_test.go
+++ b/server/storage/stagedstorage/writer_impl_test.go
@@ -1050,9 +1050,9 @@ func TestStagedFileWriter_ValidateLACAlignment_LACExceedsData(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// --- readBlockDataFromLocalFile ---
+// --- readMergeTaskBlocks ---
 
-func TestStagedFileWriter_ReadBlockDataFromLocalFile_Success(t *testing.T) {
+func TestStagedFileWriter_ReadMergeTaskBlocks_Success(t *testing.T) {
 	dir := t.TempDir()
 	cfg := newTestConfig(t)
 	writer, err := NewStagedFileWriter(context.Background(), "test-bucket", "test-root", dir, 1, 0, nil, cfg)
@@ -1073,13 +1073,23 @@ func TestStagedFileWriter_ReadBlockDataFromLocalFile_Success(t *testing.T) {
 
 	require.NotEmpty(t, writer.blockIndexes)
 
-	result := writer.readBlockDataFromLocalFile(context.Background(), writer.blockIndexes[0])
-	assert.Nil(t, result.error)
-	assert.NotEmpty(t, result.blockData)
-	assert.Equal(t, writer.blockIndexes[0], result.blockIndex)
+	task := &mergeBlockTask{blocks: writer.blockIndexes}
+	views, err := writer.readMergeTaskBlocks(context.Background(), task)
+	require.NoError(t, err)
+	require.Len(t, views, len(writer.blockIndexes))
+
+	// Every view must be exactly the bytes the index describes, which is what the previous
+	// one-ReadAt-per-block path returned. Compare against an independent read of the file.
+	raw, err := os.ReadFile(writer.segmentFilePath)
+	require.NoError(t, err)
+	for i, blockIndex := range writer.blockIndexes {
+		assert.Len(t, views[i], int(blockIndex.BlockSize))
+		expected := raw[blockIndex.StartOffset : blockIndex.StartOffset+int64(blockIndex.BlockSize)]
+		assert.Equal(t, expected, views[i], "block %d view differs from the file contents", i)
+	}
 }
 
-func TestStagedFileWriter_ReadBlockDataFromLocalFile_FileNotFound(t *testing.T) {
+func TestStagedFileWriter_ReadMergeTaskBlocks_FileNotFound(t *testing.T) {
 	dir := t.TempDir()
 	cfg := newTestConfig(t)
 	writer, err := NewStagedFileWriter(context.Background(), "test-bucket", "test-root", dir, 1, 0, nil, cfg)
@@ -1089,15 +1099,26 @@ func TestStagedFileWriter_ReadBlockDataFromLocalFile_FileNotFound(t *testing.T) 
 	// Remove the segment file to cause read failure
 	os.Remove(writer.segmentFilePath)
 
-	blockIndex := &codec.IndexRecord{
+	task := &mergeBlockTask{blocks: []*codec.IndexRecord{{
 		BlockNumber:  0,
 		StartOffset:  0,
 		BlockSize:    100,
 		FirstEntryID: 0,
 		LastEntryID:  9,
-	}
-	result := writer.readBlockDataFromLocalFile(context.Background(), blockIndex)
-	assert.NotNil(t, result.error)
+	}}}
+	_, err = writer.readMergeTaskBlocks(context.Background(), task)
+	assert.Error(t, err)
+}
+
+// TestCompactedBlockHeaderWidthsAreFixed pins the assumption processMergeTask relies on when it
+// reserves space for the leading records before merging the payload into the same buffer: both
+// record types encode to a fixed width. A codec change that broke this would otherwise leave a
+// gap of zero bytes between the headers and the data.
+func TestCompactedBlockHeaderWidthsAreFixed(t *testing.T) {
+	assert.Equal(t, codec.RecordHeaderSize+codec.HeaderRecordSize,
+		len(codec.EncodeRecord(&codec.HeaderRecord{Version: codec.FormatVersion, FirstEntryID: 7})))
+	assert.Equal(t, codec.RecordHeaderSize+codec.BlockHeaderRecordSize,
+		len(codec.EncodeRecord(&codec.BlockHeaderRecord{BlockNumber: 3, FirstEntryID: 1, LastEntryID: 9, BlockLength: 42, BlockCrc: 1234})))
 }
 
 // --- determineIfNeedRecoveryMode ---

--- a/server/storage/stagedstorage/writer_impl_test.go
+++ b/server/storage/stagedstorage/writer_impl_test.go
@@ -1110,6 +1110,100 @@ func TestStagedFileWriter_ReadMergeTaskBlocks_FileNotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestStagedFileWriter_ReadMergeTaskBlocks_NoBlocks(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+	writer, err := NewStagedFileWriter(context.Background(), "test-bucket", "test-root", dir, 1, 0, nil, cfg)
+	require.NoError(t, err)
+	defer writer.Close(context.Background())
+
+	views, err := writer.readMergeTaskBlocks(context.Background(), &mergeBlockTask{})
+	require.NoError(t, err)
+	assert.Empty(t, views)
+}
+
+func TestStagedFileWriter_ReadMergeTaskBlocks_ShortFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+	writer, err := NewStagedFileWriter(context.Background(), "test-bucket", "test-root", dir, 1, 0, nil, cfg)
+	require.NoError(t, err)
+	defer writer.Close(context.Background())
+
+	// A block whose span runs past the end of the file: the single ReadAt must fail rather than
+	// hand back a short buffer that the per-block views would then slice out of range.
+	task := &mergeBlockTask{blocks: []*codec.IndexRecord{{
+		BlockNumber: 0,
+		StartOffset: 0,
+		BlockSize:   1 << 20,
+	}}}
+	_, err = writer.readMergeTaskBlocks(context.Background(), task)
+	assert.Error(t, err)
+}
+
+// TestStagedFileWriter_ReadMergeTaskBlocks_UnorderedBlocks covers the span being derived from the
+// blocks themselves rather than from the first and last of the slice. planMergeBlockTasks always
+// hands over a consecutive ascending run, so this cannot happen today; the point is that the one
+// ReadAt does not silently return the wrong bytes if that ever stops holding.
+func TestStagedFileWriter_ReadMergeTaskBlocks_UnorderedBlocks(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+	// Small blocks so the segment holds several of them: reversing a single-block slice would
+	// leave the span calculation untested.
+	cfg.Woodpecker.Logstore.SegmentSyncPolicy.MaxFlushSize = config.ByteSize(200)
+	writer, err := NewStagedFileWriter(context.Background(), "test-bucket", "test-root", dir, 1, 0, nil, cfg)
+	require.NoError(t, err)
+
+	const n = 40
+	for i := int64(0); i < n; i++ {
+		_, err = writer.WriteDataAsync(context.Background(), i, []byte(fmt.Sprintf("payload-%04d-abcdefghij", i)), nil)
+		require.NoError(t, err)
+	}
+	require.NoError(t, writer.Sync(context.Background()))
+	time.Sleep(400 * time.Millisecond)
+	_, err = writer.Finalize(context.Background(), n-1)
+	require.NoError(t, err)
+	defer writer.Close(context.Background())
+	require.Greater(t, len(writer.blockIndexes), 1, "need multiple blocks for the span to matter")
+
+	// Reverse the order the blocks are handed over in.
+	reversed := make([]*codec.IndexRecord, 0, len(writer.blockIndexes))
+	for i := len(writer.blockIndexes) - 1; i >= 0; i-- {
+		reversed = append(reversed, writer.blockIndexes[i])
+	}
+
+	views, err := writer.readMergeTaskBlocks(context.Background(), &mergeBlockTask{blocks: reversed})
+	require.NoError(t, err)
+	require.Len(t, views, len(reversed))
+
+	raw, err := os.ReadFile(writer.segmentFilePath)
+	require.NoError(t, err)
+	for i, blockIndex := range reversed {
+		expected := raw[blockIndex.StartOffset : blockIndex.StartOffset+int64(blockIndex.BlockSize)]
+		assert.Equal(t, expected, views[i], "block %d view differs from the file contents", blockIndex.BlockNumber)
+	}
+}
+
+// TestStagedFileWriter_ProcessMergeTask_ReadFailurePropagates verifies a failed span read aborts
+// the merge task rather than proceeding with a partial buffer.
+func TestStagedFileWriter_ProcessMergeTask_ReadFailurePropagates(t *testing.T) {
+	dir := t.TempDir()
+	cfg := newTestConfig(t)
+	writer, err := NewStagedFileWriter(context.Background(), "test-bucket", "test-root", dir, 1, 0, nil, cfg)
+	require.NoError(t, err)
+	defer writer.Close(context.Background())
+
+	// The block's span runs past the end of the (empty) segment file.
+	task := &mergeBlockTask{blocks: []*codec.IndexRecord{{
+		BlockNumber: 0,
+		StartOffset: 0,
+		BlockSize:   1 << 20,
+	}}}
+	result := writer.processMergeTask(context.Background(), task, 0, 9)
+	require.NotNil(t, result)
+	assert.Error(t, result.error)
+	assert.Nil(t, result.blockIndex)
+}
+
 // TestCompactedBlockHeaderWidthsAreFixed pins the assumption processMergeTask relies on when it
 // reserves space for the leading records before merging the payload into the same buffer: both
 // record types encode to a fixed width. A codec change that broke this would otherwise leave a


### PR DESCRIPTION
## Problem

`processMergeTask` in the staged writer held three copies of every merged block at peak and built
one goroutine pool per merge task to fragment what is a single sequential read of the local file.

Fixes #319

## One payload copy removed

The three copies were the source blocks, the merged payload, and a third buffer that was only the
first two concatenated so `bytes.NewReader` had something contiguous to hand `PutObject`. The
intermediate steps are all subslices, so the source buffers stay alive until the function returns
and all three are live during the upload.

Both leading records are fixed width (`RecordHeaderSize + HeaderRecordSize`,
`RecordHeaderSize + BlockHeaderRecordSize`), so their space is now reserved up front and the data
records are merged straight into the same buffer.

`io.MultiReader` over the pieces would also have removed the copy, but `PutObject` takes an
`io.Reader` and minio-go cannot retry a partially consumed non-seekable body — a transient failure
would have failed the whole compaction and made the auditor redo every merge task of that segment
on a later cycle. Reserving the prefix keeps a seekable `bytes.Reader` and the SDK-level retry.

## The read pool removed

`planMergeBlockTasks` groups a consecutive run of `blockIndexes`, so a merge task's blocks are one
contiguous range of `data.log`. Reading them through a pool turned that into N `ReadAt` calls at
adjacent offsets, each preceded by its own `os.Open`, against data this same writer had just
written and that is normally still in page cache — it fragmented a sequential read rather than
speeding one up.

`readMergeTaskBlocks` now reads the span once and returns a view per block. The span is derived
from the blocks themselves rather than assuming adjacency, so a gap would only cost a few extra
bytes read. `segmentCompactionPolicy.maxParallelReads` no longer has a consumer on this path.

## Net effect per merge task

| | before | after |
|---|---|---|
| payload copies at peak | 3 | 2 |
| allocations | N + 2 | 2 |
| `os.Open` calls | N | 1 |
| ants pools | 1 per task | none |

## Verification

The claim is no behaviour change, so I checked the bytes rather than only the tests. A throwaway
test captured every object compaction uploads through a mocked storage client, with
`segmentCompactionPolicy.maxBytes` and `maxFlushSize` lowered so the segment split into several
blocks and several merge tasks. Running it on this branch and again with the change stashed:

```
r/1/0/footer.blk -> d783065b94ceea05 len=299
r/1/0/m_0.blk    -> 24841a377369ddae len=350
r/1/0/m_1.blk    -> f3c2b4420d65a941 len=325
r/1/0/m_2.blk    -> 0daac62913760f37 len=325
r/1/0/m_3.blk    -> da4dcc98f340bef1 len=325
r/1/0/m_4.blk    -> f424aaad03fb274b len=325
r/1/0/m_5.blk    -> f16a13414d431d08 len=517
```

Identical both ways. `m_0` is 25 bytes larger than its siblings, which is exactly
`RecordHeaderSize + HeaderRecordSize` — the `HeaderRecord` only the first merged block carries, and
a direct check that the reserved prefix width is right.

The two tests that covered `readBlockDataFromLocalFile` now cover `readMergeTaskBlocks`; the
success case additionally reads the segment file independently and asserts each returned view
equals the bytes its index describes, which is what the per-block path used to return. A new test
pins the fixed-width assumption the reserved prefix depends on, so a codec change that broke it
fails loudly instead of leaving a gap of zero bytes between the headers and the payload. The
reserved width is also checked at runtime.

- `go build ./...`: ok
- `go test ./server/...`: 7 packages ok
- `go test -race ./server/storage/stagedstorage/...`: ok
- `golangci-lint run ./server/storage/stagedstorage/...` with the CI-pinned v2.11.4: 0 issues
- `gofmt -l .`: clean
- `go mod tidy`: no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
