### PR TITLE
fix(segment): index the fence LAC by the replicas that may be missing it

### DIFF
--- a/woodpecker/segment/completion_manager.go
+++ b/woodpecker/segment/completion_manager.go
@@ -120,7 +120,7 @@ func (cm *completionManager) executeWithRetry(ctx context.Context) error {
 	}
 
 	// Phase 3 (with lock): CAS, fast-fail ops, stop executor, update metadata.
-	// Reaching this point proves Aq finalized replicas locally cover targetLAC.
+	// Reaching this point proves Aq replicas finalized at targetLAC.
 	s.Lock()
 	defer s.Unlock()
 	closeErr := s.doCloseWritingAndUpdateMetaIfNecessaryUnsafe(ctx, targetLAC)
@@ -147,7 +147,8 @@ func (cm *completionManager) failAndCloseWithoutMeta(ctx context.Context, target
 	s.NotifyWriterInvalidation(ctx, fmt.Sprintf("segment:%d complete failed after retries", s.segmentId))
 
 	// Stop this local writer so it cannot accept more appends, but do not publish
-	// Completed metadata: the required Aq qualified replicas were not established.
+	// Completed metadata: fewer than Aq replicas finalized at targetLAC, so nothing
+	// establishes where the segment ends.
 	s.Lock()
 	s.doCloseWritingWithoutMetaUnsafe(ctx, targetLAC)
 	s.Unlock()

--- a/woodpecker/segment/completion_manager_test.go
+++ b/woodpecker/segment/completion_manager_test.go
@@ -157,20 +157,17 @@ func TestCompletionManager_AllRetriesExhausted(t *testing.T) {
 }
 
 // TestCompletionManager_CompleteRetriesExhaustedDoesNotPublishCompleted covers
-// the case where fence establishes a target LAC but every Complete pass has too
-// few replicas whose returned local tail covers that target. The local writer is
-// stopped, while metadata must remain Active for recovery rather than advertising
-// an uncompacted Completed segment.
+// the case where fence establishes a target LAC but no replica ever finalizes at
+// it. The local writer is stopped, while metadata must remain Active for recovery
+// rather than advertising a segment no replica has closed.
 func TestCompletionManager_CompleteRetriesExhaustedDoesNotPublishCompleted(t *testing.T) {
 	seg, mockClient := newTestSegmentForCompletion(t)
 
 	const targetLAC = int64(5)
 	mockClient.EXPECT().FenceSegment(mock.Anything, mock.Anything, mock.Anything, int64(1), int64(1)).
 		Return(targetLAC, nil).Once()
-	// Aq=1 in this fixture, but the only replica is a successfully finalized
-	// partial replica and therefore does not qualify.
 	mockClient.EXPECT().CompleteSegment(mock.Anything, mock.Anything, mock.Anything, int64(1), int64(1), targetLAC).
-		Return(targetLAC-1, nil).Times(3)
+		Return(int64(-1), assert.AnError).Times(3)
 
 	invalidated := false
 	seg.SetWriterInvalidationNotifier(context.Background(), func(ctx context.Context, reason string) {
@@ -185,6 +182,33 @@ func TestCompletionManager_CompleteRetriesExhaustedDoesNotPublishCompleted(t *te
 	assert.Equal(t, int64(-1), seg.segmentMetaCache.Load().Metadata.LastEntryId)
 	writable, _ := seg.IsWritable(context.Background())
 	assert.False(t, writable)
+}
+
+// TestCompletionManager_PartialReplicaFinalizeStillPublishesCompleted pins the
+// contract completion switched to in #320: an ack quorum of replicas must have
+// durably recorded the target LAC, not covered it locally.
+//
+// The target comes out of the fence, so some replica reported a tail at or above
+// it. That replica can be gone by the time CompleteSegment runs, leaving only
+// replicas whose own tail is short. Those entries were never acknowledged, so
+// nothing is owed on them, and refusing to publish Completed here would be worse
+// than publishing it: the segment stays Active, and OpenLogWriter fences and
+// completes every active segment before it returns a writer, so the whole log
+// would stop accepting writes until the missing replica came back.
+func TestCompletionManager_PartialReplicaFinalizeStillPublishesCompleted(t *testing.T) {
+	seg, mockClient := newTestSegmentForCompletion(t)
+
+	const targetLAC = int64(5)
+	mockClient.EXPECT().FenceSegment(mock.Anything, mock.Anything, mock.Anything, int64(1), int64(1)).
+		Return(targetLAC, nil).Once()
+	// Finalized at the target, but the replica's own tail stops one entry short.
+	mockClient.EXPECT().CompleteSegment(mock.Anything, mock.Anything, mock.Anything, int64(1), int64(1), targetLAC).
+		Return(targetLAC-1, nil).Once()
+
+	seg.completionMgr.TriggerCompletion()
+	require.NoError(t, seg.completionMgr.WaitForCompletion())
+	assert.Equal(t, proto.SegmentState_Completed, seg.segmentMetaCache.Load().Metadata.State)
+	assert.Equal(t, targetLAC, seg.segmentMetaCache.Load().Metadata.LastEntryId)
 }
 
 // TestSegmentHandle_SetRollingReady_PropagatesCompletionError verifies that when

--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -1244,10 +1244,11 @@ func (s *segmentHandleImpl) completePrepared(ctx context.Context, quorumInfo *pr
 	return s.completeSegmentQuorum(ctx, quorumInfo, lastAddConfirmed)
 }
 
-// completeSegmentQuorum sends CompleteSegment requests to all quorum nodes and
-// counts only finalized replicas whose returned local tail covers lac. A behind
-// replica may still finalize successfully for read failover, but cannot count
-// toward the Aq proof required before publishing Completed metadata.
+// completeSegmentQuorum sends CompleteSegment requests to all quorum nodes and requires
+// ackQuorum of them to finalize at lac before Completed metadata may be published. A
+// replica whose local tail stops below lac still counts: it has durably recorded the
+// boundary, which is what stops a competing writer from closing the segment elsewhere.
+// How many replicas locally cover lac is tracked separately and reported, not enforced.
 func (s *segmentHandleImpl) completeSegmentQuorum(ctx context.Context, quorumInfo *proto.QuorumInfo, lac int64) error {
 	nodeCount := len(quorumInfo.Nodes)
 	ackQuorum := int(quorumInfo.Aq)
@@ -1565,9 +1566,10 @@ func (s *segmentHandleImpl) resolveFenceLAC(results []int64, writeQuorum, ackQuo
 	// (#320).
 	//
 	// Because a missing reply is not evidence, a target chosen this way may turn out to be held by
-	// fewer than ackQuorum replicas. completeSegmentQuorum rejects that rather than lowering the
-	// boundary, and the attempt is retried once more replicas answer: failing to complete is
-	// recoverable, publishing a boundary below acknowledged data is not.
+	// fewer than ackQuorum replicas. That is allowed: completeSegmentQuorum requires ackQuorum
+	// replicas to finalize at the target, not to cover it, precisely so this target can be used.
+	// The entries above the covered tail were never acknowledged, so nothing is owed on them;
+	// publishing a boundary below acknowledged data, by contrast, is unrecoverable.
 	// A quorum where Aq exceeds Wq is not satisfiable -- no entry can ever collect more acks than
 	// the replicas it was written to -- and would make the index below negative. Config derives
 	// Aq as Wq/2+1 so this cannot arise from a valid configuration, but recovery must not panic

--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -1302,9 +1302,25 @@ func (s *segmentHandleImpl) completeSegmentQuorum(ctx context.Context, quorumInf
 		}
 	}
 
-	// Check if we have enough successful responses for ack quorum
-	if len(qualifiedResults) < ackQuorum {
-		logger.Ctx(ctx).Warn("Insufficient qualified responses for quorum complete",
+	// Require the boundary to be durably recorded by an ack quorum of replicas, not to be
+	// covered by one.
+	//
+	// Aq is the threshold a write had to clear to be acknowledged. It says nothing about how the
+	// data is distributed once the writer is gone, and treating it as a requirement on coverage
+	// at recovery time is what made this check unsatisfiable: resolveFenceLAC returns the highest
+	// tail that cannot be shown to be below the acknowledged boundary, and when a fence reply is
+	// missing that tail may be held by a single replica. The entries in question were never
+	// acknowledged, so nothing is owed on them; they become durable when compaction moves the
+	// segment to object storage.
+	//
+	// What completion does have to establish is that enough replicas durably recorded this
+	// boundary, so a competing writer cannot close the segment at a different one. That is
+	// finalizedResults. qualifiedResults is kept for the operator-facing count below: a
+	// completion covered by fewer than ackQuorum replicas is worth seeing, but it is not a
+	// failure -- failing here would leave the log unable to open a writer at all, since
+	// OpenLogWriter fences and completes every active segment first.
+	if len(finalizedResults) < ackQuorum {
+		logger.Ctx(ctx).Warn("Insufficient finalized responses for quorum complete",
 			zap.String("logName", s.logName),
 			zap.Int64("logId", s.logId),
 			zap.Int64("segmentId", s.segmentId),
@@ -1312,8 +1328,20 @@ func (s *segmentHandleImpl) completeSegmentQuorum(ctx context.Context, quorumInf
 			zap.Int("qualifiedCount", len(qualifiedResults)),
 			zap.Int("requiredAckQuorum", ackQuorum))
 		return werr.ErrAppendOpQuorumFailed.WithCauseErrMsg(
-			fmt.Sprintf("insufficient qualified complete responses: qualified=%d finalized=%d required=%d lastError=%v",
-				len(qualifiedResults), len(finalizedResults), ackQuorum, lastError))
+			fmt.Sprintf("insufficient finalized complete responses: finalized=%d qualified=%d required=%d lastError=%v",
+				len(finalizedResults), len(qualifiedResults), ackQuorum, lastError))
+	}
+
+	if len(qualifiedResults) < ackQuorum {
+		logger.Ctx(ctx).Warn("Segment completed with fewer covering replicas than the ack quorum; "+
+			"the tail is durable on those replicas until compaction uploads the segment",
+			zap.String("logName", s.logName),
+			zap.Int64("logId", s.logId),
+			zap.Int64("segmentId", s.segmentId),
+			zap.Int64("targetLAC", lac),
+			zap.Int("finalizedCount", len(finalizedResults)),
+			zap.Int("qualifiedCount", len(qualifiedResults)),
+			zap.Int("ackQuorum", ackQuorum))
 	}
 
 	logger.Ctx(ctx).Info("Quorum complete responses collected",

--- a/woodpecker/segment/segment_handle.go
+++ b/woodpecker/segment/segment_handle.go
@@ -1512,24 +1512,48 @@ func (s *segmentHandleImpl) completeSegmentOnNode(ctx context.Context, node stri
 	}
 }
 
-// resolveFenceLAC picks the completion target from the fence responses: the highest
-// entry ID that at least ackQuorum responding replicas hold. Sorted ascending, that is
-// the ackQuorum-th largest element, so exactly ackQuorum replicas cover it and no
-// larger value does.
+// resolveFenceLAC picks the completion target from the fence responses: the highest entry ID that
+// cannot be shown to be below the acknowledged boundary. Sorted ascending, that is the element at
+// index writeQuorum-ackQuorum -- skipping the replies that may legitimately be missing an
+// acknowledged entry.
 //
-// Every element is a successful fence response -- failed nodes take the result.err
-// branch and never reach here -- so a -1 is an honest "I hold nothing" vote against
-// every entry ID >= 0 and must be counted. Dropping it would shrink the sample while
-// ackQuorum stays fixed, and the resulting target could exceed what any ack quorum
-// covers; completion would then retry forever, because a behind replica has no way to
-// catch up to an entry it never received.
+// The boundary is a fact about the replicas, not about the replies. An entry is acknowledged once
+// at least ackQuorum replicas hold it, so at most writeQuorum-ackQuorum of them can be without it.
+// A replica that did not answer is unknown, not empty, so the count of possibly-missing replies is
+// that same tolerance whatever the reply count -- which is why the index does not depend on it.
 //
-// Fewer than ackQuorum responses means no value can be shown to have quorum coverage,
-// which is a failure to prove rather than a reason to pick a smaller element.
-func (s *segmentHandleImpl) resolveFenceLAC(results []int64, ackQuorum int) (int64, error) {
-	if len(results) < ackQuorum {
+// Every element is a successful fence response -- failed nodes take the result.err branch and never
+// reach here -- so a -1 is an honest "I hold nothing" and must be counted like any other value.
+//
+// Fewer replies than the tolerance leaves nothing to conclude: even the highest reply could be the
+// one stale replica. That is a failure to prove rather than a reason to pick a smaller element.
+func (s *segmentHandleImpl) resolveFenceLAC(results []int64, writeQuorum, ackQuorum int) (int64, error) {
+	// The tolerance is the same one the append path spends before giving up, at Wq-Aq+1 failures.
+	//
+	// This used to index by len(results)-ackQuorum, which equals it only when every replica
+	// replied; one missing reply shifted it down a position and published a boundary below
+	// acknowledged data. With tails [0,0,-1] and Aq=2, a failed fence reply from the second
+	// replica left [0,-1] and selected -1, dropping an entry the client had been told was durable
+	// (#320).
+	//
+	// Because a missing reply is not evidence, a target chosen this way may turn out to be held by
+	// fewer than ackQuorum replicas. completeSegmentQuorum rejects that rather than lowering the
+	// boundary, and the attempt is retried once more replicas answer: failing to complete is
+	// recoverable, publishing a boundary below acknowledged data is not.
+	// A quorum where Aq exceeds Wq is not satisfiable -- no entry can ever collect more acks than
+	// the replicas it was written to -- and would make the index below negative. Config derives
+	// Aq as Wq/2+1 so this cannot arise from a valid configuration, but recovery must not panic
+	// its way through a malformed one.
+	if writeQuorum < ackQuorum || ackQuorum <= 0 {
 		return -1, werr.ErrAppendOpQuorumFailed.WithCauseErrMsg(
-			fmt.Sprintf("insufficient successful fence responses: got %d, need %d", len(results), ackQuorum))
+			fmt.Sprintf("inconsistent quorum for fence resolution: writeQuorum %d, ackQuorum %d", writeQuorum, ackQuorum))
+	}
+
+	missingTolerated := writeQuorum - ackQuorum
+	if len(results) <= missingTolerated {
+		return -1, werr.ErrAppendOpQuorumFailed.WithCauseErrMsg(
+			fmt.Sprintf("insufficient successful fence responses: got %d, need more than %d (writeQuorum %d - ackQuorum %d)",
+				len(results), missingTolerated, writeQuorum, ackQuorum))
 	}
 
 	// Sort a copy in ascending order, leaving the caller's slice untouched.
@@ -1539,7 +1563,7 @@ func (s *segmentHandleImpl) resolveFenceLAC(results []int64, ackQuorum int) (int
 		return sorted[i] < sorted[j]
 	})
 
-	return sorted[len(sorted)-ackQuorum], nil
+	return sorted[missingTolerated], nil
 }
 
 // fenceSegmentQuorum sends FenceSegment requests to all quorum nodes
@@ -1590,7 +1614,7 @@ func (s *segmentHandleImpl) fenceSegmentQuorum(ctx context.Context, quorumInfo *
 
 	// Resolve the completion target from the successful responses. This also enforces
 	// that enough nodes responded to prove quorum coverage in the first place.
-	lac, resolveErr := s.resolveFenceLAC(successResults, ackQuorum)
+	lac, resolveErr := s.resolveFenceLAC(successResults, int(quorumInfo.Wq), ackQuorum)
 	if resolveErr != nil {
 		logger.Ctx(ctx).Warn("Insufficient successful responses for quorum fence",
 			zap.String("logName", s.logName),

--- a/woodpecker/segment/segment_handle_complete_test.go
+++ b/woodpecker/segment/segment_handle_complete_test.go
@@ -44,19 +44,32 @@ type completeNodeResponse struct {
 //
 // Each replica response belongs to exactly one class:
 //   - Q (qualified): Finalize RPC succeeds and local LastEntryId >= target LAC.
-//   - P (partial): Finalize RPC succeeds but local LastEntryId < target LAC.
-//     The replica is durably frozen for read failover, but does not count toward Aq.
-//   - E (error): client acquisition or Finalize RPC fails and does not count toward Aq.
+//   - P (partial): Finalize RPC succeeds but local LastEntryId < target LAC. The replica has
+//     durably recorded the boundary even though its own data stops short of it.
+//   - E (error): client acquisition or Finalize RPC fails, so the replica recorded nothing.
 //
-// Completion succeeds iff the number of Q responses reaches Aq. Node ordering is
-// intentionally not enumerated because responses are collected concurrently and
-// the decision depends only on the qualified count.
+// Completion succeeds iff Q+P reaches Aq: what has to be established is that an ack quorum of
+// replicas durably recorded this boundary, so a competing writer cannot close the segment at a
+// different one. Coverage is a separate question. Aq was the threshold a write had to clear to be
+// acknowledged; it is not a requirement on how the data is distributed once the writer is gone,
+// and resolveFenceLAC deliberately returns the highest tail that cannot be shown to be below the
+// acknowledged boundary -- with a fence reply missing, that tail may be held by a single replica.
+// Those entries were never acknowledged, so nothing is owed on them; they become durable when
+// compaction uploads the segment. Requiring Aq coverage here instead would fail the completion
+// after every replica had already frozen its footer at the target, leaving no target reachable on
+// any later attempt and the log unable to open a writer at all.
+//
+// Node ordering is intentionally not enumerated because responses are collected concurrently and
+// the decision depends only on the counts.
 //
 // For the canonical Es=3, Aq=2 matrix (order-independent):
 //
-//	QQQ, QQP, QQE  -> success
-//	QPP, QPE, QEE  -> failure
-//	PPP, PPE, PEE, EEE -> failure
+//	QQQ, QQP, QQE, QPP, QPE, PPE  -> success
+//	QEE, PEE, EEE                 -> failure
+//
+// PPP cannot occur. The target is always one of the fence replies, so some replica reported a tail
+// at or above it, and a replica's tail never shrinks -- that replica answers Q or fails outright as
+// E. It is covered below only to keep the function total.
 //
 // The cases below also cover Aq=1/Aq=Es boundaries, client acquisition errors,
 // the empty-segment LAC sentinel (-1), and the first valid entry ID (0).
@@ -76,23 +89,25 @@ func TestCompleteSegmentQuorum_ResponseMatrix(t *testing.T) {
 		{name: "Q ahead P succeeds", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{5, nil, nil}, {6, nil, nil}, {4, nil, nil}}},
 		{name: "Q Q E succeeds", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{5, nil, nil}, {5, nil, nil}, {-1, completeFailure, nil}}},
 		{name: "Q Q client error succeeds", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{5, nil, nil}, {5, nil, nil}, {-1, nil, clientFailure}}},
-		{name: "Q P P fails", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{5, nil, nil}, {4, nil, nil}, {3, nil, nil}}, wantErr: true},
-		{name: "Q P E fails", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{5, nil, nil}, {4, nil, nil}, {-1, completeFailure, nil}}, wantErr: true},
+		{name: "Q P P succeeds", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{5, nil, nil}, {4, nil, nil}, {3, nil, nil}}},
+		{name: "Q P E succeeds", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{5, nil, nil}, {4, nil, nil}, {-1, completeFailure, nil}}},
 		{name: "Q E E fails", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{5, nil, nil}, {-1, completeFailure, nil}, {-1, completeFailure, nil}}, wantErr: true},
-		{name: "P P P fails", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{4, nil, nil}, {3, nil, nil}, {2, nil, nil}}, wantErr: true},
-		{name: "P P E fails", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{4, nil, nil}, {3, nil, nil}, {-1, completeFailure, nil}}, wantErr: true},
+		// Unreachable in practice (see the doc comment); kept so the function stays total.
+		{name: "P P P succeeds", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{4, nil, nil}, {3, nil, nil}, {2, nil, nil}}},
+		// The reachable no-Q case: the replica holding the target is unreachable at complete time.
+		{name: "P P E succeeds", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{4, nil, nil}, {3, nil, nil}, {-1, completeFailure, nil}}},
 		{name: "P E E fails", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{4, nil, nil}, {-1, completeFailure, nil}, {-1, completeFailure, nil}}, wantErr: true},
 		{name: "E E E fails", targetLAC: 5, aq: 2, responses: []completeNodeResponse{{-1, completeFailure, nil}, {-1, completeFailure, nil}, {-1, completeFailure, nil}}, wantErr: true},
 
 		// Ack-quorum boundaries.
-		{name: "Aq one needs one qualified", targetLAC: 5, aq: 1, responses: []completeNodeResponse{{5, nil, nil}, {4, nil, nil}, {-1, completeFailure, nil}}},
+		{name: "Aq one needs one recorded boundary", targetLAC: 5, aq: 1, responses: []completeNodeResponse{{5, nil, nil}, {4, nil, nil}, {-1, completeFailure, nil}}},
 		{name: "Aq all requires every replica qualified", targetLAC: 5, aq: 3, responses: []completeNodeResponse{{5, nil, nil}, {5, nil, nil}, {5, nil, nil}}},
-		{name: "Aq all rejects one partial", targetLAC: 5, aq: 3, responses: []completeNodeResponse{{5, nil, nil}, {5, nil, nil}, {4, nil, nil}}, wantErr: true},
+		{name: "Aq all accepts one partial that recorded the boundary", targetLAC: 5, aq: 3, responses: []completeNodeResponse{{5, nil, nil}, {5, nil, nil}, {4, nil, nil}}},
 
 		// LAC sentinel and first-entry boundaries.
 		{name: "empty target minus one counts empty replicas", targetLAC: -1, aq: 2, responses: []completeNodeResponse{{-1, nil, nil}, {-1, nil, nil}, {-1, nil, nil}}},
 		{name: "entry zero target has two qualified replicas", targetLAC: 0, aq: 2, responses: []completeNodeResponse{{0, nil, nil}, {0, nil, nil}, {-1, nil, nil}}},
-		{name: "entry zero target with one qualified fails", targetLAC: 0, aq: 2, responses: []completeNodeResponse{{0, nil, nil}, {-1, nil, nil}, {-1, completeFailure, nil}}, wantErr: true},
+		{name: "entry zero target with one qualified and one partial succeeds", targetLAC: 0, aq: 2, responses: []completeNodeResponse{{0, nil, nil}, {-1, nil, nil}, {-1, completeFailure, nil}}},
 	}
 
 	for _, tt := range tests {

--- a/woodpecker/segment/segment_handle_test.go
+++ b/woodpecker/segment/segment_handle_test.go
@@ -3157,101 +3157,138 @@ func TestResolveFenceLAC(t *testing.T) {
 	s := &segmentHandleImpl{}
 
 	tests := []struct {
-		name      string
-		results   []int64
-		ackQuorum int
-		expected  int64
-		wantErr   bool
+		name        string
+		results     []int64
+		writeQuorum int
+		ackQuorum   int
+		expected    int64
+		wantErr     bool
 	}{
 		{
-			name:      "normal 3 nodes",
-			results:   []int64{4, 6, 7},
-			ackQuorum: 2,
-			expected:  6,
+			name:        "normal 3 nodes",
+			results:     []int64{4, 6, 7},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			expected:    6,
 		},
 		{
-			name:      "all same value",
-			results:   []int64{5, 5, 5},
-			ackQuorum: 2,
-			expected:  5,
+			name:        "all same value",
+			results:     []int64{5, 5, 5},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			expected:    5,
 		},
 		{
-			// Entry 0 lives on a single replica, so it was never acked and cannot
-			// become the completion target: only that one replica could ever cover it.
-			name:      "one node empty holds the target back",
-			results:   []int64{0, -1},
-			ackQuorum: 2,
-			expected:  -1,
+			// Two of three replicas answered. Entry 0 may also be on the replica that did
+			// not answer, in which case it reached ack quorum and the client was told so.
+			// A missing reply is not evidence that the entry is absent, so the target may
+			// not be lowered past it. This is the history in #320: selecting -1 here
+			// published an empty segment over an acknowledged write.
+			name:        "missing reply may not lower the target",
+			results:     []int64{0, -1},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			expected:    0,
 		},
 		{
-			// The production wedge: fence saw [0,-1,-1] and returned 0, which only one
-			// of three replicas could finalize at, so completion never reached quorum.
-			name:      "regression: fence with [0, -1, -1] ackQuorum=2",
-			results:   []int64{0, -1, -1},
-			ackQuorum: 2,
-			expected:  -1,
+			// All three replicas answered, so the evidence is complete: entry 0 really is
+			// on one replica only and was never acked. Lowering to -1 is correct, and this
+			// is the case an earlier fix was written for -- a target of 0 could only ever
+			// be finalized by one replica, so completion never reached quorum.
+			name:        "complete evidence may lower the target",
+			results:     []int64{0, -1, -1},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			expected:    -1,
 		},
 		{
-			name:      "two valid one empty",
-			results:   []int64{-1, 0, 0},
-			ackQuorum: 2,
-			expected:  0,
+			name:        "two valid one empty",
+			results:     []int64{-1, 0, 0},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			expected:    0,
 		},
 		{
-			name:      "multiple entries with one empty node",
-			results:   []int64{2, -1},
-			ackQuorum: 2,
-			expected:  -1,
+			// Same shape as the #320 case: only two replies, so entry 2 may be on the
+			// silent replica as well.
+			name:        "multiple entries with one silent replica",
+			results:     []int64{2, -1},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			expected:    2,
 		},
 		{
-			name:      "all nodes empty",
-			results:   []int64{-1, -1},
-			ackQuorum: 2,
-			expected:  -1,
+			name:        "all nodes empty",
+			results:     []int64{-1, -1},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			expected:    -1,
 		},
 		{
-			name:      "single empty node",
-			results:   []int64{-1},
-			ackQuorum: 1,
-			expected:  -1,
+			name:        "single empty node",
+			results:     []int64{-1},
+			writeQuorum: 1,
+			ackQuorum:   1,
+			expected:    -1,
 		},
 		{
-			name:      "empty results cannot prove coverage",
-			results:   []int64{},
-			ackQuorum: 2,
-			wantErr:   true,
+			name:        "empty results cannot prove coverage",
+			results:     []int64{},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			wantErr:     true,
 		},
 		{
-			name:      "single valid node",
-			results:   []int64{0},
-			ackQuorum: 1,
-			expected:  0,
+			name:        "single valid node",
+			results:     []int64{0},
+			writeQuorum: 1,
+			ackQuorum:   1,
+			expected:    0,
 		},
 		{
-			// Fewer responses than the ack quorum proves nothing; the old clamp
-			// returned 3 here, a target only one replica could ever cover.
-			name:      "fewer responses than ackQuorum cannot prove coverage",
-			results:   []int64{3},
-			ackQuorum: 2,
-			wantErr:   true,
+			// One reply out of three leaves two silent replicas, more than the one that may
+			// legitimately be missing an acknowledged entry, so nothing can be concluded.
+			name:        "too few replies to skip the tolerated missing replicas",
+			results:     []int64{3},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			wantErr:     true,
 		},
 		{
-			name:      "three valid nodes ackQuorum=2",
-			results:   []int64{10, 8, 5},
-			ackQuorum: 2,
-			expected:  8,
+			name:        "three valid nodes ackQuorum=2",
+			results:     []int64{10, 8, 5},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			expected:    8,
 		},
 		{
-			name:      "negative sentinel other than -1",
-			results:   []int64{0, -2, 3},
-			ackQuorum: 2,
-			expected:  0,
+			name:        "negative sentinel other than -1",
+			results:     []int64{0, -2, 3},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			expected:    0,
 		},
 		{
-			name:      "does not mutate input",
-			results:   []int64{7, 3, 5},
-			ackQuorum: 2,
-			expected:  5,
+			name:        "does not mutate input",
+			results:     []int64{7, 3, 5},
+			writeQuorum: 3,
+			ackQuorum:   2,
+			expected:    5,
+		},
+		{
+			// Five replicas tolerate two missing an acknowledged entry.
+			name:        "five replicas all answered",
+			results:     []int64{9, 7, 5, 3, 1},
+			writeQuorum: 5,
+			ackQuorum:   3,
+			expected:    5,
+		},
+		{
+			name:        "five replicas two silent",
+			results:     []int64{9, 7, 5},
+			writeQuorum: 5,
+			ackQuorum:   3,
+			expected:    9,
 		},
 	}
 
@@ -3261,7 +3298,7 @@ func TestResolveFenceLAC(t *testing.T) {
 			original := make([]int64, len(tt.results))
 			copy(original, tt.results)
 
-			got, err := s.resolveFenceLAC(tt.results, tt.ackQuorum)
+			got, err := s.resolveFenceLAC(tt.results, tt.writeQuorum, tt.ackQuorum)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Equal(t, int64(-1), got)
@@ -3276,55 +3313,108 @@ func TestResolveFenceLAC(t *testing.T) {
 	}
 }
 
-// TestResolveFenceLACCoverageInvariant exhaustively checks the property the completion
-// path depends on: the returned target must be covered by at least ackQuorum responding
-// replicas, and must be the largest value with that coverage. A target above the bound
-// can never be met -- a behind replica has no way to catch up to an entry it never
-// received -- so completion would retry forever and wedge the log.
-func TestResolveFenceLACCoverageInvariant(t *testing.T) {
+// TestResolveFenceLACNeverDropsAcknowledgedData exhaustively checks the property recovery exists
+// to uphold: whatever subset of replicas answers the fence, the selected target is never below the
+// boundary the client was told was durable.
+//
+// The acknowledged boundary is a fact about the replicas, not about the replies: an entry is
+// acknowledged once at least Aq replicas hold it. A replica that does not answer is unknown, not
+// empty, so at most Wq-Aq of the answers may legitimately be missing an acknowledged entry -- the
+// same tolerance the append path spends before it gives up. Indexing by that count holds for every
+// quorum shape; the previous len(results)-ackQuorum held only when every replica answered, which
+// is how #320 published an empty segment over an acknowledged write.
+//
+// Odd and even write quorums are both covered even though the config currently offers only 3 and 5,
+// because the two differ: at Wq=4 the tolerance is 1 while ackQuorum-1 would be 2.
+func TestResolveFenceLACNeverDropsAcknowledgedData(t *testing.T) {
 	s := &segmentHandleImpl{}
-	values := []int64{-1, 0, 1, 3}
+	domain := []int64{-1, 0, 1}
 
-	coveredBy := func(results []int64, v int64) int {
-		n := 0
-		for _, r := range results {
-			if r >= v {
-				n++
+	// acknowledgedBoundary is the highest entry id held by at least ackQuorum replicas.
+	acknowledgedBoundary := func(tails []int64, ackQuorum int) int64 {
+		best := int64(-1)
+		for _, candidate := range tails {
+			held := 0
+			for _, tail := range tails {
+				if tail >= candidate {
+					held++
+				}
+			}
+			if held >= ackQuorum && candidate > best {
+				best = candidate
 			}
 		}
-		return n
+		return best
 	}
 
-	var walk func(prefix []int64, depth int)
-	walk = func(prefix []int64, depth int) {
-		if depth == 0 {
-			for ackQuorum := 1; ackQuorum <= len(prefix); ackQuorum++ {
-				lac, err := s.resolveFenceLAC(prefix, ackQuorum)
-				if !assert.NoError(t, err, "results=%v ackQuorum=%d", prefix, ackQuorum) {
-					continue
+	for writeQuorum := 3; writeQuorum <= 7; writeQuorum++ {
+		ackQuorum := writeQuorum/2 + 1
+		missingTolerated := writeQuorum - ackQuorum
+
+		t.Run(fmt.Sprintf("wq_%d_aq_%d", writeQuorum, ackQuorum), func(t *testing.T) {
+			tails := make([]int64, writeQuorum)
+
+			var walk func(depth int)
+			walk = func(depth int) {
+				if depth < writeQuorum {
+					for _, v := range domain {
+						tails[depth] = v
+						walk(depth + 1)
+					}
+					return
 				}
 
-				assert.GreaterOrEqual(t, coveredBy(prefix, lac), ackQuorum,
-					"results=%v ackQuorum=%d: lac=%d is covered by too few replicas", prefix, ackQuorum, lac)
+				acked := acknowledgedBoundary(tails, ackQuorum)
 
-				// No larger candidate may reach the same coverage, i.e. lac is maximal
-				// and the fence is not truncating acked data.
-				for _, cand := range prefix {
-					if cand > lac {
-						assert.Less(t, coveredBy(prefix, cand), ackQuorum,
-							"results=%v ackQuorum=%d: lac=%d but %d also has quorum coverage", prefix, ackQuorum, lac, cand)
+				// Every subset of replicas that could have answered the fence.
+				for mask := 0; mask < 1<<writeQuorum; mask++ {
+					replies := make([]int64, 0, writeQuorum)
+					for i := 0; i < writeQuorum; i++ {
+						if mask&(1<<i) != 0 {
+							replies = append(replies, tails[i])
+						}
+					}
+
+					lac, err := s.resolveFenceLAC(replies, writeQuorum, ackQuorum)
+					if len(replies) <= missingTolerated {
+						assert.Error(t, err, "tails=%v replies=%v: too few replies must not yield a target", tails, replies)
+						continue
+					}
+					if !assert.NoError(t, err, "tails=%v replies=%v", tails, replies) {
+						continue
+					}
+
+					assert.GreaterOrEqual(t, lac, acked,
+						"tails=%v replies=%v: selected %d, below the acknowledged boundary %d", tails, replies, lac, acked)
+
+					// With every replica answering the evidence is complete, so the target is
+					// exactly the acknowledged boundary -- no lower (data loss) and no higher
+					// (a target too few replicas can finalize, which wedges completion).
+					if len(replies) == writeQuorum {
+						assert.Equal(t, acked, lac, "tails=%v: complete evidence should select the acknowledged boundary", tails)
 					}
 				}
 			}
-			return
-		}
-		for _, v := range values {
-			walk(append(prefix, v), depth-1)
-		}
+			walk(0)
+		})
 	}
+}
 
-	for n := 1; n <= 4; n++ {
-		walk(make([]int64, 0, n), n)
+// TestResolveFenceLACIssue320 is the reported history: three replicas, tails [0,0,-1] so entry 0
+// reached ack quorum and the client was told it was durable, then the fence RPC to the second
+// replica fails. The surviving replies are [0,-1].
+func TestResolveFenceLACIssue320(t *testing.T) {
+	s := &segmentHandleImpl{}
+
+	lac, err := s.resolveFenceLAC([]int64{0, -1}, 3, 2)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), lac, "the acknowledged entry must survive a failed fence reply")
+
+	// Rotating which replica is empty and which fence reply is lost must not change that.
+	for _, replies := range [][]int64{{-1, 0}, {0, -1}} {
+		got, err := s.resolveFenceLAC(replies, 3, 2)
+		assert.NoError(t, err)
+		assert.Equal(t, int64(0), got, "replies=%v", replies)
 	}
 }
 
@@ -5750,11 +5840,18 @@ func TestFenceSegmentQuorum_InsufficientResponses(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestFenceSegmentQuorum_FewerNodesThanAckQuorum covers the case where every node
-// answers successfully yet the responses still cannot prove ack-quorum coverage, so
-// there is no node error to surface. Fence must refuse rather than hand completion a
-// target only a minority of replicas holds.
-func TestFenceSegmentQuorum_FewerNodesThanAckQuorum(t *testing.T) {
+// TestFenceSegmentQuorum_PartialRepliesBelowTolerance covers the shape that is not "everything
+// failed": a valid three-replica quorum where one node answers and two do not. An acknowledged
+// entry can be missing from at most Wq-Aq = 1 replica, so a single reply leaves two unknowns --
+// more than the tolerance -- and even that reply could be the stale one. Fence must refuse rather
+// than hand completion a target derived from insufficient evidence.
+//
+// The surfaced error is the node failure, not the resolve error: with a valid quorum every result
+// is either an error or a success, so too few successes always implies at least one node error,
+// and fence prefers it as the root cause. That also means the resolve error is only reachable
+// through a malformed quorum or a cancelled collection, which is why the tolerance guard itself is
+// covered by unit tests on resolveFenceLAC rather than from here.
+func TestFenceSegmentQuorum_PartialRepliesBelowTolerance(t *testing.T) {
 	mockMetadata := mocks_meta.NewMetadataProvider(t)
 	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
 	cfg := &config.Configuration{
@@ -5765,10 +5862,13 @@ func TestFenceSegmentQuorum_FewerNodesThanAckQuorum(t *testing.T) {
 		},
 	}
 
+	// node1 answers; node2 and node3 do not.
 	mockClient := mocks_logstore_client.NewLogStoreClient(t)
-	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, mock.Anything).Return(mockClient, nil)
 	mockClient.EXPECT().FenceSegment(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(int64(5), nil)
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, "node1").Return(mockClient, nil)
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, "node2").Return(nil, errors.New("conn error"))
+	mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, "node3").Return(nil, errors.New("conn error"))
 
 	segmentMeta := &meta.SegmentMeta{
 		Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Active, LastEntryId: -1},
@@ -5777,12 +5877,11 @@ func TestFenceSegmentQuorum_FewerNodesThanAckQuorum(t *testing.T) {
 	sh := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, false, nil)
 	impl := sh.(*segmentHandleImpl)
 
-	// One node cannot establish coverage for an ack quorum of two.
-	quorum := &proto.QuorumInfo{Id: 1, Es: 1, Aq: 2, Wq: 1, Nodes: []string{"node1"}}
+	quorum := &proto.QuorumInfo{Id: 1, Es: 3, Aq: 2, Wq: 3, Nodes: []string{"node1", "node2", "node3"}}
 	lastEntryId, err := impl.fenceSegmentQuorum(context.Background(), quorum)
 	assert.Error(t, err)
 	assert.Equal(t, int64(-1), lastEntryId)
-	assert.Contains(t, err.Error(), "insufficient successful fence responses")
+	assert.Contains(t, err.Error(), "conn error", "the node failure should surface as the root cause")
 }
 
 // === syncLACToQuorumAsync tests ===
@@ -6648,5 +6747,30 @@ func TestSyncLACToQuorumAsync_BoundedWhenNodeHangs(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("syncLACToQuorumAsync did not return: a hung node wedged the LAC syncer")
+	}
+}
+
+// TestResolveFenceLACRejectsInconsistentQuorum pins the guard directly: an ack quorum above the
+// write quorum makes the tolerance Wq-Aq negative, which would index before the start of the
+// sorted replies. Recovery must return an error rather than panic on a malformed quorum.
+func TestResolveFenceLACRejectsInconsistentQuorum(t *testing.T) {
+	s := &segmentHandleImpl{}
+
+	for _, tc := range []struct {
+		name        string
+		writeQuorum int
+		ackQuorum   int
+	}{
+		{"ack quorum above write quorum", 1, 2},
+		{"ack quorum far above write quorum", 3, 9},
+		{"zero ack quorum", 3, 0},
+		{"negative ack quorum", 3, -1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			lac, err := s.resolveFenceLAC([]int64{5, 5, 5}, tc.writeQuorum, tc.ackQuorum)
+			assert.Error(t, err)
+			assert.Equal(t, int64(-1), lac)
+			assert.Contains(t, err.Error(), "inconsistent quorum")
+		})
 	}
 }

--- a/woodpecker/segment/segment_handle_test.go
+++ b/woodpecker/segment/segment_handle_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/zilliztech/woodpecker/common/channel"
 	"github.com/zilliztech/woodpecker/common/config"
@@ -6773,4 +6774,133 @@ func TestResolveFenceLACRejectsInconsistentQuorum(t *testing.T) {
 			assert.Contains(t, err.Error(), "inconsistent quorum")
 		})
 	}
+}
+
+// TestCompleteSegmentQuorum_TargetHeldByOneReplica covers the shape recovery now produces when a
+// fence reply is missing: the target is the highest tail that cannot be shown to be below the
+// acknowledged boundary, and only one replica holds data up to it.
+//
+// Requiring an ack quorum of covering replicas here would fail the completion -- after every
+// replica had already frozen its footer at that target. No later attempt could then succeed: the
+// target itself can never gather more coverage, and a lower one is rejected by the frozen footers.
+// Since OpenLogWriter fences and completes every active segment before it returns, that would
+// leave the whole log unable to accept a writer, to avoid carrying entries that were never
+// acknowledged in the first place.
+func TestCompleteSegmentQuorum_TargetHeldByOneReplica(t *testing.T) {
+	mockMetadata := mocks_meta.NewMetadataProvider(t)
+	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	cfg := &config.Configuration{
+		Woodpecker: config.WoodpeckerConfig{
+			Client: config.ClientConfig{
+				SegmentAppend: config.SegmentAppendConfig{QueueSize: 10, MaxRetries: 2},
+			},
+		},
+	}
+
+	// Replica tails [1,0,0]: entry 1 reached a single replica and was never acknowledged.
+	// Recovery targets 1 after a fence reply went missing.
+	for node, tail := range map[string]int64{"node1": 1, "node2": 0, "node3": 0} {
+		cli := mocks_logstore_client.NewLogStoreClient(t)
+		cli.EXPECT().CompleteSegment(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(tail, nil)
+		mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, node).Return(cli, nil)
+	}
+
+	segmentMeta := &meta.SegmentMeta{
+		Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Active, LastEntryId: -1},
+		Revision: 1,
+	}
+	sh := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, false, nil)
+	impl := sh.(*segmentHandleImpl)
+
+	quorum := &proto.QuorumInfo{Id: 1, Es: 3, Aq: 2, Wq: 3, Nodes: []string{"node1", "node2", "node3"}}
+	err := impl.completeSegmentQuorum(context.Background(), quorum, 1)
+	assert.NoError(t, err, "all three replicas recorded the boundary, so the segment must close")
+}
+
+// TestFenceAndComplete_PartialFenceDoesNotWedgeFinalizedReplicas walks the whole
+// recovery path -- fence, then complete -- against replicas that behave like
+// StagedFileWriter: Finalize burns the target LAC into a durable footer, and a
+// later Finalize at a different LAC is refused with ErrInvalidLACAlignment.
+//
+// Tails are [1,0,0] and one tail-0 replica is unreachable, so the fence sees
+// [1,0] and targets 1 -- a boundary a single replica covers. Completion has to
+// succeed on this pass. If it did not, the replicas finalized at 1 would outlive
+// it, the next fence would see every reply and target 0, and every one of those
+// footers would reject 0: the segment could never close, on this process or any
+// later one. The second half of this test runs exactly that pass to show it.
+func TestFenceAndComplete_PartialFenceDoesNotWedgeFinalizedReplicas(t *testing.T) {
+	mockMetadata := mocks_meta.NewMetadataProvider(t)
+	mockClientPool := mocks_logstore_client.NewLogStoreClientPool(t)
+	cfg := &config.Configuration{
+		Woodpecker: config.WoodpeckerConfig{
+			Client: config.ClientConfig{
+				SegmentAppend: config.SegmentAppendConfig{QueueSize: 10, MaxRetries: 2},
+			},
+		},
+	}
+
+	const notFinalized = int64(-2)
+	type replica struct {
+		tail      int64
+		footer    int64
+		reachable bool
+	}
+	replicas := map[string]*replica{
+		"node1": {tail: 1, footer: notFinalized, reachable: true},
+		"node2": {tail: 0, footer: notFinalized, reachable: false}, // missed the fence
+		"node3": {tail: 0, footer: notFinalized, reachable: true},
+	}
+
+	for node, r := range replicas {
+		r := r
+		cli := mocks_logstore_client.NewLogStoreClient(t)
+		cli.EXPECT().FenceSegment(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, bucket, root string, logId, segId int64) (int64, error) {
+				if !r.reachable {
+					return -1, errors.New("node unreachable")
+				}
+				return r.tail, nil
+			})
+		cli.EXPECT().CompleteSegment(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			RunAndReturn(func(ctx context.Context, bucket, root string, logId, segId, lac int64) (int64, error) {
+				if !r.reachable {
+					return -1, errors.New("node unreachable")
+				}
+				if r.footer != notFinalized && r.footer != lac {
+					return -1, werr.ErrInvalidLACAlignment.WithCauseErrMsg(
+						fmt.Sprintf("footer already finalized at %d, refusing %d", r.footer, lac))
+				}
+				r.footer = lac
+				return r.tail, nil
+			})
+		mockClientPool.EXPECT().GetLogStoreClient(mock.Anything, node).Return(cli, nil)
+	}
+
+	segmentMeta := &meta.SegmentMeta{
+		Metadata: &proto.SegmentMetadata{SegNo: 1, State: proto.SegmentState_Active, LastEntryId: -1},
+		Revision: 1,
+	}
+	sh := NewSegmentHandle(context.Background(), 1, "testLog", segmentMeta, mockMetadata, mockClientPool, cfg, false, nil)
+	impl := sh.(*segmentHandleImpl)
+	quorum := &proto.QuorumInfo{Id: 1, Es: 3, Aq: 2, Wq: 3, Nodes: []string{"node1", "node2", "node3"}}
+	ctx := context.Background()
+
+	// Pass 1: one replica silent at fence.
+	lac, err := impl.fenceSegmentQuorum(ctx, quorum)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), lac, "a silent replica is unknown, not empty, so the target stays at 1")
+	require.NoError(t, impl.completeSegmentQuorum(ctx, quorum, lac),
+		"two replicas recorded the boundary, which is what completion needs")
+	assert.Equal(t, int64(1), replicas["node1"].footer)
+	assert.Equal(t, int64(1), replicas["node3"].footer)
+
+	// Pass 2, the counterfactual: the missing replica is back and every reply is in,
+	// so the target drops to 0 -- and the footers already burned at 1 refuse it.
+	replicas["node2"].reachable = true
+	lac, err = impl.fenceSegmentQuorum(ctx, quorum)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), lac)
+	assert.Error(t, impl.completeSegmentQuorum(ctx, quorum, lac),
+		"only the replica that never finalized can accept 0, which is below the ack quorum")
 }


### PR DESCRIPTION
## Problem

`resolveFenceLAC` indexed the sorted fence replies at `len(results)-ackQuorum`, which is the
acknowledged boundary only when every replica answered. One failed reply shifts the index down a
position and publishes a boundary below data the client was told was durable.

Fixes #320

With tails `[0,0,-1]` and `Aq=2`, entry 0 had reached ack quorum. A failed fence RPC to the second
replica leaves replies `[0,-1]`, and `len-Aq` selects `-1`. Completion succeeds at `-1`, compaction
seals an empty object, and a fresh reader cannot retrieve the acknowledged entry.

## The index

The boundary is a fact about the replicas, not about the replies. An entry is acknowledged once at
least `Aq` replicas hold it, so at most `Wq-Aq` of them can be without it — the same tolerance the
append path spends before giving up at `Wq-Aq+1` failures (`segment_handle.go:444`). A replica that
did not answer is unknown, not empty, so that count does not depend on how many answered, and
neither does the index:

```go
missingTolerated := writeQuorum - ackQuorum
return sorted[missingTolerated], nil
```

`len(results)-ackQuorum` equals this only when `len(results) == Wq`.

`Wq` rather than `Es` because `quorumInfo.Nodes` is the write set — the append path already
expresses its tolerance as `Wq-Aq+1` over the same list, indexed by the same `serverIndex`. The two
are equal today (`GetWriteQuorumSize` returns `GetEnsembleSize`), but `Wq` is the quantity the rule
is actually about.

## This reverses a deliberate trade, and that should be reviewed as such

The previous rule guaranteed the target was covered by `ackQuorum` **responders**, so completion
could always finalize. `TestResolveFenceLACCoverageInvariant` asserted exactly that, with the
rationale that a target above it "can never be met — a behind replica has no way to catch up to an
entry it never received — so completion would retry forever and wedge the log". A table case
records `[0,-1,-1]` as a production wedge that the current rule was written to fix.

The two properties are incompatible once a reply is missing: proving coverage among responders
requires treating silence as absence, which is what loses acknowledged data. This change prefers to
fail and retry rather than lower the boundary.

**The earlier wedge is not reintroduced.** It had all three replicas answering, where old and new
agree — `[0,-1,-1]` still resolves to `-1`. The loss only ever occurred when a reply was missing,
so the two cases do not overlap. There is a test for each, named for which one it is.

## Second commit: completion had to change with it

The open question in the first commit — what happens when a completion now fails — turned out to
have a bad answer, and adversarial review found it independently. Completion is **not** free of side
effects, so "fail and retry" is not available:

- `completeSegmentQuorum` sends `CompleteSegment(lac)` to every node and counts qualifying replicas
  only afterwards (`1259-1261`, `1288`).
- `segmentProcessor.Complete` calls `writer.Finalize(ctx, lac)` without checking `lac` against the
  local tail (`server/processor/segment_processor.go:200`), and in service mode that writer is
  always a `StagedFileWriter`.
- `StagedFileWriter.Finalize` burns the requested LAC into a durable footer even on a replica whose
  tail is below it (`stagedstorage/writer_impl.go:1252`), and refuses any later `Finalize` at a
  different LAC with `ErrInvalidLACAlignment` (`1175-1181`). The footer survives restart (`2183`).

So a completion that fails the old `qualifiedResults >= Aq` check leaves the replicas finalized at
the target while metadata stays Active. The next fence gets every reply, resolves lower, and every
finalized footer rejects that lower target. The segment can never close — and `OpenLogWriter`
fences and completes every active segment before handing back a writer (`log/log_handle.go:268`,
`:298`), so one wedged segment stops writes on the whole log.

The check is now `len(finalizedResults) >= ackQuorum`.

`Aq` is the threshold a write had to clear to be *acknowledged*. It is a fact about the write path,
not a requirement on how the data is distributed once the writer is gone, and reading it as the
latter is what made the check unsatisfiable. What completion has to establish is that enough
replicas durably recorded *this* boundary, so a competing writer cannot close the segment at a
different one — that is the finalized count. Entries between a replica's own tail and the target
were never acknowledged, so nothing is owed on them; they become durable when compaction uploads
the segment. Coverage below `Aq` is logged as a warning instead of failing.

**Corner case this leaves, filed as #327:** if the replica holding the target dies between the fence
and the complete, the segment closes at a boundary no surviving replica covers — compaction cannot
run and a reader waits at the tail until that replica returns or an operator forces it. No
acknowledged entry is lost. The alternative is the write outage above, in a case a three-replica
quorum is supposed to absorb.

## Also fixed

A malformed quorum whose ack requirement exceeds its write quorum makes `Wq-Aq` negative and would
have indexed before the start of the slice — a panic in the recovery path. Config derives `Aq` as
`Wq/2+1` and cannot produce one, but it is now refused explicitly.

I found this because `TestFenceSegmentQuorum_FewerNodesThanAckQuorum` built exactly such a quorum
(`Es=1, Wq=1, Aq=2`). That was not carelessness: with a valid quorum every fence result is either an
error or a success, so too few successes always implies at least one node error, and fence prefers
the node error as the root cause — making `return -1, resolveErr` unreachable from
`fenceSegmentQuorum`. Fabricating an impossible quorum was the only way to reach it.

That test now uses a valid three-replica quorum with two failing nodes and asserts the node error
surfaces, and the guards are covered directly on `resolveFenceLAC`, where they are reachable.

## Tests

- `TestResolveFenceLACNeverDropsAcknowledgedData` walks every combination of replica tails and
  answering subsets for write quorums 3 through 7, asserting the selected target is never below the
  acknowledged boundary, and is exactly it when every replica answers — which also pins that the
  earlier wedge stays fixed. Odd and even write quorums both appear because they differ: at `Wq=4`
  the tolerance is 1 while `ackQuorum-1` would be 2. Only 3 and 5 are configurable today.
- `TestResolveFenceLACIssue320` is the reported history, with the empty replica and the lost reply
  rotated.
- `TestResolveFenceLACRejectsInconsistentQuorum` covers the malformed-quorum guard.
- The table test gains a `writeQuorum` column. Two cases change expectation, and their comments
  changed with them — one previously read "Entry 0 lives on a single replica, so it was never
  acked", which is an inference the evidence does not support when only two of three replied.

- `TestFenceAndComplete_PartialFenceDoesNotWedgeFinalizedReplicas` drives fence then complete
  against replicas that model `StagedFileWriter`'s footer — `CompleteSegment` records a LAC and
  refuses a later one that differs. Tails `[1,0,0]`, `Wq=3`/`Aq=2`, one replica silent at fence. It
  asserts the first pass completes, then runs the counterfactual second pass with every reply
  present (target drops to 0) and asserts those footers reject it, which is the wedge made visible.
- The complete response matrix gains the five cells this flips. `PPP` is documented as unreachable:
  the target always comes from a fence reply, so some replica reported a tail at or above it, and a
  replica's tail never shrinks.
- `TestCompletionManager_CompleteRetriesExhaustedDoesNotPublishCompleted` (from #250) keeps its
  subject — no Completed metadata when completion never lands — but its failure is now no replica
  finalizing rather than a finalized replica reading short. The latter is the case it was written
  for and is no longer a failure; it moved to
  `TestCompletionManager_PartialReplicaFinalizeStillPublishesCompleted`.

Checked that the property test fails against the previous implementation, so it is load-bearing
rather than merely green. Its first counterexample is the reported history:

```
tails=[-1 0 0] replies=[-1 0]: selected -1, below the acknowledged boundary 0
```

## Verification

- `go test ./woodpecker/segment/` and `go test -race ./woodpecker/segment/`: ok
- `golangci-lint run ./woodpecker/...` with the CI-pinned v2.11.4: 0 issues
- `gofmt -l .`: clean, `go mod tidy`: no diff

This addresses the recovery boundary and the completion check that depends on it. The issue's other
asks — controls for truly empty segments and for unacknowledged minority-only writes — are not
covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

