### PR TITLE
enhance(log): jitter the auditor's first tick and bound the compaction pass

### DIFF
--- a/woodpecker/log/internal_log_writer.go
+++ b/woodpecker/log/internal_log_writer.go
@@ -262,8 +262,7 @@ func (l *internalLogWriterImpl) WriteAsync(ctx context.Context, msg *WriteMessag
 }
 
 func (l *internalLogWriterImpl) runAuditor() {
-	ticker := time.NewTicker(time.Duration(l.auditorMaxInterval * int(time.Second)))
-	defer ticker.Stop()
+	interval := time.Duration(l.auditorMaxInterval) * time.Second
 
 	// Storage mode is fixed for the writer's lifetime; read it once here rather than per
 	// segment. localMode disables the compaction pass (see compactCompletedSegments), so
@@ -276,10 +275,26 @@ func (l *internalLogWriterImpl) runAuditor() {
 		zap.Int("intervalSeconds", l.auditorMaxInterval),
 		zap.Bool("localStorageCompactionDisabled", localMode))
 
+	// The first tick is jittered so writers created together do not tick in lockstep; the
+	// ticker takes over at the full interval from there. See auditorFirstTickDelay.
+	firstTick := time.NewTimer(auditorFirstTickDelay(interval))
+	defer firstTick.Stop()
+	tickC := firstTick.C
+	var ticker *time.Ticker
+	defer func() {
+		if ticker != nil {
+			ticker.Stop()
+		}
+	}()
+
 	auditCycle := uint64(0)
 	for {
 		select {
-		case <-ticker.C:
+		case <-tickC:
+			if ticker == nil {
+				ticker = time.NewTicker(interval)
+				tickC = ticker.C
+			}
 			if l.maintenanceCtx.Err() != nil || !l.isWriterValid.Load() {
 				l.stopMaintenance()
 				return
@@ -346,6 +361,7 @@ func (l *internalLogWriterImpl) runAuditor() {
 				zap.Int("segmentsProcessed", cs.processed),
 				zap.Int("segmentsCompacted", cs.compacted),
 				zap.Int("segmentsFailed", cs.failed),
+				zap.Int("segmentsDeferred", cs.deferred),
 				zap.Int("truncatedSegments", len(truncatedSegmentExists)))
 
 			// Clean up truncated segments (object-storage data + local files + tombstones).

--- a/woodpecker/log/internal_log_writer.go
+++ b/woodpecker/log/internal_log_writer.go
@@ -275,26 +275,18 @@ func (l *internalLogWriterImpl) runAuditor() {
 		zap.Int("intervalSeconds", l.auditorMaxInterval),
 		zap.Bool("localStorageCompactionDisabled", localMode))
 
-	// The first tick is jittered so writers created together do not tick in lockstep; the
-	// ticker takes over at the full interval from there. See auditorFirstTickDelay.
-	firstTick := time.NewTimer(auditorFirstTickDelay(interval))
-	defer firstTick.Stop()
-	tickC := firstTick.C
-	var ticker *time.Ticker
-	defer func() {
-		if ticker != nil {
-			ticker.Stop()
-		}
-	}()
+	// Spread the start so writers created together do not tick in lockstep.
+	if !waitAuditorStartJitter(l.maintenanceCtx, l.writerClose, interval) {
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 
 	auditCycle := uint64(0)
 	for {
 		select {
-		case <-tickC:
-			if ticker == nil {
-				ticker = time.NewTicker(interval)
-				tickC = ticker.C
-			}
+		case <-ticker.C:
 			if l.maintenanceCtx.Err() != nil || !l.isWriterValid.Load() {
 				l.stopMaintenance()
 				return

--- a/woodpecker/log/log_auditor.go
+++ b/woodpecker/log/log_auditor.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand/v2"
+	"sort"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -42,11 +45,41 @@ import (
 // RPC fanouts. The remainder is picked up on subsequent cycles.
 const maxCompactedNotifyPerCycle = 64
 
+// maxCompactedPerCycle bounds how many Completed segments one auditor cycle compacts. The
+// remainder is picked up on subsequent cycles, mirroring maxCompactedNotifyPerCycle above.
+//
+// Compaction is the more expensive of the two passes by a wide margin -- a merge plus
+// object-storage uploads, against one etcd write -- so a backlog swamps a cycle harder here. The
+// exposure is worst exactly while recovering: whenever compaction has been failing (object storage
+// unwritable, wrong credentials, a version mismatch) Completed segments pile up, and the moment it
+// recovers every log tries to drain its whole backlog at once.
+const maxCompactedPerCycle = 64
+
+// auditorFirstTickDelay returns a random delay in [0, interval) for an auditor's first tick.
+//
+// Every log writer runs its own auditor on a fixed period whose phase is set by when the writer was
+// created, so anything that opens many writers at once -- a node restart, a WAL failover, a channel
+// rebalance -- aligns their tickers, and periodic tickers never drift back apart. At a few thousand
+// logs that is a few thousand auditors waking in the same millisecond every interval, each fanning
+// compaction RPCs at the same nodes. segmentRollingPolicy.maxInterval is a fixed period too, so
+// logs opened together also seal segments together and the two alignments compound: a synchronised
+// wave of segments enters Completed, and the next synchronised tick tries to compact all of them.
+//
+// Jittering only the first tick decorrelates the writers once, for the process lifetime, and the
+// delay is shorter than the interval the first tick used to wait, so no cycle is postponed.
+func auditorFirstTickDelay(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int64N(int64(interval)))
+}
+
 // compactStats summarizes one compactCompletedSegments pass for the auditor cycle log.
 type compactStats struct {
 	processed int
 	compacted int
 	failed    int
+	deferred  int // Completed segments left for a later cycle by maxCompactedPerCycle
 }
 
 // compactCompletedSegments compacts every Completed segment in the snapshot, sequentially by
@@ -64,22 +97,36 @@ func compactCompletedSegments(ctx context.Context, logHandle LogHandle, segs map
 	if localMode {
 		return st
 	}
+	// Oldest first, then bounded. Ranging a map is randomly ordered, which was harmless while
+	// every Completed segment was visited each cycle; under a bound it would let a segment be
+	// skipped cycle after cycle by chance, holding its local data.log for as long as that lasts.
+	// Ascending segment number drains the oldest backlog first, which is also the data that has
+	// been occupying local disk the longest.
+	completed := make([]int64, 0, len(segs))
 	for _, seg := range segs {
+		if seg.Metadata.State == proto.SegmentState_Completed {
+			completed = append(completed, seg.Metadata.SegNo)
+		}
+	}
+	sort.Slice(completed, func(i, j int) bool { return completed[i] < completed[j] })
+	if len(completed) > maxCompactedPerCycle {
+		st.deferred = len(completed) - maxCompactedPerCycle
+		completed = completed[:maxCompactedPerCycle]
+	}
+
+	for _, segNo := range completed {
 		if ctx.Err() != nil {
 			break
 		}
-		if seg.Metadata.State != proto.SegmentState_Completed {
-			continue
-		}
 		st.processed++
-		recoverySegmentHandle, err := logHandle.GetRecoverableSegmentHandle(ctx, seg.Metadata.SegNo)
+		recoverySegmentHandle, err := logHandle.GetRecoverableSegmentHandle(ctx, segNo)
 		if err != nil {
-			logger.Ctx(ctx).Warn("get log segment failed when log auditor running", zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()), zap.Int64("segId", seg.Metadata.SegNo), zap.Error(err))
+			logger.Ctx(ctx).Warn("get log segment failed when log auditor running", zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()), zap.Int64("segId", segNo), zap.Error(err))
 			st.failed++
 			continue
 		}
 		if err := recoverySegmentHandle.Compact(ctx); err != nil {
-			logger.Ctx(ctx).Warn("auditor maintain the log segment failed", zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()), zap.Int64("segId", seg.Metadata.SegNo), zap.Error(err))
+			logger.Ctx(ctx).Warn("auditor maintain the log segment failed", zap.String("logName", logHandle.GetName()), zap.Int64("logId", logHandle.GetId()), zap.Int64("segId", segNo), zap.Error(err))
 			st.failed++
 			continue
 		}
@@ -90,7 +137,7 @@ func compactCompletedSegments(ctx context.Context, logHandle LogHandle, segs map
 		logger.Ctx(ctx).Debug("Successfully compacted segment",
 			zap.String("logName", logHandle.GetName()),
 			zap.Int64("logId", logHandle.GetId()),
-			zap.Int64("segmentId", seg.Metadata.SegNo))
+			zap.Int64("segmentId", segNo))
 	}
 	return st
 }

--- a/woodpecker/log/log_auditor.go
+++ b/woodpecker/log/log_auditor.go
@@ -55,7 +55,8 @@ const maxCompactedNotifyPerCycle = 64
 // recovers every log tries to drain its whole backlog at once.
 const maxCompactedPerCycle = 64
 
-// auditorFirstTickDelay returns a random delay in [0, interval) for an auditor's first tick.
+// waitAuditorStartJitter delays an auditor's start by a random fraction of its interval, returning
+// false if the writer shut down while waiting.
 //
 // Every log writer runs its own auditor on a fixed period whose phase is set by when the writer was
 // created, so anything that opens many writers at once -- a node restart, a WAL failover, a channel
@@ -65,13 +66,24 @@ const maxCompactedPerCycle = 64
 // logs opened together also seal segments together and the two alignments compound: a synchronised
 // wave of segments enters Completed, and the next synchronised tick tries to compact all of them.
 //
-// Jittering only the first tick decorrelates the writers once, for the process lifetime, and the
-// delay is shorter than the interval the first tick used to wait, so no cycle is postponed.
-func auditorFirstTickDelay(interval time.Duration) time.Duration {
+// Spreading the start decorrelates the writers once, for the process lifetime. It postpones the
+// first cycle by up to one interval, which is of no consequence for background maintenance on a
+// writer that has only just opened. The wait watches the same two shutdown signals as the auditor
+// loop, so a writer closed during it is not held up.
+func waitAuditorStartJitter(ctx context.Context, writerClose <-chan struct{}, interval time.Duration) bool {
 	if interval <= 0 {
-		return 0
+		return true
 	}
-	return time.Duration(rand.Int64N(int64(interval)))
+	timer := time.NewTimer(time.Duration(rand.Int64N(int64(interval))))
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-writerClose:
+		return false
+	case <-ctx.Done():
+		return false
+	}
 }
 
 // compactStats summarizes one compactCompletedSegments pass for the auditor cycle log.

--- a/woodpecker/log/log_auditor_test.go
+++ b/woodpecker/log/log_auditor_test.go
@@ -518,23 +518,50 @@ func TestCompactCompletedSegments_OldestFirst(t *testing.T) {
 	}
 }
 
-// TestAuditorFirstTickDelay covers the phase spreading that keeps writers created together from
-// ticking in lockstep, and the two properties the loop depends on: the delay never exceeds the
-// interval (so no first cycle is postponed relative to the unjittered ticker), and a non-positive
-// interval yields no delay at all.
-func TestAuditorFirstTickDelay(t *testing.T) {
-	const interval = time.Minute
-	buckets := map[int]int{}
-	for range 2000 {
-		d := auditorFirstTickDelay(interval)
-		require.GreaterOrEqual(t, d, time.Duration(0))
-		require.Less(t, d, interval, "the jittered first tick must not fire later than the plain ticker would")
-		buckets[int(d*8/interval)]++
-	}
-	// A fixed phase would put every sample in one bucket; spreading across the interval is the
-	// whole point of the change.
-	assert.Len(t, buckets, 8, "first-tick delay should spread across the interval, got %v", buckets)
+// TestWaitAuditorStartJitter covers the phase spreading that keeps writers created together from
+// ticking in lockstep, and the two shutdown signals the auditor loop itself watches: a writer
+// closed during the wait must not be held up by it.
+func TestWaitAuditorStartJitter(t *testing.T) {
+	closed := make(chan struct{})
 
-	assert.Zero(t, auditorFirstTickDelay(0))
-	assert.Zero(t, auditorFirstTickDelay(-time.Second))
+	t.Run("spreads the start across the interval", func(t *testing.T) {
+		const interval = 50 * time.Millisecond
+		buckets := map[int]int{}
+		for range 60 {
+			start := time.Now()
+			require.True(t, waitAuditorStartJitter(context.Background(), closed, interval))
+			waited := time.Since(start)
+			// Generous upper bound: the delay is under one interval by construction, the slack
+			// only absorbs scheduler wake-up latency on a loaded CI machine.
+			require.Less(t, waited, interval+100*time.Millisecond)
+			if b := int(waited * 4 / interval); b < 4 {
+				buckets[b]++ // 4 quarters of the interval
+			}
+		}
+		// A fixed phase would land every sample in one bucket; spreading is the whole point.
+		assert.GreaterOrEqual(t, len(buckets), 3, "start should spread across the interval, got %v", buckets)
+	})
+
+	t.Run("returns immediately when the writer is closing", func(t *testing.T) {
+		writerClose := make(chan struct{}, 1)
+		writerClose <- struct{}{}
+		start := time.Now()
+		assert.False(t, waitAuditorStartJitter(context.Background(), writerClose, time.Hour))
+		assert.Less(t, time.Since(start), time.Second)
+	})
+
+	t.Run("returns immediately when the writer is invalidated", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		start := time.Now()
+		assert.False(t, waitAuditorStartJitter(ctx, closed, time.Hour))
+		assert.Less(t, time.Since(start), time.Second)
+	})
+
+	t.Run("no wait when the interval is not positive", func(t *testing.T) {
+		start := time.Now()
+		assert.True(t, waitAuditorStartJitter(context.Background(), closed, 0))
+		assert.True(t, waitAuditorStartJitter(context.Background(), closed, -time.Second))
+		assert.Less(t, time.Since(start), 50*time.Millisecond)
+	})
 }

--- a/woodpecker/log/log_auditor_test.go
+++ b/woodpecker/log/log_auditor_test.go
@@ -459,3 +459,82 @@ func TestSweepOrphanedCleanupRecords(t *testing.T) {
 	assert.Equal(t, []int64{5, math.MaxInt64}, cm.sweepBounds)
 	assert.Equal(t, []int64{5, math.MaxInt64}, nm.sweepBoundsSnapshot())
 }
+
+// TestCompactCompletedSegments_BoundedPerCycle verifies one cycle compacts at most
+// maxCompactedPerCycle segments and reports the rest as deferred, so a backlog cannot swamp a
+// single cycle -- the exposure being a recovery stampede, where compaction has been failing, the
+// Completed set has grown, and every log tries to drain it the moment storage comes back.
+func TestCompactCompletedSegments_BoundedPerCycle(t *testing.T) {
+	lh := &testLogHandleMock{}
+	lh.On("GetName").Return("test-log").Maybe()
+	lh.On("GetId").Return(int64(1)).Maybe()
+	// Every lookup fails: the pass still counts the segment as processed, which is what the
+	// bound is being measured against, and no segment handle is needed.
+	lh.On("GetRecoverableSegmentHandle", mock.Anything, mock.Anything).Return(nil, errors.New("boom"))
+
+	const total = maxCompactedPerCycle + 25
+	segs := map[int64]*meta.SegmentMeta{}
+	for i := int64(1); i <= total; i++ {
+		segs[i] = segMeta(i, proto.SegmentState_Completed)
+	}
+
+	st := compactCompletedSegments(context.Background(), lh, segs, false)
+	assert.Equal(t, maxCompactedPerCycle, st.processed)
+	assert.Equal(t, total-maxCompactedPerCycle, st.deferred)
+}
+
+// TestCompactCompletedSegments_OldestFirst verifies the bounded pass drains in ascending segment
+// order. Ranging a map is randomly ordered; unbounded that was harmless because every Completed
+// segment was visited, but under a bound it would let a segment be skipped cycle after cycle by
+// chance while its local data.log stayed on disk.
+func TestCompactCompletedSegments_OldestFirst(t *testing.T) {
+	lh := &testLogHandleMock{}
+	lh.On("GetName").Return("test-log").Maybe()
+	lh.On("GetId").Return(int64(1)).Maybe()
+
+	var mu sync.Mutex
+	var seen []int64
+	lh.On("GetRecoverableSegmentHandle", mock.Anything, mock.Anything).
+		Return(nil, errors.New("boom")).
+		Run(func(args mock.Arguments) {
+			mu.Lock()
+			defer mu.Unlock()
+			seen = append(seen, args.Get(1).(int64))
+		})
+
+	// Insert high segment numbers first so a map-order pass would be unlikely to come out sorted.
+	segs := map[int64]*meta.SegmentMeta{}
+	for i := int64(maxCompactedPerCycle * 2); i >= 1; i-- {
+		segs[i] = segMeta(i, proto.SegmentState_Completed)
+	}
+
+	compactCompletedSegments(context.Background(), lh, segs, false)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, seen, maxCompactedPerCycle)
+	for i, segNo := range seen {
+		require.Equal(t, int64(i+1), segNo, "expected the oldest %d segments in order", maxCompactedPerCycle)
+	}
+}
+
+// TestAuditorFirstTickDelay covers the phase spreading that keeps writers created together from
+// ticking in lockstep, and the two properties the loop depends on: the delay never exceeds the
+// interval (so no first cycle is postponed relative to the unjittered ticker), and a non-positive
+// interval yields no delay at all.
+func TestAuditorFirstTickDelay(t *testing.T) {
+	const interval = time.Minute
+	buckets := map[int]int{}
+	for range 2000 {
+		d := auditorFirstTickDelay(interval)
+		require.GreaterOrEqual(t, d, time.Duration(0))
+		require.Less(t, d, interval, "the jittered first tick must not fire later than the plain ticker would")
+		buckets[int(d*8/interval)]++
+	}
+	// A fixed phase would put every sample in one bucket; spreading across the interval is the
+	// whole point of the change.
+	assert.Len(t, buckets, 8, "first-tick delay should spread across the interval, got %v", buckets)
+
+	assert.Zero(t, auditorFirstTickDelay(0))
+	assert.Zero(t, auditorFirstTickDelay(-time.Second))
+}

--- a/woodpecker/log/log_writer.go
+++ b/woodpecker/log/log_writer.go
@@ -352,26 +352,18 @@ func (l *logWriterImpl) runAuditor() {
 		zap.Int("intervalSeconds", l.auditorMaxInterval),
 		zap.Bool("localStorageCompactionDisabled", localMode))
 
-	// The first tick is jittered so writers created together do not tick in lockstep; the
-	// ticker takes over at the full interval from there. See auditorFirstTickDelay.
-	firstTick := time.NewTimer(auditorFirstTickDelay(interval))
-	defer firstTick.Stop()
-	tickC := firstTick.C
-	var ticker *time.Ticker
-	defer func() {
-		if ticker != nil {
-			ticker.Stop()
-		}
-	}()
+	// Spread the start so writers created together do not tick in lockstep.
+	if !waitAuditorStartJitter(l.maintenanceCtx, l.writerClose, interval) {
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 
 	auditCycle := uint64(0)
 	for {
 		select {
-		case <-tickC:
-			if ticker == nil {
-				ticker = time.NewTicker(interval)
-				tickC = ticker.C
-			}
+		case <-ticker.C:
 			if l.maintenanceCtx.Err() != nil || l.sessionLock == nil || !l.sessionLock.IsValid() {
 				l.stopMaintenance()
 				return

--- a/woodpecker/log/log_writer.go
+++ b/woodpecker/log/log_writer.go
@@ -339,8 +339,7 @@ func (l *logWriterImpl) WriteAsync(ctx context.Context, msg *WriteMessage) <-cha
 }
 
 func (l *logWriterImpl) runAuditor() {
-	ticker := time.NewTicker(time.Duration(l.auditorMaxInterval * int(time.Second)))
-	defer ticker.Stop()
+	interval := time.Duration(l.auditorMaxInterval) * time.Second
 
 	// Storage mode is fixed for the writer's lifetime; read it once here rather than per
 	// segment. localMode disables the compaction pass (see compactCompletedSegments), so
@@ -353,10 +352,26 @@ func (l *logWriterImpl) runAuditor() {
 		zap.Int("intervalSeconds", l.auditorMaxInterval),
 		zap.Bool("localStorageCompactionDisabled", localMode))
 
+	// The first tick is jittered so writers created together do not tick in lockstep; the
+	// ticker takes over at the full interval from there. See auditorFirstTickDelay.
+	firstTick := time.NewTimer(auditorFirstTickDelay(interval))
+	defer firstTick.Stop()
+	tickC := firstTick.C
+	var ticker *time.Ticker
+	defer func() {
+		if ticker != nil {
+			ticker.Stop()
+		}
+	}()
+
 	auditCycle := uint64(0)
 	for {
 		select {
-		case <-ticker.C:
+		case <-tickC:
+			if ticker == nil {
+				ticker = time.NewTicker(interval)
+				tickC = ticker.C
+			}
 			if l.maintenanceCtx.Err() != nil || l.sessionLock == nil || !l.sessionLock.IsValid() {
 				l.stopMaintenance()
 				return
@@ -422,6 +437,7 @@ func (l *logWriterImpl) runAuditor() {
 				zap.Int("segmentsProcessed", cs.processed),
 				zap.Int("segmentsCompacted", cs.compacted),
 				zap.Int("segmentsFailed", cs.failed),
+				zap.Int("segmentsDeferred", cs.deferred),
 				zap.Int("truncatedSegments", len(truncatedSegmentExists)))
 
 			// Clean up truncated segments (object-storage data + local files + tombstones).

--- a/woodpecker/log/log_writer_test.go
+++ b/woodpecker/log/log_writer_test.go
@@ -1621,7 +1621,9 @@ func TestInternalLogWriter_RunAuditor_FullCycle_NoSegments(t *testing.T) {
 	go w.runAuditor()
 
 	// Wait for at least one tick
-	time.Sleep(1500 * time.Millisecond)
+	// The auditor jitters its start by up to one interval before the ticker takes over, so a
+	// cycle has certainly run only after twice the interval.
+	time.Sleep(2500 * time.Millisecond)
 
 	// Stop auditor
 	w.writerClose <- struct{}{}
@@ -1644,7 +1646,9 @@ func TestInternalLogWriter_RunAuditor_CheckTruncatedError(t *testing.T) {
 	mockLogHandle.On("CheckAndSetSegmentTruncatedIfNeed", mock.Anything).Return(werr.ErrInternalError)
 
 	go w.runAuditor()
-	time.Sleep(1500 * time.Millisecond)
+	// The auditor jitters its start by up to one interval before the ticker takes over, so a
+	// cycle has certainly run only after twice the interval.
+	time.Sleep(2500 * time.Millisecond)
 	w.writerClose <- struct{}{}
 
 	mockLogHandle.AssertCalled(t, "CheckAndSetSegmentTruncatedIfNeed", mock.Anything)
@@ -1665,7 +1669,9 @@ func TestInternalLogWriter_RunAuditor_GetSegmentsError(t *testing.T) {
 	mockLogHandle.On("GetSegments", mock.Anything).Return(nil, werr.ErrInternalError)
 
 	go w.runAuditor()
-	time.Sleep(1500 * time.Millisecond)
+	// The auditor jitters its start by up to one interval before the ticker takes over, so a
+	// cycle has certainly run only after twice the interval.
+	time.Sleep(2500 * time.Millisecond)
 	w.writerClose <- struct{}{}
 
 	mockLogHandle.AssertCalled(t, "GetSegments", mock.Anything)
@@ -1692,7 +1698,9 @@ func TestInternalLogWriter_RunAuditor_CompactCompletedSegments(t *testing.T) {
 	mockSegHandle.EXPECT().Compact(mock.Anything).Return(nil)
 
 	go w.runAuditor()
-	time.Sleep(1500 * time.Millisecond)
+	// The auditor jitters its start by up to one interval before the ticker takes over, so a
+	// cycle has certainly run only after twice the interval.
+	time.Sleep(2500 * time.Millisecond)
 	w.writerClose <- struct{}{}
 
 	mockLogHandle.AssertCalled(t, "GetRecoverableSegmentHandle", mock.Anything, int64(1))
@@ -1718,7 +1726,9 @@ func TestInternalLogWriter_RunAuditor_CompactError(t *testing.T) {
 	mockSegHandle.EXPECT().Compact(mock.Anything).Return(werr.ErrInternalError)
 
 	go w.runAuditor()
-	time.Sleep(1500 * time.Millisecond)
+	// The auditor jitters its start by up to one interval before the ticker takes over, so a
+	// cycle has certainly run only after twice the interval.
+	time.Sleep(2500 * time.Millisecond)
 	w.writerClose <- struct{}{}
 
 	mockSegHandle.AssertCalled(t, "Compact", mock.Anything)
@@ -1741,7 +1751,9 @@ func TestInternalLogWriter_RunAuditor_GetRecoverableError(t *testing.T) {
 	mockLogHandle.On("GetRecoverableSegmentHandle", mock.Anything, int64(1)).Return(nil, werr.ErrSegmentNotFound)
 
 	go w.runAuditor()
-	time.Sleep(1500 * time.Millisecond)
+	// The auditor jitters its start by up to one interval before the ticker takes over, so a
+	// cycle has certainly run only after twice the interval.
+	time.Sleep(2500 * time.Millisecond)
 	w.writerClose <- struct{}{}
 
 	mockLogHandle.AssertCalled(t, "GetRecoverableSegmentHandle", mock.Anything, int64(1))
@@ -1773,7 +1785,9 @@ func TestInternalLogWriter_RunAuditor_TruncatedSegmentsCleanup(t *testing.T) {
 	cleanupMgr.On("CleanupSegment", mock.Anything, "test-log", int64(1), int64(1)).Return(nil)
 
 	go w.runAuditor()
-	time.Sleep(1500 * time.Millisecond)
+	// The auditor jitters its start by up to one interval before the ticker takes over, so a
+	// cycle has certainly run only after twice the interval.
+	time.Sleep(2500 * time.Millisecond)
 	w.writerClose <- struct{}{}
 
 	cleanupMgr.AssertCalled(t, "CleanupSegment", mock.Anything, "test-log", int64(1), int64(1))
@@ -1793,7 +1807,9 @@ func TestLogWriter_RunAuditor_FullCycle(t *testing.T) {
 	mockLogHandle.On("GetSegments", mock.Anything).Return(map[int64]*meta.SegmentMeta{}, nil)
 
 	go w.runAuditor()
-	time.Sleep(1500 * time.Millisecond)
+	// The auditor jitters its start by up to one interval before the ticker takes over, so a
+	// cycle has certainly run only after twice the interval.
+	time.Sleep(2500 * time.Millisecond)
 	w.writerClose <- struct{}{}
 
 	mockLogHandle.AssertCalled(t, "CheckAndSetSegmentTruncatedIfNeed", mock.Anything)
@@ -1832,7 +1848,9 @@ func TestLogWriter_RunAuditor_WithCompletedAndTruncated(t *testing.T) {
 	cleanupMgr.On("CleanupSegment", mock.Anything, "test-log", int64(1), int64(2)).Return(nil)
 
 	go w.runAuditor()
-	time.Sleep(1500 * time.Millisecond)
+	// The auditor jitters its start by up to one interval before the ticker takes over, so a
+	// cycle has certainly run only after twice the interval.
+	time.Sleep(2500 * time.Millisecond)
 	w.writerClose <- struct{}{}
 
 	mockSegHandle.AssertCalled(t, "Compact", mock.Anything)


### PR DESCRIPTION
## Problem

Every log writer runs its own auditor on a bare `time.NewTicker(auditorMaxInterval)`, and the
compaction pass inside that cycle had no per-cycle bound. Both push a synchronised burst of
`CompactSegment` RPCs at the woodpecker nodes.

Fixes #317

## Spread the auditor start

A ticker's phase is set by when the writer was created, so anything that opens many writers at once
— a node restart, a WAL failover, a channel rebalance — aligns them, and periodic tickers never
drift back apart. At a few thousand logs that is a few thousand auditors waking in the same
millisecond every interval. `segmentRollingPolicy.maxInterval` is a fixed period too, so logs opened
together also seal segments together and the two alignments compound: a synchronised wave of
segments enters `Completed`, and the next synchronised tick tries to compact all of them.

`runAuditor` now waits a random `[0, interval)` before starting its ticker. The ticker inherits that
offset, so the writers are decorrelated once for the process lifetime: two opened together stay
`d₁ - d₂` apart for as long as the process runs.

Two notes on the shape, both from review on this PR — an earlier revision jittered the *first tick*
instead, by swapping the loop's channel from a one-shot timer to the ticker:

- **The first cycle now lands in `[interval, 2×interval)`** rather than at exactly `interval`. The
  phase spread is identical either way, so "never postpone a cycle" was a constraint we had imposed
  on ourselves, not one the goal implies. Everything the auditor does — compaction, compacted-mark
  distribution, truncated-segment cleanup, the orphan sweep — is background reclamation with no
  latency deadline, and at the default 10s interval the worst case is a first cycle 20s after the
  writer opens. Accepting that leaves the loop exactly as it was: no timer/ticker channel swap, and
  no `if ticker == nil` check sitting in the tick case for a property that only matters once. It
  also removes any chance of a cycle firing at `t≈0`, in the middle of the same startup storm that
  opened the writers.
- **The wait watches `writerClose` and `maintenanceCtx.Done()`**, the same two signals `runAuditor`
  exits on, so a writer closed during it is not held up. That is what the loop-embedded version was
  reaching for, and what a bare `time.Sleep` would have missed;
  `TestLogWriter_RunAuditor_StopsOnWriterClose` covers it.

## Bound the compaction pass

`distributeCompactedMarks` has stopped a backlog from swamping a single cycle since
`maxCompactedNotifyPerCycle` was added, and the comment on that constant notes compaction is not
counted. `compactCompletedSegments` walked every `Completed` segment with no cap, though compaction
is the far more expensive pass — a merge plus object-storage uploads, against one etcd write.

The exposure is worst exactly while recovering: whenever compaction has been failing (object storage
unwritable, wrong credentials, a version mismatch) `Completed` segments pile up, and the moment
storage returns every log tries to drain its whole backlog at once.

A cycle now compacts at most `maxCompactedPerCycle` (64, mirroring the notify path) and reports the
rest as `segmentsDeferred` in the cycle summary — which is also the signal an operator wants when
compaction is falling behind.

**Ordering came with the bound, not as a separate change.** Ranging a map is randomly ordered. That
was harmless while every `Completed` segment was visited each cycle, but under a bound it would let
a segment be skipped cycle after cycle by chance while its local `data.log` stayed on disk. The pass
now walks in ascending segment order, which also drains the data that has occupied local disk
longest.

## Note on what this does not fix

The bound caps how many segments a cycle attempts, not how long the cycle runs: a segment can still
take up to `segmentCompactionPolicy.timeout` on each of its quorum nodes in turn, so a bounded pass
against a hanging object store can still outlast the interval. That is #318, and the two are
complementary — this one shapes the peak, that one bounds the duration.

## Verification

- `go test ./woodpecker/log/`: ok
- `go test -race ./woodpecker/log/ -run 'TestWaitAuditorStartJitter|RunAuditor'`: ok
- `golangci-lint run ./woodpecker/log/...` with the CI-pinned v2.11.4: 0 issues
- `gofmt -l .`: clean
- `go vet ./woodpecker/log/`: clean

New tests cover the bound (only `maxCompactedPerCycle` attempted, remainder reported deferred), the
ordering (oldest first, with the map deliberately populated in descending order so a map-order pass
would be very unlikely to come out sorted), and the start jitter (spread across the interval, plus
both shutdown signals returning immediately instead of waiting the delay out).

The nine `RunAuditor` tests waited 1500ms against a 1s interval, so with the first cycle pushed past
one interval they became coin flips rather than outright failures. They now wait past twice the
interval, which is when a cycle has certainly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
