### PR TITLE
enhance(logstore): size the shared flush pool from config, not the host's cores

### DIFF
--- a/common/config/configuration.go
+++ b/common/config/configuration.go
@@ -196,6 +196,24 @@ type SegmentCompactionPolicy struct {
 	Timeout            DurationSeconds `yaml:"timeout"`
 }
 
+// SyncSchedulerConfig stores the node-wide staged-storage sync scheduler configuration.
+type SyncSchedulerConfig struct {
+	// MaxWorkers is the number of workers in the node's shared flush pool, as a plain count.
+	//
+	// Each worker blocks in fdatasync while a flush is in flight, so this bounds how many
+	// concurrent syncs the node can have outstanding, not how much CPU it uses -- Go hands the
+	// P back for the duration of a blocking syscall, so a worker parked in fdatasync costs an
+	// OS thread rather than a core. Sizing it by CPU count therefore has no mechanical basis,
+	// and reading the host's core count (rather than the cgroup limit) made the effective value
+	// depend on which machine a pod happened to land on.
+	//
+	// Tune it from the volume's IOPS budget: workers ~= target IOPS x fsync latency. Past the
+	// point where the device saturates, more workers buy queueing rather than throughput, and
+	// shrink the per-block batching that absorbs load, so raise it toward the budget and not
+	// beyond.
+	MaxWorkers int `yaml:"maxWorkers"`
+}
+
 // RetentionPolicyConfig stores the data retention policy configuration.
 type RetentionPolicyConfig struct {
 	TTL int `yaml:"ttl"` // Time to live for truncated segments before eligible for GC
@@ -344,6 +362,7 @@ type MinioConfig struct {
 type LogstoreConfig struct {
 	SegmentSyncPolicy       SegmentSyncPolicyConfig      `yaml:"segmentSyncPolicy"`
 	SegmentCompactionPolicy SegmentCompactionPolicy      `yaml:"segmentCompactionPolicy"`
+	SyncScheduler           SyncSchedulerConfig          `yaml:"syncScheduler"`
 	SegmentReadPolicy       SegmentReadPolicyConfig      `yaml:"segmentReadPolicy"`
 	RetentionPolicy         RetentionPolicyConfig        `yaml:"retentionPolicy"`
 	FencePolicy             FencePolicyConfig            `yaml:"fencePolicy"`
@@ -800,6 +819,9 @@ func (c *Configuration) validateLogstoreConfig() error {
 	}
 
 	// Validate SegmentCompactionPolicy
+	if logstore.SyncScheduler.MaxWorkers <= 0 {
+		return fmt.Errorf("sync scheduler max workers must be positive, got %d", logstore.SyncScheduler.MaxWorkers)
+	}
 	if logstore.SegmentCompactionPolicy.MaxBytes <= 0 {
 		return fmt.Errorf("segment compaction policy max bytes must be positive, got %d", logstore.SegmentCompactionPolicy.MaxBytes.Int64())
 	}
@@ -933,6 +955,9 @@ func getDefaultWoodpeckerConfig() WoodpeckerConfig {
 				RetryInterval:              DurationMilliseconds{Duration: Duration{duration: 2000 * 1000000}}, // 2000ms
 				MaxFlushSize:               ByteSize(16000000),
 				MaxFlushThreads:            8,
+			},
+			SyncScheduler: SyncSchedulerConfig{
+				MaxWorkers: 32,
 			},
 			SegmentCompactionPolicy: SegmentCompactionPolicy{
 				MaxBytes:           ByteSize(32000000),

--- a/common/config/configuration_test.go
+++ b/common/config/configuration_test.go
@@ -72,6 +72,7 @@ func TestNewConfiguration(t *testing.T) {
 	assert.Equal(t, 1000, config.Woodpecker.Logstore.SegmentSyncPolicy.RetryInterval.Milliseconds())
 	assert.Equal(t, int64(2000000), config.Woodpecker.Logstore.SegmentSyncPolicy.MaxFlushSize.Int64())
 	assert.Equal(t, 32, config.Woodpecker.Logstore.SegmentSyncPolicy.MaxFlushThreads)
+	assert.Equal(t, 32, config.Woodpecker.Logstore.SyncScheduler.MaxWorkers)
 	assert.Equal(t, int64(2000000), config.Woodpecker.Logstore.SegmentCompactionPolicy.MaxBytes.Int64())
 	assert.Equal(t, 4, config.Woodpecker.Logstore.SegmentCompactionPolicy.MaxParallelUploads)
 	assert.Equal(t, 8, config.Woodpecker.Logstore.SegmentCompactionPolicy.MaxParallelReads)
@@ -178,6 +179,7 @@ func TestNewConfiguration(t *testing.T) {
 	assert.Equal(t, 2000, defaultConfig.Woodpecker.Logstore.SegmentSyncPolicy.RetryInterval.Milliseconds())
 	assert.Equal(t, int64(16000000), defaultConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxFlushSize.Int64())
 	assert.Equal(t, 8, defaultConfig.Woodpecker.Logstore.SegmentSyncPolicy.MaxFlushThreads)
+	assert.Equal(t, 32, defaultConfig.Woodpecker.Logstore.SyncScheduler.MaxWorkers)
 	assert.Equal(t, int64(32000000), defaultConfig.Woodpecker.Logstore.SegmentCompactionPolicy.MaxBytes.Int64())
 	assert.Equal(t, 4, defaultConfig.Woodpecker.Logstore.SegmentCompactionPolicy.MaxParallelUploads)
 	assert.Equal(t, 8, defaultConfig.Woodpecker.Logstore.SegmentCompactionPolicy.MaxParallelReads)
@@ -475,6 +477,9 @@ func TestQuorumConfigValidation(t *testing.T) {
 							MaxFlushSize:               NewByteSize(16000000),
 							MaxFlushThreads:            8,
 						},
+						SyncScheduler: SyncSchedulerConfig{
+							MaxWorkers: 32,
+						},
 						SegmentCompactionPolicy: SegmentCompactionPolicy{
 							MaxBytes:           NewByteSize(32000000),
 							MaxParallelUploads: 4,
@@ -696,6 +701,11 @@ func TestValidateClientConfig_Errors(t *testing.T) {
 		assert.ErrorContains(t, cfg.Validate(), "max blocks must be positive")
 	})
 
+	t.Run("SyncScheduler MaxWorkers<=0", func(t *testing.T) {
+		cfg := newValidCfg()
+		cfg.Woodpecker.Logstore.SyncScheduler.MaxWorkers = 0
+		assert.ErrorContains(t, cfg.Validate(), "sync scheduler max workers must be positive")
+	})
 	t.Run("Auditor MaxInterval<=0", func(t *testing.T) {
 		cfg := newValidCfg()
 		cfg.Woodpecker.Client.Auditor.MaxInterval = NewDurationSecondsFromInt(0)
@@ -1124,6 +1134,9 @@ func TestCustomPlacementConfiguration(t *testing.T) {
 					RetryInterval:              NewDurationMillisecondsFromInt(2000),
 					MaxFlushSize:               NewByteSize(16000000),
 					MaxFlushThreads:            8,
+				},
+				SyncScheduler: SyncSchedulerConfig{
+					MaxWorkers: 32,
 				},
 				SegmentCompactionPolicy: SegmentCompactionPolicy{
 					MaxBytes:           NewByteSize(32000000),

--- a/config/woodpecker.yaml
+++ b/config/woodpecker.yaml
@@ -99,6 +99,13 @@ woodpecker:
       retryInterval: 1000 # Maximum interval between two retries in milliseconds
       maxFlushSize: 2000000 # Maximum size of a block in bytes to flush, default is 2MB, which is the best practice for cloud storage
       maxFlushThreads: 32 # Maximum number of threads to flush data
+    syncScheduler:
+      # Workers in the node's shared flush pool, as a plain count. Each one blocks in fdatasync
+      # while a flush is in flight, so this bounds concurrent syncs, not CPU usage -- a worker
+      # parked in a blocking syscall costs an OS thread, not a core.
+      # Tune from the volume's IOPS budget: workers ~= target IOPS x fsync latency. Past the point
+      # where the device saturates, more workers buy queueing rather than throughput.
+      maxWorkers: 32
     segmentCompactionPolicy:
       maxBytes: 2000000 # Maximum size of a merged block in bytes after compact, default is 2M
       maxParallelUploads: 4 # Maximum number of parallel upload threads for compaction, default is 4

--- a/server/logstore.go
+++ b/server/logstore.go
@@ -23,7 +23,6 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -142,7 +141,7 @@ func NewLogStore(ctx context.Context, cfg *config.Configuration, storageClient s
 		ctx:               ctx,
 		cancel:            cancel,
 		storageClient:     storageClient,
-		syncScheduler:     stagedstorage.NewSyncScheduler(runtime.NumCPU() * 2),
+		syncScheduler:     stagedstorage.NewSyncScheduler(cfg.Woodpecker.Logstore.SyncScheduler.MaxWorkers),
 		segmentProcessors: make(map[string]map[int64]processor.SegmentProcessor),
 		deletingLogs:      make(map[string]struct{}),
 		deletingInstances: make(map[string]struct{}),

--- a/server/logstore_test.go
+++ b/server/logstore_test.go
@@ -1624,3 +1624,23 @@ func TestLogStore_EvictSegmentWriter_AbsentKeyIsNoop(t *testing.T) {
 	store.spMu.RUnlock()
 	assert.False(t, logExists, "EvictSegmentWriter must not create a processor for an absent key")
 }
+
+// TestNewLogStore_SyncSchedulerUsesConfiguredWorkers verifies the node's shared flush pool is
+// sized from configuration rather than from the host's core count. Reading runtime.NumCPU() gave
+// the machine's cores, not the pod's cgroup limit, so identically specced pods ended up with pools
+// differing by a factor of eight depending on where they were scheduled -- and raising the pod's
+// CPU limit did not change it.
+func TestNewLogStore_SyncSchedulerUsesConfiguredWorkers(t *testing.T) {
+	for _, workers := range []int{1, 7, 48} {
+		cfg, err := config.NewConfiguration()
+		require.NoError(t, err)
+		cfg.Woodpecker.Storage.Type = "service"
+		cfg.Woodpecker.Storage.RootPath = t.TempDir()
+		cfg.Woodpecker.Logstore.SyncScheduler.MaxWorkers = workers
+
+		ls := NewLogStore(context.Background(), cfg, nil).(*logStore)
+		assert.Equal(t, workers, ls.syncScheduler.Capacity(),
+			"the shared flush pool should come from logstore.syncScheduler.maxWorkers")
+		ls.syncScheduler.Close()
+	}
+}

--- a/server/storage/stagedstorage/sync_scheduler.go
+++ b/server/storage/stagedstorage/sync_scheduler.go
@@ -3,7 +3,6 @@ package stagedstorage
 import (
 	"container/heap"
 	"context"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -72,6 +71,23 @@ type SyncScheduler struct {
 	closed  atomic.Bool
 }
 
+// defaultSyncSchedulerWorkers is the pool size used when no configured value is available.
+// It mirrors logstore.syncScheduler.maxWorkers so the two cannot drift.
+const defaultSyncSchedulerWorkers = 32
+
+// syncSchedulerQueueSize is the depth of both scheduler channels.
+//
+// It is deliberately independent of the worker count: the queues hold pending work, and the
+// amount of pending work is bounded by the number of writers, not by how many of them are being
+// serviced at once. Each writer can have at most one schedule request and one submitted sync job
+// outstanding (the syncScheduled and syncTaskSubmitted CAS gates), so one slot per writer is the
+// real ceiling. Sizing it as workerCount x 4096 tied a multi-megabyte preallocation to a quantity
+// that has nothing to do with it.
+//
+// The depth matters because a full scheduleCh blocks its caller, and the caller is the append
+// path: WriteDataAsync schedules the next sync check before it returns.
+const syncSchedulerQueueSize = 65536
+
 var (
 	defaultSyncSchedulerOnce sync.Once
 	defaultSyncScheduler     *SyncScheduler
@@ -79,28 +95,21 @@ var (
 
 func DefaultSyncScheduler() *SyncScheduler {
 	defaultSyncSchedulerOnce.Do(func() {
-		defaultSyncScheduler = NewSyncScheduler(runtime.NumCPU() * 2)
+		defaultSyncScheduler = NewSyncScheduler(defaultSyncSchedulerWorkers)
 	})
 	return defaultSyncScheduler
 }
 
 func NewSyncScheduler(workerCount int) *SyncScheduler {
 	if workerCount <= 0 {
-		workerCount = runtime.NumCPU() * 2
-	}
-	if workerCount <= 0 {
-		workerCount = 1
-	}
-	queueSize := workerCount * 4096
-	if queueSize < 1024 {
-		queueSize = 1024
+		workerCount = defaultSyncSchedulerWorkers
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &SyncScheduler{
 		ctx:         ctx,
 		cancel:      cancel,
-		scheduleCh:  make(chan syncScheduleRequest, queueSize),
-		jobCh:       make(chan syncJob, queueSize),
+		scheduleCh:  make(chan syncScheduleRequest, syncSchedulerQueueSize),
+		jobCh:       make(chan syncJob, syncSchedulerQueueSize),
 		workerCount: workerCount,
 	}
 	s.wg.Add(1)

--- a/server/storage/stagedstorage/sync_scheduler_test.go
+++ b/server/storage/stagedstorage/sync_scheduler_test.go
@@ -4,12 +4,12 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -128,7 +128,7 @@ func BenchmarkSyncSchedulerJobDispatchLatency(b *testing.B) {
 	for _, jobs := range []int{1_000, 10_000, 100_000} {
 		b.Run(fmt.Sprintf("jobs_%d", jobs), func(b *testing.B) {
 			b.ReportAllocs()
-			scheduler := NewSyncScheduler(runtime.NumCPU())
+			scheduler := NewSyncScheduler(defaultSyncSchedulerWorkers)
 			defer scheduler.Close()
 
 			latencies := make(chan time.Duration, jobs)
@@ -172,7 +172,7 @@ func BenchmarkSyncSchedulerDelayedCheckLatency(b *testing.B) {
 	for _, checks := range []int{1_000, 10_000, 100_000} {
 		b.Run(fmt.Sprintf("checks_%d", checks), func(b *testing.B) {
 			b.ReportAllocs()
-			scheduler := NewSyncScheduler(runtime.NumCPU())
+			scheduler := NewSyncScheduler(defaultSyncSchedulerWorkers)
 			defer scheduler.Close()
 
 			delay := 10 * time.Millisecond
@@ -207,4 +207,44 @@ func BenchmarkSyncSchedulerDelayedCheckLatency(b *testing.B) {
 			b.ReportMetric(float64(maxLateNs)/1e3, "max_late_us/check")
 		})
 	}
+}
+
+// TestNewSyncScheduler_WorkerCountIsExplicit verifies the pool size comes from the caller, and
+// that a non-positive value falls back to the documented default rather than to the host's core
+// count. Deriving it from runtime.NumCPU() read the machine's cores rather than the pod's cgroup
+// limit, so identically specced pods ended up with pools that differed by a factor of eight
+// depending on where they were scheduled.
+func TestNewSyncScheduler_WorkerCountIsExplicit(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"explicit count is honoured", 5, 5},
+		{"one is honoured", 1, 1},
+		{"zero falls back to the default", 0, defaultSyncSchedulerWorkers},
+		{"negative falls back to the default", -3, defaultSyncSchedulerWorkers},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSyncScheduler(tc.in)
+			defer s.Close()
+			assert.Equal(t, tc.want, s.Capacity())
+		})
+	}
+}
+
+// TestNewSyncScheduler_QueueDepthIsIndependentOfWorkers verifies the channel depth no longer
+// scales with the pool size. The queues hold pending work, which is bounded by the number of
+// writers rather than by how many are being serviced, so tying a multi-megabyte preallocation to
+// the worker count sized it by the wrong quantity.
+func TestNewSyncScheduler_QueueDepthIsIndependentOfWorkers(t *testing.T) {
+	small := NewSyncScheduler(1)
+	defer small.Close()
+	large := NewSyncScheduler(64)
+	defer large.Close()
+
+	assert.Equal(t, cap(small.scheduleCh), cap(large.scheduleCh))
+	assert.Equal(t, cap(small.jobCh), cap(large.jobCh))
+	assert.Equal(t, syncSchedulerQueueSize, cap(small.scheduleCh))
+	assert.Equal(t, syncSchedulerQueueSize, cap(small.jobCh))
 }


### PR DESCRIPTION
## Problem

The staged-storage sync worker pool was sized as `runtime.NumCPU() * 2`.

Fixes #314

Its workers block in `fdatasync` (`writer_impl.go`, `w.file.Sync()`), so core count is the wrong
quantity to size them by: Go hands the P back for the duration of a blocking syscall, so a worker
parked in `fdatasync` costs an OS thread, not a core. And `runtime.NumCPU()` reports the **host's**
cores rather than the pod's cgroup limit, so identically specced pods ended up with pools differing
by a factor of eight depending on where they were scheduled — and raising a pod's CPU limit did not
change it.

The practical effect: the pool, not the volume, capped concurrent fsync. A per-volume write ceiling
of ~2,126 IOPS against a gp3 baseline of 3,000, with load above that turning into queueing rather
than throughput. Because each log writes its own file, the sustainable number of concurrent fsyncs
also bounds how many active logs a pod can carry at a given per-message write latency.

## `logstore.syncScheduler.maxWorkers`

A plain count, default 32, wired in `NewLogStore` where `cfg` was already in scope.

**A plain number, not a multiplier.** A multiplier of core count reintroduces exactly the drift
above, and the quantity has no relationship to cores. A plain number gives the same flush
concurrency on every node shape, so a deployment is tuned to its volume's IOPS budget once.

**Not under `segmentSyncPolicy`.** That section is per-segment policy, while this pool is shared by
every writer on the node. `segmentSyncPolicy.maxFlushThreads` also already means something
different: it sizes a pool per object-storage *segment writer*, so the process-wide bound there
scales with the number of active segment writers. Reusing that key would have made one YAML value
mean "per segment" under one `storage.type` and "per node" under another.

The YAML comment carries the tuning rule: `workers ≈ target volume IOPS × fsync latency`, and that
past the point where the device saturates more workers buy queueing rather than throughput — so it
should be raised toward the volume's budget, not indefinitely.

## Queue depth decoupled

`queueSize := workerCount * 4096` tied a multi-megabyte preallocation to a quantity that has
nothing to do with it. The queues hold *pending* work, which is bounded by the number of writers
rather than by how many are being serviced: the `syncScheduled` and `syncTaskSubmitted` CAS gates
allow at most one schedule request and one submitted job per writer, so one slot per writer is the
real ceiling.

It is now a constant 65,536 slots:

| host cores | old workers | old slots | old prealloc | new workers | new slots | new prealloc |
|---|---|---|---|---|---|---|
| 4 | 8 | 32,768 | 1.0 MB | 32 | 65,536 | 2.0 MB |
| 8 | 16 | 65,536 | 2.0 MB | 32 | 65,536 | 2.0 MB |
| 16 | 32 | 131,072 | 4.0 MB | 32 | 65,536 | 2.0 MB |
| 32 | 64 | 262,144 | 8.0 MB | 32 | 65,536 | 2.0 MB |

The depth matters rather than being a free parameter: a full `scheduleCh` blocks its caller, and
the caller is the append path — `WriteDataAsync` schedules the next sync check before it returns.
65,536 is at or above the previous value for every host shape except the 16- and 32-core ones,
where the old sizing was simply larger than anything the CAS gates can fill.

## Also

A non-positive worker count falls back to the documented default rather than to the core count, so
`NewSyncScheduler` and the config default cannot disagree. The two benchmarks that passed
`runtime.NumCPU()` now pass the same constant, which also makes their results comparable across
machines.

## Verification

- `go test ./common/config/ ./server/ ./server/storage/stagedstorage/`: ok
- `go test -race ./common/config/ ./server/storage/stagedstorage/`: ok
- `golangci-lint run ./server/... ./common/config/...` with the CI-pinned v2.11.4: 0 issues
- `gofmt -l .`: clean, `go mod tidy`: no diff

New tests:

- `TestNewLogStore_SyncSchedulerUsesConfiguredWorkers` — the end-to-end claim: the pool a logstore
  builds has the capacity the config asked for, across several values.
- `TestNewSyncScheduler_WorkerCountIsExplicit` — explicit counts are honoured; non-positive falls
  back to the default rather than the core count.
- `TestNewSyncScheduler_QueueDepthIsIndependentOfWorkers` — a 1-worker and a 64-worker scheduler
  get the same channel depth.
- Config: `maxWorkers` asserted on the YAML and defaults paths, plus the validation error. Since
  the shipped value equals the in-code default, a wrong indentation would be invisible — checked
  with a throwaway config setting it to 4242, which came through.

Two hand-built `Configuration` fixtures in the config tests needed the new field, the same as for
every other validated logstore setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
